### PR TITLE
Remove arbitrary magic numbers and hardcoded limits

### DIFF
--- a/src/popoto/fields/field.py
+++ b/src/popoto/fields/field.py
@@ -48,7 +48,7 @@ class Field(metaclass=FieldBase):
     auto: bool = False
     null: bool = True
     value: str = None
-    max_length: int = 1024
+    max_length: int = None
     default = ""
     sorted: bool = False
 
@@ -60,7 +60,7 @@ class Field(metaclass=FieldBase):
             "auto": False,
             "null": True,
             "value": None,
-            "max_length": 1024,  # Redis limit is 512MB
+            "max_length": None,
             "default": None,
             "sorted": False,
         }
@@ -85,7 +85,7 @@ class Field(metaclass=FieldBase):
                 f"field {field} is type {field.type}. But value is {type(value)}"
             )
             return False
-        if field.type == str and len(str(value)) > field.max_length:
+        if field.max_length is not None and field.type == str and len(str(value)) > field.max_length:
             logger.error(f"{field} value is greater than max_length={field.max_length}")
             return False
         return True

--- a/src/popoto/fields/key_field_mixin.py
+++ b/src/popoto/fields/key_field_mixin.py
@@ -34,13 +34,13 @@ class KeyFieldMixin:
     """
 
     key: bool = True
-    max_length: int = 128
+    max_length: int = None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         keyfield_defaults = {
             "key": True,
-            "max_length": 128,  # Redis limit is 512MB
+            "max_length": None,
         }
         self.field_defaults.update(keyfield_defaults)
         # set field options, let kwargs override

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -37,6 +37,11 @@ class ModelException(Exception):
     pass
 
 
+# Length of hex digest used for index hashes. 16 hex chars = 64 bits,
+# sufficient for index key uniqueness within a single model's field combinations.
+INDEX_HASH_LENGTH = 16
+
+
 class ModelOptions:
     def __init__(self, model_name):
         self.model_name = model_name
@@ -135,7 +140,7 @@ class ModelOptions:
                 return None  # Don't index NULL values (allows multiple NULLs)
             values.append(str(value))
         combined = ":".join(values)
-        return hashlib.sha256(combined.encode()).hexdigest()[:16]
+        return hashlib.sha256(combined.encode()).hexdigest()[:INDEX_HASH_LENGTH]
 
     def compute_index_hash_from_values(self, field_names: tuple, field_values: dict) -> str:
         """Compute hash from a dict of field values (for cleanup of old values).
@@ -151,7 +156,7 @@ class ModelOptions:
                 return None
             values.append(str(value))
         combined = ":".join(values)
-        return hashlib.sha256(combined.encode()).hexdigest()[:16]
+        return hashlib.sha256(combined.encode()).hexdigest()[:INDEX_HASH_LENGTH]
 
 
 class ModelBase(type):
@@ -480,7 +485,8 @@ class Model(metaclass=ModelBase):
 
             # validate str max_length
             if (
-                self._meta.fields[field_name].type == str
+                self._meta.fields[field_name].max_length is not None
+                and self._meta.fields[field_name].type == str
                 and getattr(self, field_name)
                 and len(getattr(self, field_name))
                 > self._meta.fields[field_name].max_length

--- a/src/popoto/utils/django/user.py
+++ b/src/popoto/utils/django/user.py
@@ -5,6 +5,17 @@ from ...fields.shortcuts import KeyField, AutoKeyField, BooleanField
 from ...models.base import Model
 from ..mixins.timestampable import Timestampable
 
+# Number of digits in the generated login code
+LOGIN_CODE_LENGTH = 4
+
+# Login code returned for test accounts (emails ending with TEST_ACCOUNT_DOMAIN)
+TEST_ACCOUNT_DOMAIN = "@example.com"
+TEST_ACCOUNT_LOGIN_CODE = "1234"
+
+# Terms of service must be agreed to after this date to be considered valid.
+# Update this date when new terms are published.
+TERMS_EFFECTIVE_DATE = datetime(2024, 1, 1)
+
 
 class User(Timestampable, Model):
     id = AutoKeyField()
@@ -59,16 +70,16 @@ class User(Timestampable, Model):
     def four_digit_login_code(self):
         import hashlib
 
-        if self.email.endswith("@example.com"):
-            return "1234"  # for test accounts
+        if self.email.endswith(TEST_ACCOUNT_DOMAIN):
+            return TEST_ACCOUNT_LOGIN_CODE
         hash_object = hashlib.md5(
             bytes(f"{self.id}{self.email}{self.last_login}", encoding="utf-8")
         )
-        return str(int(hash_object.hexdigest(), 16))[-4:]
+        return str(int(hash_object.hexdigest(), 16))[-LOGIN_CODE_LENGTH:]
 
     @property
     def is_agreed_to_terms(self) -> bool:
-        if self.agreed_to_terms_at and self.agreed_to_terms_at > datetime(2024, 1, 1):
+        if self.agreed_to_terms_at and self.agreed_to_terms_at > TERMS_EFFECTIVE_DATE:
             return True
         return False
 

--- a/src/popoto/utils/multithreading.py
+++ b/src/popoto/utils/multithreading.py
@@ -1,6 +1,7 @@
 # A DECORATOR FOR PYTHON THREADING
 # http://docs.python.org/2/library/threading.html#thread-objects
 # http://stackoverflow.com/questions/18420699/multithreading-for-python-django
+import os
 from collections.abc import Callable
 from threading import Thread
 
@@ -32,8 +33,7 @@ def run_all_multithreaded(function_def, list_of_params):
 
     from multiprocessing.dummy import Pool as ThreadPool
 
-    # make the Pool of workers
-    pool = ThreadPool(16)
+    pool = ThreadPool(min(len(list_of_params), os.cpu_count() or 4))
 
     # open functions in their own threads
     # and compile all the results


### PR DESCRIPTION
## Summary
- Remove default `max_length` on `Field` (was 1024) and `KeyFieldMixin` (was 128). Default is now `None`, deferring limit enforcement to Redis itself. Validation is skipped when `max_length` is not explicitly set.
- Replace hardcoded `ThreadPool(16)` with a pool sized to `min(work_items, cpu_count)`.
- Extract magic numbers in `ModelOptions` and `User` into named, documented module-level constants (`INDEX_HASH_LENGTH`, `LOGIN_CODE_LENGTH`, `TEST_ACCOUNT_DOMAIN`, `TEST_ACCOUNT_LOGIN_CODE`, `TERMS_EFFECTIVE_DATE`).

## Test plan
- [x] All 65 existing tests pass
- [ ] Verify fields without explicit `max_length` accept strings of any length
- [ ] Verify fields with explicit `max_length` still enforce the limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)