### PR TITLE
Add async support for Model and Query operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.1.2",
+    "pytest-asyncio>=0.21.0",
     "mypy>=0.971",
     "black>=22.6.0",
 ]

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -1,4 +1,7 @@
 import logging
+import asyncio
+import sys
+import functools
 
 import redis
 
@@ -14,6 +17,17 @@ from ..fields.relationship import Relationship
 from ..redis_db import POPOTO_REDIS_DB
 
 logger = logging.getLogger("POPOTO.model_base")
+
+# Python 3.8 compatibility for asyncio.to_thread()
+if sys.version_info >= (3, 9):
+    to_thread = asyncio.to_thread
+else:
+    # Backport for Python 3.8
+    async def to_thread(func, *args, **kwargs):
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, functools.partial(func, *args, **kwargs)
+        )
 
 global RELATED_MODEL_LOAD_SEQUENCE
 RELATED_MODEL_LOAD_SEQUENCE = set()
@@ -805,3 +819,78 @@ class Model(metaclass=ModelBase):
             "fields": cls._meta.field_names,
             "query_filters": query_filters,
         }
+
+    # Async methods
+
+    async def async_save(
+        self,
+        pipeline: redis.client.Pipeline = None,
+        ignore_errors: bool = False,
+        **kwargs,
+    ):
+        """Async version of save().
+
+        Runs the synchronous save() method in a thread pool to avoid blocking
+        the event loop.
+
+        Args:
+            pipeline: Optional Redis pipeline for batching operations
+            ignore_errors: If True, log errors instead of raising exceptions
+            **kwargs: Additional arguments passed to save()
+
+        Returns:
+            Pipeline or db_response depending on whether pipeline was provided
+        """
+        return await to_thread(
+            self.save, pipeline=pipeline, ignore_errors=ignore_errors, **kwargs
+        )
+
+    async def async_delete(
+        self, pipeline: redis.client.Pipeline = None, *args, **kwargs
+    ):
+        """Async version of delete().
+
+        Runs the synchronous delete() method in a thread pool to avoid blocking
+        the event loop.
+
+        Args:
+            pipeline: Optional Redis pipeline for batching operations
+            *args: Additional positional arguments passed to delete()
+            **kwargs: Additional keyword arguments passed to delete()
+
+        Returns:
+            Pipeline or boolean(object existed AND was deleted)
+        """
+        return await to_thread(self.delete, pipeline=pipeline, *args, **kwargs)
+
+    @classmethod
+    async def async_create(cls, pipeline: redis.client.Pipeline = None, **kwargs):
+        """Async version of create().
+
+        Creates a new model instance and saves it to Redis in a thread pool
+        to avoid blocking the event loop.
+
+        Args:
+            pipeline: Optional Redis pipeline for batching operations
+            **kwargs: Field values for the new instance
+
+        Returns:
+            Pipeline or Model instance depending on whether pipeline was provided
+        """
+        return await to_thread(cls.create, pipeline=pipeline, **kwargs)
+
+    @classmethod
+    async def async_load(cls, db_key: str = None, **kwargs):
+        """Async version of load().
+
+        Loads a model instance from Redis by db_key or field values in a
+        thread pool to avoid blocking the event loop.
+
+        Args:
+            db_key: Optional db_key string to load
+            **kwargs: Field values to construct db_key if not provided
+
+        Returns:
+            Model instance or None if not found
+        """
+        return await to_thread(cls.load, db_key=db_key, **kwargs)

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -1,9 +1,23 @@
 import logging
+import asyncio
+import sys
+import functools
 
 from .db_key import DB_key
 from ..redis_db import POPOTO_REDIS_DB, ENCODING
 
 logger = logging.getLogger("POPOTO.Query")
+
+# Python 3.8 compatibility for asyncio.to_thread()
+if sys.version_info >= (3, 9):
+    to_thread = asyncio.to_thread
+else:
+    # Backport for Python 3.8
+    async def to_thread(func, *args, **kwargs):
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, functools.partial(func, *args, **kwargs)
+        )
 
 
 class QueryException(Exception):
