### PR TITLE
Fix ReadTheDocs build: add required build.os config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,14 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 mkdocs:
   configuration: mkdocs.yml
   fail_on_warning: false
 
 python:
-   install:
-   - requirements: docs/requirements.txt
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary
- Adds required `build.os` and `build.tools.python` settings to `.readthedocs.yaml`
- ReadTheDocs v2 config now requires these fields; builds were failing with "Config validation error in build.os"

## Changes
```yaml
build:
  os: ubuntu-22.04
  tools:
    python: "3.11"
```

## Test plan
- [ ] ReadTheDocs build succeeds after merge
- [ ] https://popoto.readthedocs.io/en/latest/ shows updated documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)