### PR TITLE
Implement Meta.ttl for automatic TTL expiration

### DIFF
--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -50,6 +50,7 @@ class ModelOptions:
         self.auto_created = False
         self.base_meta = None
         self.order_by = None  # Default ordering for queries
+        self.ttl = None  # Default TTL in seconds for all instances
 
     def add_field(self, field_name: str, field: Field):
         if not field_name[0] == "_" and not field_name[0].islower():
@@ -152,6 +153,7 @@ class ModelBase(type):
 
         options.abstract = getattr(attr_meta, "abstract", False)
         options.order_by = getattr(attr_meta, "order_by", None)
+        options.ttl = getattr(attr_meta, "ttl", None)
 
         # Validate order_by field exists
         if options.order_by:
@@ -160,6 +162,14 @@ class ModelBase(type):
                 raise ModelException(
                     f"Meta.order_by references '{field_name}' but this field does not exist on {name}"
                 )
+
+        # Validate ttl is a positive integer if provided
+        if options.ttl is not None and (
+            not isinstance(options.ttl, int) or options.ttl <= 0
+        ):
+            raise ModelException(
+                f"Meta.ttl must be a positive integer (seconds), got {options.ttl}"
+            )
 
         options.meta = attr_meta or getattr(new_class, "Meta", None)
         options.base_meta = getattr(new_class, "_meta", None)
@@ -173,8 +183,6 @@ class Model(metaclass=ModelBase):
 
     def __init__(self, **kwargs):
         cls = self.__class__
-        # self._ttl = kwargs.get('ttl', None)
-        # self._expire_at = kwargs.get('expire_at', None)
 
         # allow init kwargs to set any base parameters
         self.__dict__.update(kwargs)
@@ -237,8 +245,11 @@ class Model(metaclass=ModelBase):
             if is_parent_model:
                 RELATED_MODEL_LOAD_SEQUENCE = set()
 