@@ -381,3 +395,81 @@ class Query:
             for redis_hash in hashes_list
             if redis_hash
         ]
+
+    # Async methods
+
+    async def async_get(
+        self, db_key: DB_key = None, redis_key: str = None, **kwargs
+    ) -> "Model":
+        """Async version of get().
+
+        Retrieves a single model instance from Redis in a thread pool to avoid
+        blocking the event loop.
+
+        Args:
+            db_key: Optional DB_key object
+            redis_key: Optional Redis key string
+            **kwargs: Field values to construct query
+
+        Returns:
+            Model instance or None if not found
+        """
+        return await to_thread(self.get, db_key=db_key, redis_key=redis_key, **kwargs)
+
+    async def async_filter(self, **kwargs) -> list:
+        """Async version of filter().
+
+        Filters model instances based on field values in a thread pool to avoid
+        blocking the event loop.
+
+        Args:
+            **kwargs: Filter parameters (field values, limit, order_by, values)
+
+        Returns:
+            List of model instances or dicts (if values= specified)
+        """
+        return await to_thread(self.filter, **kwargs)
+
+    async def async_all(self, **kwargs) -> list:
+        """Async version of all().
+
+        Retrieves all model instances in a thread pool to avoid blocking
+        the event loop.
+
+        Args:
+            **kwargs: Optional order_by and values parameters
+
+        Returns:
+            List of all model instances or dicts (if values= specified)
+        """
+        return await to_thread(self.all, **kwargs)
+
+    async def async_count(self, **kwargs) -> int:
+        """Async version of count().
+
+        Counts model instances matching filter criteria in a thread pool to avoid
+        blocking the event loop.
+
+        Args:
+            **kwargs: Optional filter parameters
+
+        Returns:
+            Count of matching instances
+        """
+        return await to_thread(self.count, **kwargs)
+
+    async def async_keys(self, catchall=False, clean=False, **kwargs) -> list:
+        """Async version of keys().
+
+        Retrieves Redis keys for model instances in a thread pool to avoid
+        blocking the event loop.
+
+        Args:
+            catchall: If True, use KEYS pattern (debug only, not for production)
+            clean: If True, clean up orphaned keys (debug only, not for production)
+            **kwargs: Additional parameters
+
+        Returns:
+            List of Redis keys
+        """
+        return await to_thread(self.keys, catchall=catchall, clean=clean, **kwargs)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,263 @@
+import sys
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+import pytest
+import asyncio
+from src import popoto
+from src.popoto.redis_db import POPOTO_REDIS_DB
+
+
+@pytest.fixture(autouse=True)
+def flush_redis():
+    """Clean Redis before each test."""
+    POPOTO_REDIS_DB.flushdb()
+
+
+class TestJob(popoto.Model):
+    job_id = popoto.AutoKeyField()
+    project_key = popoto.KeyField()
+    status = popoto.KeyField(default="pending")
+    priority = popoto.SortedField(type=int, sort_by="project_key")
+    created_at = popoto.SortedField(type=float, sort_by="project_key")
+    message_text = popoto.Field()
+
+
+@pytest.mark.asyncio
+async def test_async_create():
+    """Test async_create creates a model instance."""
+    job = await TestJob.async_create(
+        project_key="valor",
+        status="pending",
+        priority=1,
+        created_at=1234567890.0,
+        message_text="test message",
+    )
+
+    assert job is not None
+    assert job.project_key == "valor"
+    assert job.status == "pending"
+    assert job.priority == 1
+
+
+@pytest.mark.asyncio
+async def test_async_save():
+    """Test async_save persists changes."""
+    job = TestJob(
+        project_key="valor", status="pending", priority=1, created_at=1234567890.0
+    )
+
+    result = await job.async_save()
+    assert result is not False
+
+    # Verify saved
+    loaded = TestJob.query.get(job_id=job.job_id, project_key="valor", status="pending")
+    assert loaded is not None
+    assert loaded.priority == 1
+
+
+@pytest.mark.asyncio
+async def test_async_filter():
+    """Test async_filter returns matching instances."""
+    # Create test data
+    await TestJob.async_create(
+        project_key="valor", status="pending", priority=1, created_at=1.0
+    )
+    await TestJob.async_create(
+        project_key="valor", status="running", priority=2, created_at=2.0
+    )
+    await TestJob.async_create(
+        project_key="other", status="pending", priority=3, created_at=3.0
+    )
+
+    # Filter
+    jobs = await TestJob.query.async_filter(project_key="valor", status="pending")
+
+    assert len(jobs) == 1
+    assert jobs[0].project_key == "valor"
+    assert jobs[0].status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_async_get():
+    """Test async_get retrieves single instance."""
+    job = await TestJob.async_create(
+        project_key="valor", status="pending", priority=1, created_at=1.0
+    )
+
+    loaded = await TestJob.query.async_get(
+        job_id=job.job_id, project_key="valor", status="pending"
+    )
+
+    assert loaded is not None
+    assert loaded.job_id == job.job_id
+    assert loaded.priority == 1
+
+
+@pytest.mark.asyncio
+async def test_async_delete():
+    """Test async_delete removes instance."""
+    job = await TestJob.async_create(
+        project_key="valor", status="pending", priority=1, created_at=1.0
+    )
+
+    result = await job.async_delete()
+    assert result is True
+
+    # Verify deleted
+    loaded = TestJob.query.get(job_id=job.job_id, project_key="valor", status="pending")
+    assert loaded is None
+
+
+@pytest.mark.asyncio
+async def test_async_all():
+    """Test async_all returns all instances."""
+    await TestJob.async_create(
+        project_key="valor", status="pending", priority=1, created_at=1.0
+    )
+    await TestJob.async_create(
+        project_key="valor", status="running", priority=2, created_at=2.0
+    )
+
+    jobs = await TestJob.query.async_all()
+
+    assert len(jobs) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_count():
+    """Test async_count returns count."""
+    await TestJob.async_create(
+        project_key="valor", status="pending", priority=1, created_at=1.0
+    )
+    await TestJob.async_create(
+        project_key="valor", status="running", priority=2, created_at=2.0
+    )
+
+    count = await TestJob.query.async_count()
+    assert count == 2
+
+    count_filtered = await TestJob.query.async_count(status="pending")
+    assert count_filtered == 1
+
+
+@pytest.mark.asyncio
+async def test_async_load():
+    """Test async_load retrieves by db_key."""
+    job = await TestJob.async_create(
+        project_key="valor", status="pending", priority=1, created_at=1.0
+    )
+
+    loaded = await TestJob.async_load(
+        job_id=job.job_id, project_key="valor", status="pending"
+    )
+
+    assert loaded is not None
+    assert loaded == job
+
+
+@pytest.mark.asyncio
+async def test_async_keys():
+    """Test async_keys returns Redis keys."""
+    await TestJob.async_create(
+        project_key="valor", status="pending", priority=1, created_at=1.0
+    )
+    await TestJob.async_create(
+        project_key="valor", status="running", priority=2, created_at=2.0
+    )
+
+    keys = await TestJob.query.async_keys()
+
+    assert len(keys) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_filter_with_limit():
+    """Test async_filter with limit parameter."""
+    # Create test data
+    for i in range(5):
+        await TestJob.async_create(
+            project_key="valor", status="pending", priority=i, created_at=float(i)
+        )
+
+    # Filter with limit
+    jobs = await TestJob.query.async_filter(project_key="valor", limit=3)
+
+    assert len(jobs) == 3
+
+
+@pytest.mark.asyncio
+async def test_async_filter_with_order_by():
+    """Test async_filter with order_by parameter."""
+    # Create test data with different priorities
+    await TestJob.async_create(
+        project_key="valor", status="pending", priority=3, created_at=1.0
+    )
+    await TestJob.async_create(
+        project_key="valor", status="pending", priority=1, created_at=2.0
+    )
+    await TestJob.async_create(
+        project_key="valor", status="pending", priority=2, created_at=3.0
+    )
+
+    # Filter with order_by
+    jobs = await TestJob.query.async_filter(
+        project_key="valor", status="pending", order_by="priority"
+    )
+
+    assert len(jobs) == 3
+    assert jobs[0].priority == 1
+    assert jobs[1].priority == 2
+    assert jobs[2].priority == 3
+
+
+@pytest.mark.asyncio
+async def test_async_update_and_save():
+    """Test updating a field and saving asynchronously."""
+    job = await TestJob.async_create(
+        project_key="valor", status="pending", priority=1, created_at=1.0
+    )
+
+    # Update status
+    job.status = "running"
+    await job.async_save()
+
+    # Reload and verify - need to use new key since status is a KeyField
+    loaded = TestJob.query.get(job_id=job.job_id, project_key="valor", status="running")
+    assert loaded is not None
+    assert loaded.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_async_concurrent_operations():
+    """Test running multiple async operations concurrently."""
+    # Create multiple jobs concurrently
+    jobs = await asyncio.gather(
+        TestJob.async_create(
+            project_key="valor", status="pending", priority=1, created_at=1.0
+        ),
+        TestJob.async_create(
+            project_key="valor", status="pending", priority=2, created_at=2.0
+        ),
+        TestJob.async_create(
+            project_key="valor", status="pending", priority=3, created_at=3.0
+        ),
+    )
+
+    assert len(jobs) == 3
+
+    # Query concurrently
+    results = await asyncio.gather(
+        TestJob.query.async_count(),
+        TestJob.query.async_all(),
+        TestJob.query.async_filter(
+            project_key="valor", priority__gte=2
+        ),  # Must include project_key for sorted field
+    )
+
+    count, all_jobs, filtered_jobs = results
+    assert count == 3
+    assert len(all_jobs) == 3
+    assert len(filtered_jobs) == 2


