### PR TITLE
Make pandas an optional dependency

### DIFF
--- a/docs/plans/ACTIVE-20260201-stress-tests.md
+++ b/docs/plans/ACTIVE-20260201-stress-tests.md
@@ -1,0 +1,56 @@
+# Plan: Comprehensive Stress Tests for Popoto
+
+**Status**: PLANNED
+**Created**: 2026-02-01
+**Issue**: #63 follow-up — improve test coverage and confidence
+
+## New file: `tests/test_stress.py`
+
+A single test file using proper pytest structure with fixtures for cleanup. Each test creates, exercises, and verifies data at scale. Uses `pytest.mark.slow` so they can be skipped in quick CI runs.
+
+### Test cases
+
+1. **test_bulk_create_save_delete** — Create and save 1000 KeyValue models, query all back, verify count and data integrity, delete all, verify empty.
+
+2. **test_bulk_sorted_field_range_queries** — Save 500 items with SortedField(type=int), then run range queries (`__gt`, `__lt`, `__gte`, `__lte`) and verify result counts match expected ranges.
+
+3. **test_bulk_geo_radius_search** — Save 200 locations with GeoField spread across a geographic area, then run radius searches at various distances and verify results are within the expected radius.
+
+4. **test_bulk_unique_key_operations** — Save 500 items with UniqueKeyField, verify uniqueness enforcement (duplicate raises exception), verify all are queryable by unique key.
+
+5. **test_bulk_relationship_integrity** — Create 100 parent + 500 child models with Relationship fields, query children by parent, verify referential integrity after saves and deletes.
+
+6. **test_bulk_filter_key_field** — Save 500 items with varied KeyField values, exercise `__startswith`, `__endswith`, `__in`, `__contains`, `__isnull` filters at scale, verify result correctness.
+
+7. **test_bulk_mixed_field_types** — Save 200 models with int, float, decimal, string, bool, list, dict, date, datetime fields, load them all back, assert every field round-trips correctly.
+
+8. **test_async_concurrent_operations** — Use `asyncio.gather` to concurrently create 200 items, then concurrently query them, then concurrently delete them. Verify data integrity at each step.
+
+9. **test_sorted_field_ordering** — Save 500 items with SortedField, query with `order_by` (ascending and descending), verify ordering is correct across the full result set.
+
+10. **test_rapid_update_cycles** — Save 100 items, then update each one 10 times in sequence (1000 total saves), verify final values are correct and no data corruption.
+
+### Shared fixtures
+
+- `flush_redis` autouse fixture calling `POPOTO_REDIS_DB.flushdb()` before each test
+- Model classes defined at module level (outside test functions)
+- `pytest.mark.slow` on all tests
+
+### pyproject.toml update
+
+Add pytest marker config:
+```toml
+[tool.pytest.ini_options]
+markers = ["slow: stress and performance tests"]
+```
+
+## Files to modify
+- **Create**: `tests/test_stress.py`
+- **Edit**: `pyproject.toml` — add pytest markers config
+
+## Verification
+```bash
+pytest tests/test_stress.py -v        # Run all stress tests
+pytest -m "not slow"                  # Run fast tests only
+pytest tests/test_stress.py -k bulk_create  # Run single stress test
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,15 @@ keywords = ["redis", "ORM", "database"]
 requires-python = ">=3.8"
 dependencies = [
     "redis>=4.3.4",
-    "pandas>=1.4.3",
-    "numpy>=1.23.1",
     "msgpack>=1.0.4",
-    "msgpack-numpy>=0.4.8",
 ]
 
 [project.optional-dependencies]
+dataframe = [
+    "pandas>=1.4.3",
+    "numpy>=1.23.1",
+    "msgpack-numpy>=0.4.8",
+]
 dev = [
     "pytest>=7.1.2",
     "pytest-asyncio>=0.21.0",

--- a/src/popoto/__init__.py
+++ b/src/popoto/__init__.py
@@ -19,7 +19,10 @@ from .fields.shortcuts import (
     SortedKeyField,
 )
 from .fields.geo_field import GeoField
-from .fields.dataframe_field import DataFrameField
+try:
+    from .fields.dataframe_field import DataFrameField
+except ImportError:
+    pass
 from .fields.datetime_field import DatetimeField
 from .fields.relationship import Relationship
 from .models.base import Model, ModelBase

--- a/src/popoto/fields/dataframe_field.py
+++ b/src/popoto/fields/dataframe_field.py
@@ -1,6 +1,12 @@
 import logging
-import pandas as pd
 from .field import Field
+
+try:
+    import pandas as pd
+
+    _pandas_available = True
+except ImportError:
+    _pandas_available = False
 
 logger = logging.getLogger("POPOTO.DataFrame")
 
@@ -9,14 +15,20 @@ class DataFrameField(Field):
     """
     A field that stores Pandas DataFrame objects
     required: pandas.DataFrame object
+
+    Requires the 'dataframe' extra: pip install popoto[dataframe]
     """
 
-    type: type = pd.DataFrame
-    default: pd.DataFrame = pd.DataFrame()
     null: bool = False
 
     def __init__(self, **kwargs):
+        if not _pandas_available:
+            raise ImportError(
+                "pandas is required to use DataFrameField. "
+                "Install it with: pip install popoto[dataframe]"
+            )
         super().__init__(**kwargs)
+        self.type = pd.DataFrame
         dataframefield_defaults = {
             "type": pd.DataFrame,
             "null": True,

--- a/src/popoto/models/encoding.py
+++ b/src/popoto/models/encoding.py
@@ -2,9 +2,15 @@ import datetime
 from collections import namedtuple
 from decimal import Decimal
 import msgpack
-import pandas as pd
 from ..exceptions import ModelException
 from ..redis_db import ENCODING
+
+try:
+    import pandas as pd
+
+    _pandas_available = True
+except ImportError:
+    _pandas_available = False
 
 EncoderDecoder = namedtuple("EncoderDecoder", "key, encoder, decoder")
 
@@ -51,15 +57,18 @@ TYPE_ENCODER_DECODERS = {
             obj["as_encodable"], "%H:%M:%S.%f"
         ).time(),
     ),
-    pd.DataFrame: EncoderDecoder(
+}
+
+if _pandas_available:
+    TYPE_ENCODER_DECODERS[pd.DataFrame] = EncoderDecoder(
         key="__dataframe__",
         encoder=lambda obj: {
             "__dataframe__": True,
             "as_encodable": obj.to_json(),
         },
         decoder=lambda obj: pd.read_json(obj["as_encodable"]),
-    ),
-}
+    )
+
 DECODERS_BY_KEYSTRING = {
     encoder_decoder.key: encoder_decoder.decoder
     for encoder_decoder in TYPE_ENCODER_DECODERS.values()
@@ -74,18 +83,13 @@ def decode_custom_types(obj):
     return obj
 
 
-# def decode_custom_types(obj):
-#     if isinstance(obj, dict) and "as_encodable" in obj:
-#         for encoder_decoder in TYPE_ENCODER_DECODERS.values():
-#             if encoder_decoder.key in obj:
-#                 return encoder_decoder.decoder(obj)
-#     return obj
-
-
 def encode_popoto_model_obj(obj: "Model") -> dict:
-    import msgpack_numpy as m
+    try:
+        import msgpack_numpy as m
 
-    m.patch()
+        m.patch()
+    except ImportError:
+        pass
 
     encoded_hashmap = dict()
     for field_name, field in obj._meta.fields.items():

--- a/tests/test_dataframe_field.py
+++ b/tests/test_dataframe_field.py
@@ -1,5 +1,8 @@
 import sys
 import os
+import pytest
+
+pd = pytest.importorskip("pandas")
 
 from src.popoto.redis_db import POPOTO_REDIS_DB
 
@@ -7,7 +10,6 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
 
 from src import popoto
-import pandas as pd
 
 
 class DataFrameModel(popoto.Model):


### PR DESCRIPTION
## Summary
- Move `pandas`, `numpy`, `msgpack-numpy` from required to optional dependencies (`pip install popoto[dataframe]`)
- Guard all pandas imports with try/except so core library loads without pandas
- `DataFrameField` raises clear `ImportError` with install instructions when used without pandas
- Test file uses `pytest.importorskip("pandas")` to skip when pandas is absent
- Includes stress test plan doc in `docs/plans/`

Closes #63

## Test plan
- [ ] `pytest --ignore=tests/test_sortedfield.py --ignore=tests/test_dataframe_field.py` passes (core tests unaffected)
- [ ] `pytest tests/test_dataframe_field.py` passes when pandas is installed
- [ ] `python -c "import popoto; print(popoto.Model)"` works without pandas
- [ ] `pip install popoto[dataframe]` installs pandas/numpy/msgpack-numpy

🤖 Generated with [Claude Code](https://claude.com/claude-code)