### PR TITLE
Implement GeoField with_distances for geo queries

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -214,7 +214,7 @@ Use the `GeoField` to set coordinates on a model to enable these powerful query 
 Popoto provides a namedtuple `Coordinates`. Although, any tuple of `(float, float)` for `(latitude, longitude)` is allowed.
 
 ```python
-from GeoField import Coordinates
+from popoto import Model, KeyField, GeoField
 
 class GeoModel(Model):
     name = KeyField()
@@ -222,16 +222,49 @@ class GeoModel(Model):
 
 
 rome = GeoModel.create(
-    name="Rome", 
-    coordinates=Coordinates(latitude=41.902782, longitude=12.496366)
+    name="Rome",
+    coordinates=GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
 )
 
 vatican = GeoModel.create(
     name="Vatican",
-    coordinates=Coordinates(latitude=41.904755, longitude=12.454628)
+    coordinates=GeoField.Coordinates(latitude=41.904755, longitude=12.454628)
 )
 
 assert vatican in GeoModel.query.filter(coordinates=rome.coordinates, coordinates_radius=5, coordinates_radius_unit='km')
+```
+
+### Query with Distances
+
+Use `{field_name}_with_distances=True` to include distance information in query results.
+When enabled, each returned object will have `_geo_distance` and `_geo_distance_unit` attributes,
+and results are automatically sorted by distance (closest first).
+
+```python
+# Find all locations within 10km of Rome, with distances
+results = GeoModel.query.filter(
+    coordinates=(41.902782, 12.496366),
+    coordinates_radius=10,
+    coordinates_radius_unit='km',
+    coordinates_with_distances=True
+)
+
+for location in results:
+    print(f"{location.name}: {location._geo_distance} {location._geo_distance_unit}")
+# Output:
+# Rome: 0.0 km
+# Vatican: 3.5 km
+```
+
+You can also use a member instance as the center point:
+
+```python
+results = GeoModel.query.filter(
+    coordinates_member=rome,
+    coordinates_radius=10,
+    coordinates_radius_unit='km',
+    coordinates_with_distances=True
+)
 ```
 
 

--- a/src/popoto/fields/geo_field.py
+++ b/src/popoto/fields/geo_field.py
@@ -48,6 +48,8 @@ class GeoField(Field):
                     f"{field_name}_longitude",
                     f"{field_name}_radius",
                     f"{field_name}_radius_unit",
+                    f"{field_name}_member",
+                    f"{field_name}_with_distances",
                 }
             )
         )
@@ -154,17 +156,18 @@ class GeoField(Field):
             return POPOTO_REDIS_DB.zrem(geo_db_key.redis_key, geo_member)
 
     @classmethod
-    def filter_query(cls, model: "Model", field_name: str, **query_params) -> set:
+    def filter_query(cls, model: "Model", field_name: str, **query_params):
         """
         :param model: the popoto.Model to query from
         :param field_name: the name of the field being filtered on
         :param query_params: dict of filter args and values
-        :return: set{db_key, db_key, ..}
+        :return: set{db_key, db_key, ..} or tuple(set, distances_dict, unit) if with_distances=True
         """
         field = model._meta.fields[field_name]
         geo_db_key = cls.get_geo_db_key(model, field_name)
         coordinates = GeoField.Coordinates(None, None)
         member, radius, unit = None, 1, "m"
+        with_distances = False
         for query_param, query_value in query_params.items():
 
             if query_param == f"{field_name}":
@@ -203,24 +206,29 @@ class GeoField(Field):
                     raise QueryException(f"{query_param} must be one of m|km|ft|mi ")
                 unit = query_value
 
+            elif query_param.endswith("_with_distances"):
+                with_distances = bool(query_value)
+
         if member:
             redis_db_keys_list = POPOTO_REDIS_DB.georadiusbymember(
                 geo_db_key.redis_key,
                 member=member.db_key.redis_key,
                 radius=radius,
-                unit=unit,  # , withdist=True, sort='asc'
+                unit=unit,
+                withdist=with_distances,
+                sort="ASC" if with_distances else None,
             )
 
-        elif coordinates.latitude and coordinates.longitude:
-            # logger.debug(f"geo query on {dict(model=model._meta.db_class_key, longitude=coordinates.longitude, latitude=coordinates.latitude, radius=radius, unit=unit)}")
+        elif coordinates.latitude is not None and coordinates.longitude is not None:
             redis_db_keys_list = POPOTO_REDIS_DB.georadius(
                 geo_db_key.redis_key,
                 longitude=coordinates.longitude,
                 latitude=coordinates.latitude,
                 radius=radius,
-                unit=unit,  # , withdist=True, sort='asc'
+                unit=unit,
+                withdist=with_distances,
+                sort="ASC" if with_distances else None,
             )