### PR DESCRIPTION
## Summary

Implements async-native methods for Popoto to support integration with asyncio-based applications like async job queues, Telethon bots, and other async Python services.

This eliminates the need for users to manually wrap every Popoto call with `asyncio.to_thread()`.

## Changes

### New Async Methods

**Model class:**
- `async_create()` - Create and save model instance
- `async_save()` - Save model instance
- `async_delete()` - Delete model instance
- `async_load()` - Load model instance by key

**Query class:**
- `async_get()` - Get single instance
- `async_filter()` - Filter instances
- `async_all()` - Get all instances
- `async_count()` - Count instances
- `async_keys()` - Get Redis keys

### Implementation

Uses `asyncio.to_thread()` wrapper pattern:
- Wraps synchronous methods with async versions
- Runs sync operations in thread pool to avoid blocking event loop
- Minimal code duplication - easy to maintain
- Python 3.8 compatibility shim included

### Testing

- Added `pytest-asyncio` to dev dependencies
- Created comprehensive test suite: `tests/test_async.py`
- 13 new tests covering all async operations
- All 65 tests passing (13 new + 52 existing)

## Usage Example

```python
import asyncio
from popoto import Model, AutoKeyField, KeyField, SortedField, Field

class Job(Model):
    job_id = AutoKeyField()
    project_key = KeyField()
    status = KeyField(default="pending")
    priority = SortedField(type=int, sort_by="project_key")
    created_at = SortedField(type=float, sort_by="project_key")
    message_text = Field()

async def main():
    # Create
    job = await Job.async_create(
        project_key="valor",
        status="pending",
        priority=1,
        created_at=1234567890.0,
        message_text="test"
    )
    
    # Filter
    jobs = await Job.query.async_filter(
        project_key="valor",
        status="pending"
    )
    
    # Update
    job.status = "running"
    await job.async_save()
    
    # Delete
    await job.async_delete()

asyncio.run(main())
```

## Test Plan

- [x] All async methods tested with comprehensive test coverage
- [x] Concurrent operations tested with `asyncio.gather()`
- [x] Existing tests still pass (no regressions)
- [x] Python 3.8+ compatibility verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)