### PR TITLE
Enforce unique constraint on UniqueKeyField

### DIFF
--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -560,6 +560,31 @@ class Model(metaclass=ModelBase):
                 else:
                     raise ModelException(error_message)
 
+        # Check unique field constraints (individual fields with unique=True)
+        for field_name, field in self._meta.fields.items():
+            if not getattr(field, "unique", False):
+                continue
+            field_value = getattr(self, field_name)
+            if field_value is None:
+                continue
+            unique_set_key = DB_key(
+                field.get_special_use_field_db_key(self, field_name), field_value
+            )
+            existing_members = POPOTO_REDIS_DB.smembers(unique_set_key.redis_key)
+            own_key = self.db_key.redis_key
+            own_key_bytes = own_key.encode() if isinstance(own_key, str) else own_key
+            other_members = {m for m in existing_members if m != own_key_bytes}
+            if other_members:
+                error_message = (
+                    f"Unique constraint violated: {field_name}={field_value} "
+                    f"already exists on another instance"
+                )
+                if ignore_errors:
+                    logger.error(error_message)
+                    return False
+                else:
+                    raise ModelException(error_message)
+
         # run any necessary formatting on field data before saving
         for field_name, field in self._meta.fields.items():
             setattr(

--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -244,12 +244,10 @@ def test_bulk_unique_key_operations(performance_timer):
         results = list(UniqueItemModel.query.all())
         assert len(results) == 1000
 
-        # TODO: UniqueKeyField currently doesn't enforce uniqueness - this is a known bug
-        # See production hardening plan Phase 1 for the fix
-        # Once fixed, this should raise an exception:
-        # with pytest.raises(Exception):
-        #     duplicate = UniqueItemModel(key="key_duplicate", unique_code="UNIQUE0000")
-        #     duplicate.save()
+        # UniqueKeyField should reject duplicate values on different instances
+        with pytest.raises(Exception):
+            duplicate = UniqueItemModel(key="key_duplicate", unique_code="UNIQUE0000")
+            duplicate.save()
 
         # Delete first 500
         for i in range(500):


### PR DESCRIPTION
## Summary
- UniqueKeyField was not enforcing uniqueness — duplicate values on different instances were silently allowed
- Adds pre_save() check using the existing SET index to reject duplicates before data is written

## How It Works
The KeyFieldMixin already maintains a Redis SET at `ClassName:field_name:value` containing all db_keys with that value. For fields with `unique=True`, pre_save() now checks if the SET has members belonging to other instances before allowing the save.

## Edge Cases Verified
- ✅ Create new instance with unique value
- ✅ Re-save same instance (update, not rejected)
- ✅ Duplicate value on different instance → raises ModelException
- ✅ Delete instance, then reuse freed value → allowed
- ✅ All 83 existing tests pass
- ✅ Stress test unique key assertion re-enabled

## Test plan
- [x] All existing tests pass (83/83)
- [x] Stress test `test_bulk_unique_key_operations` validates enforcement at scale (1000 items)
- [x] Manual verification of create/update/duplicate/delete-reuse cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)