-            # logger.debug(f"geo query returned {redis_db_keys_list}")
         else:
             from ..models.query import QueryException
 
@@ -229,4 +237,9 @@ class GeoField(Field):
                 f"geofilter requires either coordinates or instance of the same model"
             )
 
-        return set(redis_db_keys_list)
+        if with_distances:
+            # Result is [(key, distance), ...] when withdist=True
+            distances = {item[0]: item[1] for item in redis_db_keys_list}
+            return set(distances.keys()), distances, unit
+        else:
+            return set(redis_db_keys_list)

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -21,6 +21,8 @@ class Query:
     def __init__(self, model_class: "Model"):
         self.model_class = model_class
         self.options = model_class._meta
+        self._geo_distances = {}  # {redis_key: distance}
+        self._geo_distance_unit = None  # unit for distance values
 
     def get(self, db_key: DB_key = None, redis_key: str = None, **kwargs) -> "Model":
         if (
@@ -144,9 +146,15 @@ class Query:
                     if k in kwargs
                 }
             )
-            db_keys_sets.append(
-                field.__class__.filter_query(self.model_class, field_name, **kwargs)
-            )
+            result = field.__class__.filter_query(self.model_class, field_name, **kwargs)
+            # Handle tuple return from GeoField with distances
+            if isinstance(result, tuple) and len(result) == 3:
+                keys_set, distances, unit = result
+                self._geo_distances.update(distances)
+                self._geo_distance_unit = unit
+                db_keys_sets.append(keys_set)
+            else:
+                db_keys_sets.append(result)
             yet_employed_kwargs_set = yet_employed_kwargs_set.difference(
                 self.options.filter_query_params_by_field[field_name]
             ).difference(
@@ -165,10 +173,17 @@ class Query:
             field = self.options.fields[field_name]
             logger.debug(f"query on {field_name} with {params_for_field}")
             logger.debug({k: kwargs[k] for k in params_for_field})
-            key_set = field.__class__.filter_query(
+            result = field.__class__.filter_query(
                 self.model_class, field_name, **{k: kwargs[k] for k in params_for_field}
             )
-            db_keys_sets.append(key_set)
+            # Handle tuple return from GeoField with distances
+            if isinstance(result, tuple) and len(result) == 3:
+                keys_set, distances, unit = result
+                self._geo_distances.update(distances)
+                self._geo_distance_unit = unit
+                db_keys_sets.append(keys_set)
+            else:
+                db_keys_sets.append(result)
             yet_employed_kwargs_set = yet_employed_kwargs_set.difference(
                 params_for_field
             )
@@ -191,6 +206,10 @@ class Query:
         Run query using the given paramters
         return a list of model_class objects
         """
+        # Reset geo distances for this query
+        self._geo_distances = {}
+        self._geo_distance_unit = None
+
         db_keys_set = self.filter_for_keys_set(**kwargs)
         if not len(db_keys_set):
             return []
@@ -199,16 +218,44 @@ class Query:
         if "order_by" not in kwargs and self.model_class._meta.order_by:
             kwargs["order_by"] = self.model_class._meta.order_by
 
-        return self.prepare_results(
-            Query.get_many_objects(
-                self.model_class,
-                db_keys_set,
-                order_by_attr_name=kwargs.get("order_by", None),
-                limit=kwargs.get("limit", None),
-                values=kwargs.get("values", None),
-            ),
-            **kwargs,
+        objects = Query.get_many_objects(
+            self.model_class,
+            db_keys_set,
+            order_by_attr_name=kwargs.get("order_by", None),
+            limit=kwargs.get("limit", None),
+            values=kwargs.get("values", None),
         )
+
+        # Attach geo distances to objects if available
+        if self._geo_distances:
+            # Normalize distance dict keys to strings for consistent lookup
+            normalized_distances = {}
+            for key, dist in self._geo_distances.items():
+                if isinstance(key, bytes):
+                    normalized_distances[key.decode()] = dist
+                else:
+                    normalized_distances[key] = dist
+
+            for obj in objects:
+                if isinstance(obj, dict):
+                    # When values= is used, obj is a dict - skip distance attachment
+                    continue
+                redis_key = obj.db_key.redis_key
+                if isinstance(redis_key, bytes):
+                    redis_key = redis_key.decode()
+                distance = normalized_distances.get(redis_key)
+                if distance is not None:
+                    obj._geo_distance = distance
+                    obj._geo_distance_unit = self._geo_distance_unit
+
+            # Sort by distance (ascending) to preserve geo-sorted order
+            # Only sort model objects, not dicts
+            model_objects = [o for o in objects if not isinstance(o, dict)]
+            dict_objects = [o for o in objects if isinstance(o, dict)]
+            model_objects.sort(key=lambda o: getattr(o, '_geo_distance', float('inf')))
+            objects = model_objects + dict_objects
+
+        return self.prepare_results(objects, **kwargs)
 
     def prepare_results(
         self,

--- a/tests/test_geo_with_distances.py
+++ b/tests/test_geo_with_distances.py
@@ -1,0 +1,239 @@
+"""
+Tests for GeoField with_distances feature (Issue #24)
+"""
+import sys
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+import pytest
+from src.popoto.redis_db import POPOTO_REDIS_DB
+from src import popoto
+
+
+class Location(popoto.Model):
+    name = popoto.KeyField()
+    coordinates = popoto.GeoField()
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    """Clean up test data before and after each test"""
+    for item in Location.query.all():
+        item.delete()
+    yield
+    for item in Location.query.all():
+        item.delete()
+
+
+class TestGeoWithDistances:
+    def test_basic_with_distances(self):
+        """Test that with_distances returns distance values on instances"""
+        # Create two locations
+        rome = Location.create(
+            name="Rome",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+        )
+        vatican = Location.create(
+            name="Vatican",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.904755, longitude=12.454628)
+        )
+
+        # Query with distances from Rome's coordinates
+        results = Location.query.filter(
+            coordinates=(41.902782, 12.496366),
+            coordinates_radius=10,
+            coordinates_radius_unit='km',
+            coordinates_with_distances=True
+        )
+
+        assert len(results) == 2
+
+        # All results should have _geo_distance attribute
+        for result in results:
+            assert hasattr(result, '_geo_distance')
+            assert hasattr(result, '_geo_distance_unit')
+            assert result._geo_distance_unit == 'km'
+            assert isinstance(result._geo_distance, float)
+
+    def test_distances_are_accurate(self):
+        """Test that returned distances are approximately correct"""
+        # Rome coordinates
+        rome = Location.create(
+            name="Rome",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+        )
+        # Vatican is about 3.5km from Rome center
+        vatican = Location.create(
+            name="Vatican",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.904755, longitude=12.454628)
+        )
+
+        results = Location.query.filter(
+            coordinates=(41.902782, 12.496366),
+            coordinates_radius=10,
+            coordinates_radius_unit='km',
+            coordinates_with_distances=True
+        )
+
+        # Find Rome and Vatican in results
+        rome_result = next(r for r in results if r.name == "Rome")
+        vatican_result = next(r for r in results if r.name == "Vatican")
+
+        # Rome should be at distance 0 (querying from its own location)
+        assert rome_result._geo_distance == 0.0
+
+        # Vatican should be approximately 3.5km away
+        assert 3.0 <= vatican_result._geo_distance <= 4.0
+
+    def test_distances_sorted_ascending(self):
+        """Test that results with distances are sorted by distance (closest first)"""
+        # Create locations at different distances from Rome
+        rome = Location.create(
+            name="Rome",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+        )
+        vatican = Location.create(
+            name="Vatican",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.904755, longitude=12.454628)
+        )
+        # Florence is about 230km from Rome
+        florence = Location.create(
+            name="Florence",
+            coordinates=popoto.GeoField.Coordinates(latitude=43.769560, longitude=11.255814)
+        )
+
+        results = Location.query.filter(
+            coordinates=(41.902782, 12.496366),
+            coordinates_radius=500,
+            coordinates_radius_unit='km',
+            coordinates_with_distances=True
+        )
+
+        assert len(results) == 3
+
+        # Should be sorted by distance: Rome (0), Vatican (~3.5km), Florence (~230km)
+        assert results[0].name == "Rome"
+        assert results[0]._geo_distance == 0.0
+
+        assert results[1].name == "Vatican"
+        assert results[1]._geo_distance < 10  # Should be ~3.5km
+
+        assert results[2].name == "Florence"
+        assert results[2]._geo_distance > 200  # Should be ~230km
+
+    def test_with_distances_different_units(self):
+        """Test that different distance units work correctly"""
+        rome = Location.create(
+            name="Rome",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+        )
+        vatican = Location.create(
+            name="Vatican",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.904755, longitude=12.454628)
+        )
+
+        # Query in meters
+        results_m = Location.query.filter(
+            coordinates=(41.902782, 12.496366),
+            coordinates_radius=10000,
+            coordinates_radius_unit='m',
+            coordinates_with_distances=True
+        )
+        vatican_m = next(r for r in results_m if r.name == "Vatican")
+        assert vatican_m._geo_distance_unit == 'm'
+        assert vatican_m._geo_distance > 3000  # Should be ~3500m
+
+        # Query in miles
+        results_mi = Location.query.filter(
+            coordinates=(41.902782, 12.496366),
+            coordinates_radius=10,
+            coordinates_radius_unit='mi',
+            coordinates_with_distances=True
+        )
+        vatican_mi = next(r for r in results_mi if r.name == "Vatican")
+        assert vatican_mi._geo_distance_unit == 'mi'
+        assert vatican_mi._geo_distance < 3  # Should be ~2.2mi
+
+    def test_with_distances_by_member(self):
+        """Test with_distances using a member instance instead of coordinates"""
+        rome = Location.create(
+            name="Rome",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+        )
+        vatican = Location.create(
+            name="Vatican",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.904755, longitude=12.454628)
+        )
+
+        # Query by member (from Rome)
+        results = Location.query.filter(
+            coordinates_member=rome,
+            coordinates_radius=10,
+            coordinates_radius_unit='km',
+            coordinates_with_distances=True
+        )
+
+        assert len(results) == 2
+
+        rome_result = next(r for r in results if r.name == "Rome")
+        vatican_result = next(r for r in results if r.name == "Vatican")
+
+        assert rome_result._geo_distance == 0.0
+        assert vatican_result._geo_distance > 0
+
+    def test_without_distances_no_attribute(self):
+        """Test that without with_distances, objects don't have distance attributes"""
+        rome = Location.create(
+            name="Rome",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+        )
+
+        # Query without with_distances
+        results = Location.query.filter(
+            coordinates=(41.902782, 12.496366),
+            coordinates_radius=10,
+            coordinates_radius_unit='km'
+        )
+
+        assert len(results) == 1
+        assert not hasattr(results[0], '_geo_distance')
+
+    def test_with_distances_empty_result(self):
+        """Test that empty results work correctly with with_distances"""
+        rome = Location.create(
+            name="Rome",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+        )
+
+        # Query from a location with no nearby results
+        results = Location.query.filter(
+            coordinates=(0.0, 0.0),  # Middle of Atlantic
+            coordinates_radius=1,
+            coordinates_radius_unit='km',
+            coordinates_with_distances=True
+        )
+
+        assert len(results) == 0
+
+    def test_with_distances_false_explicit(self):
+        """Test that explicitly setting with_distances=False works"""
+        rome = Location.create(
+            name="Rome",
+            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+        )
+
+        results = Location.query.filter(
+            coordinates=(41.902782, 12.496366),
+            coordinates_radius=10,
+            coordinates_radius_unit='km',
+            coordinates_with_distances=False
+        )
+
+        assert len(results) == 1
+        assert not hasattr(results[0], '_geo_distance')
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Adds `{field_name}_with_distances=True` parameter to GeoField queries
- Returns distance information on each model instance (`_geo_distance`, `_geo_distance_unit`)
- Results are automatically sorted by distance (closest first)
- Also adds `{field_name}_member` parameter support for querying by member instance

## Changes

- **src/popoto/fields/geo_field.py**: Added `with_distances` and `member` parameters, returns distance data alongside keys
- **src/popoto/models/query.py**: Stores and attaches distance metadata to loaded objects
- **tests/test_geo_with_distances.py**: Comprehensive test suite (8 tests)
- **docs/fields.md**: Updated GeoField documentation with usage examples

## Usage

```python
results = Location.query.filter(
    coordinates=(41.902782, 12.496366),
    coordinates_radius=10,
    coordinates_radius_unit='km',
    coordinates_with_distances=True
)

for location in results:
    print(f"{location.name}: {location._geo_distance} {location._geo_distance_unit}")
```

## Test plan

- [x] All 8 new tests pass
- [x] Existing geo tests pass (`test_geofield.py`)
- [x] Related tests pass (`test_queries.py`, `test_kitchen_sink.py`)

Closes #24