-        self._ttl = None  # todo: set default in child Meta class
-        self._expire_at = None  # todo: datetime? or timestamp?
+        # Set TTL from Meta.ttl as default if not already set via kwargs
+        if not hasattr(self, "_ttl") or self._ttl is None:
+            self._ttl = self._meta.ttl
+        if not hasattr(self, "_expire_at"):
+            self._expire_at = None  # Can be set per-instance as datetime
 
         # validate initial attributes
         if not self.is_valid(
@@ -477,10 +488,12 @@ class Model(metaclass=ModelBase):
 
         if isinstance(pipeline, redis.client.Pipeline):
             pipeline = pipeline.hset(new_db_key.redis_key, mapping=hset_mapping)  # 1
-            # if ttl is not None:
-            #     pipeline = pipeline.expire(new_db_key, ttl)  # 2
-            # if expire_at is not None:
-            #     pipeline = pipeline.expire_at(new_db_key, expire_at)  # 2
+            if self._ttl is not None:
+                pipeline = pipeline.expire(new_db_key.redis_key, self._ttl)  # 2
+            elif self._expire_at is not None:
+                pipeline = pipeline.expireat(
+                    new_db_key.redis_key, int(self._expire_at.timestamp())
+                )  # 2
             pipeline = pipeline.sadd(
                 self._meta.db_class_set_key.redis_key, new_db_key.redis_key
             )  # 3
@@ -525,10 +538,12 @@ class Model(metaclass=ModelBase):
             db_response = POPOTO_REDIS_DB.hset(
                 new_db_key.redis_key, mapping=hset_mapping
             )  # 1
-            # if ttl is not None:
-            #     POPOTO_REDIS_DB.expire(new_db_key, ttl)  # 2
-            # if expire_at is not None:
-            #     POPOTO_REDIS_DB.expireat(new_db_key, ttl)  # 2
+            if self._ttl is not None:
+                POPOTO_REDIS_DB.expire(new_db_key.redis_key, self._ttl)  # 2
+            elif self._expire_at is not None:
+                POPOTO_REDIS_DB.expireat(
+                    new_db_key.redis_key, int(self._expire_at.timestamp())
+                )  # 2
             POPOTO_REDIS_DB.sadd(
                 self._meta.db_class_set_key.redis_key, new_db_key.redis_key
             )  # 3

--- a/tests/test_meta_ttl.py
+++ b/tests/test_meta_ttl.py
@@ -1,0 +1,138 @@
+"""
+Tests for Model Meta.ttl feature
+"""
+
+import pytest
+import time
+from src.popoto import Model, KeyField, Field
+from src.popoto.redis_db import POPOTO_REDIS_DB
+
+
+# Flush Redis before tests
+@pytest.fixture(autouse=True)
+def flush_redis():
+    POPOTO_REDIS_DB.flushdb()
+
+
+class CachedData(Model):
+    key = KeyField()
+    value = Field()
+
+    class Meta:
+        ttl = 2  # Expires after 2 seconds
+
+
+class PermanentData(Model):
+    key = KeyField()
+    value = Field()
+
+
+def test_meta_ttl_sets_expiration():
+    """Test that Meta.ttl sets expiration on saved models."""
+    data = CachedData.create(key="test1", value="data1")
+
+    # Check that TTL is set
+    ttl = POPOTO_REDIS_DB.ttl(data.db_key.redis_key)
+    assert ttl > 0 and ttl <= 2  # TTL should be set and <= 2 seconds
+
+
+def test_meta_ttl_expires_after_timeout():
+    """Test that models with Meta.ttl expire after the specified time."""
+    data = CachedData.create(key="test2", value="data2")
+
+    # Verify it exists immediately
+    assert CachedData.query.get(key="test2") is not None
+
+    # Wait for TTL to expire (2 seconds + buffer)
+    time.sleep(2.5)
+
+    # Verify it no longer exists
+    assert CachedData.query.get(key="test2") is None
+
+
+def test_no_meta_ttl():
+    """Test that models without Meta.ttl don't expire."""
+    data = PermanentData.create(key="test3", value="data3")
+
+    # Check that no TTL is set (-1 means no expiration)
+    ttl = POPOTO_REDIS_DB.ttl(data.db_key.redis_key)
+    assert ttl == -1
+
+    # Wait a bit and verify it still exists
+    time.sleep(1)
+    assert PermanentData.query.get(key="test3") is not None
+
+
+def test_instance_ttl_override():
+    """Test that instance-level _ttl overrides Meta.ttl."""
+    # Create with instance-level TTL override
+    data = CachedData(key="test4", value="data4")
+    data._ttl = 5  # Override Meta.ttl (which is 2)
+    data.save()
+
+    # Check that TTL is 5 seconds, not 2
+    ttl = POPOTO_REDIS_DB.ttl(data.db_key.redis_key)
+    assert ttl > 2 and ttl <= 5
+
+
+def test_no_ttl_on_permanent_model():
+    """Test that _ttl=None doesn't set expiration even with Meta.ttl."""
+    data = CachedData(key="test5", value="data5")
+    data._ttl = None  # Explicitly set to None to disable TTL
+    data.save()
+
+    # Check that no TTL is set
+    ttl = POPOTO_REDIS_DB.ttl(data.db_key.redis_key)
+    assert ttl == -1
+
+
+def test_invalid_meta_ttl_raises():
+    """Test that invalid Meta.ttl raises ModelException."""
+    from src.popoto.models.base import ModelException
+
+    # Negative TTL
+    with pytest.raises(ModelException, match="must be a positive integer"):
+
+        class BadModel1(Model):
+            key = KeyField()
+
+            class Meta:
+                ttl = -1
+
+    # Zero TTL
+    with pytest.raises(ModelException, match="must be a positive integer"):
+
+        class BadModel2(Model):
+            key = KeyField()
+
+            class Meta:
+                ttl = 0
+
+    # String TTL
+    with pytest.raises(ModelException, match="must be a positive integer"):
+
+        class BadModel3(Model):
+            key = KeyField()
+
+            class Meta:
+                ttl = "10"
+
+
+def test_meta_ttl_with_update():
+    """Test that TTL is refreshed on update."""
+    data = CachedData.create(key="test6", value="data6")
+
+    # Wait 1 second
+    time.sleep(1)
+
+    # Update the model
+    data.value = "updated"
+    data.save()
+
+    # TTL should be refreshed to ~2 seconds
+    ttl = POPOTO_REDIS_DB.ttl(data.db_key.redis_key)
+    assert ttl > 1 and ttl <= 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements `Meta.ttl` to define default TTL (time-to-live) for all model instances. This is the second of three features requested in issue #27.

## Features

- **Class-level default**: `Meta: ttl = 300` expires all instances after 300 seconds
- **Instance override**: `obj._ttl = 600` overrides Meta default for specific instance
- **Disable per-instance**: `obj._ttl = None` removes expiration for specific instance
- **Validation**: Raises `ModelException` if ttl is not a positive integer
- **TTL refresh**: TTL is refreshed on every save/update

## Implementation

1. **ModelOptions** - Added `ttl` attribute
2. **ModelBase metaclass** - Parse and validate `Meta.ttl` (must be positive integer)
3. **Model.__init__** - Set `_ttl` from Meta.ttl as default (allows instance override)
4. **Model.save()** - Uncommented existing TTL code, applies `EXPIRE` after `HSET`

## Usage

```python
class CachedData(Model):
    key = KeyField()
    value = Field()
    
    class Meta:
        ttl = 300  # Expires after 5 minutes

# Automatically expires
data = CachedData.create(key="temp", value="data")

# Override per-instance
data = CachedData(key="custom", value="data")
data._ttl = 600  # 10 minutes instead
data.save()

# Disable expiration for specific instance
data._ttl = None
data.save()
```

## Tests

✅ 7 new tests covering:
- TTL expiration behavior
- Instance override
- Models without TTL
- Validation of invalid TTL values
- TTL refresh on update

✅ All 27 existing tests pass

## Next Steps

This PR implements 2 of 3 features from #27:
- ✅ order_by (PR #50)
- ✅ ttl
- ⏳ unique_together

Partial fix for #27

🤖 Generated with [Claude Code](https://claude.ai/claude-code)