### PR TITLE
Remove internal dev docs from ReadTheDocs navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,8 +15,6 @@ nav:
     - API Reference: 'api-reference.md'
     - Contributing:
         - Style Guide: 'STYLE_GUIDE.md'
-    - Completed:
-        - Meta Class Implementation: 'completed/meta-class-implementation.md'
 
 markdown_extensions:
     - admonition


### PR DESCRIPTION
## Summary
- Removes the 'Completed' section from mkdocs.yml navigation
- The meta-class-implementation.md was internal development documentation that leaked into the public ReadTheDocs site

## Test plan
- [x] Verify mkdocs.yml no longer references internal docs
- [ ] Confirm ReadTheDocs rebuild excludes the internal docs from navigation