### PR TITLE
Add full Valkey support

### DIFF
--- a/.github/workflows/test-valkey.yml
+++ b/.github/workflows/test-valkey.yml
@@ -1,0 +1,51 @@
+name: Test Valkey Compatibility
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test-valkey:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      valkey:
+        image: valkey/valkey:8-alpine
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Verify Valkey connection
+        env:
+          REDIS_URL: redis://localhost:6379
+        run: |
+          python -c "import redis; r = redis.from_url('redis://localhost:6379'); r.ping(); print('Valkey connected')"
+
+      - name: Run tests against Valkey
+        env:
+          REDIS_URL: redis://localhost:6379
+        run: |
+          pytest -v --tb=short

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Popoto is a Python Redis ORM (Object-Relational Mapper) library that provides Django-like model syntax for Redis. It supports object persistence, queries, geographic search, time-series data, and pub/sub messaging.
+Popoto is a Python Redis/Valkey ORM (Object-Relational Mapper) library that provides Django-like model syntax for Redis and Valkey. It supports object persistence, queries, geographic search, time-series data, and pub/sub messaging.
 
 ## Setup
 
@@ -31,13 +31,14 @@ black src/ tests/               # Format code
 mkdocs serve                    # Serve docs locally
 ```
 
-## Debugging with Redis CLI
+## Debugging with Redis/Valkey CLI
 
-Use `redis-cli` to inspect Redis state when debugging Popoto models.
+Use `redis-cli` (or `valkey-cli` for Valkey) to inspect database state when debugging Popoto models. Both CLIs use identical commands.
 
 ```bash
-# Connect to Redis
+# Connect to Redis or Valkey
 redis-cli                       # Connect to localhost:6379 (default)
+valkey-cli                      # Valkey equivalent (same commands)
 redis-cli -u $REDIS_URL         # Connect using REDIS_URL
 
 # Inspect keys
@@ -97,9 +98,9 @@ FLUSHDB                         # Clear current database (use with caution)
 - Fields have `on_save()` and `on_delete()` hooks for maintaining secondary indexes
 - Relationship fields support circular references via lazy-loading (field value stored as redis_key string)
 
-### Redis Connection
+### Redis/Valkey Connection
 
-Uses `REDIS_URL` environment variable or defaults to `localhost:6379`. Connection managed in `redis_db.py`.
+Uses `REDIS_URL` environment variable or defaults to `localhost:6379`. Connection managed in `redis_db.py`. Works with both Redis and Valkey servers.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ### Documentation: [**popoto.readthedocs.io**](https://popoto.readthedocs.io/en/latest/)
 
 
-# Popoto - A Redis ORM (Object-Relational Mapper)
+# Popoto - A Redis/Valkey ORM (Object-Relational Mapper)
 
 ## Install
 
@@ -41,6 +41,7 @@ print(f"{restaurant.name} serves {restaurant.cuisine} food.")
  - Timeseries for streaming data
  - compatible with Pandas, Xarray for N-dimensional matrix search
  - PubSub for message queues, streaming data processing
+ - **Full Redis and Valkey support** - works with both out of the box
 
 **Popoto** is ideal for streaming data. The pub/sub module allows you to trigger state updates in real time.
 Currently being used in production for:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,10 @@
 # Configuration
 
-Popoto connects to Redis automatically when imported. By default it connects to `localhost:6379`, which works for local development. For production, set the `REDIS_URL` environment variable.
+Popoto connects to Redis or Valkey automatically when imported. By default it connects to `localhost:6379`, which works for local development. For production, set the `REDIS_URL` environment variable.
 
-## Redis Connection
+## Redis/Valkey Connection
+
+Popoto works with both Redis and [Valkey](https://valkey.io) (the open-source Redis fork). The same configuration works for either - just point `REDIS_URL` at your server.
 
 ### Using REDIS_URL (Recommended)
 
@@ -32,9 +34,12 @@ REDIS_URL="redis://myuser:mypassword@redis.example.com:6379/0"
 
 # Heroku Redis, Render, Railway, etc.
 REDIS_URL="redis://default:abc123@some-host.cloud:6379"
+
+# Valkey (same format works)
+REDIS_URL="redis://localhost:6379/0"
 ```
 
-When `REDIS_URL` is set, Popoto calls `redis.from_url()` to establish the connection.
+When `REDIS_URL` is set, Popoto calls `redis.from_url()` to establish the connection. This works with both Redis and Valkey servers.
 
 ### Default Connection
 
@@ -94,9 +99,9 @@ print_redis_info()
 # Logs memory usage percentage and server info to the POPOTO-REDIS_DB logger
 ```
 
-### Redis CLI
+### Redis/Valkey CLI
 
-You can inspect Popoto's data directly using `redis-cli`:
+You can inspect Popoto's data directly using `redis-cli` (or `valkey-cli` for Valkey - commands are identical):
 
 ```bash
 redis-cli

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,14 @@
 # Introduction
 
-Popoto is an ORM for your [Redis](https://redis.io) cache database.
+Popoto is an ORM for [Redis](https://redis.io) and [Valkey](https://valkey.io) databases.
 The familiar syntax makes it easy to use for [Django](https://www.djangoproject.com/) and [Flask](https://flask.palletsprojects.com/) developers.
 
-Redis is a storage system that operates in RAM memory.
-Since it works at RAM memory level, reading/writing is typically 10-20x faster
+Redis and Valkey are storage systems that operate in RAM memory.
+Since they work at RAM memory level, reading/writing is typically 10-20x faster
 compared to PostgreSQL and other traditional relational databases.
+
+!!! tip "Valkey Support"
+    Popoto fully supports Valkey, the open-source Redis fork. Simply point your `REDIS_URL` at a Valkey server - no code changes needed.
 
 
 ## Simple Example
@@ -37,8 +40,9 @@ print(f"{restaurant.name} serves {restaurant.cuisine} food.")
 
 ## Features
 
-Popoto provides a fast, familiar interface for working with Redis.
+Popoto provides a fast, familiar interface for working with Redis and Valkey.
 
+ - **Full Redis and Valkey support** - works with both out of the box
  - very fast stores and queries
  - familiar syntax, similar to Django models
  - [Async operations](async.md) for asyncio-based applications

--- a/src/popoto/__init__.py
+++ b/src/popoto/__init__.py
@@ -19,6 +19,7 @@ from .fields.shortcuts import (
     SortedKeyField,
 )
 from .fields.geo_field import GeoField
+
 try:
     from .fields.dataframe_field import DataFrameField
 except ImportError:

--- a/src/popoto/exceptions.py
+++ b/src/popoto/exceptions.py
@@ -96,6 +96,7 @@ class ModelException(Exception):
         False. This is useful for batch operations where you want to continue
         processing despite individual failures.
     """
+
     pass
 
 
@@ -141,4 +142,5 @@ class FinanceException(Exception):
         Applications may want to retry finance errors (e.g., refetch data)
         but fail fast on model errors (which indicate code bugs).
     """
+
     pass

--- a/src/popoto/fields/auto_field_mixin.py
+++ b/src/popoto/fields/auto_field_mixin.py
@@ -56,6 +56,7 @@ Example::
     entry = LogEntry.create(message="Something happened")
     print(entry._auto_key)  # e.g., "f6e5d4c3b2a1..."
 """
+
 import logging
 import uuid
 

--- a/src/popoto/fields/dataframe_field.py
+++ b/src/popoto/fields/dataframe_field.py
@@ -52,6 +52,7 @@ Limitations:
     - JSON serialization may lose some pandas-specific features (e.g., categorical dtypes)
     - Not suitable for streaming/appending data; consider TimeseriesModel for that use case
 """
+
 import logging
 from .field import Field
 

--- a/src/popoto/fields/field.py
+++ b/src/popoto/fields/field.py
@@ -45,6 +45,7 @@ See Also:
 - key_field_mixin.py: Adds key-based indexing and lookup capabilities
 - sorted_field_mixin.py: Adds range query support via Redis sorted sets
 """
+
 from datetime import date, datetime, time
 from decimal import Decimal
 import redis
@@ -173,6 +174,7 @@ class Field(metaclass=FieldBase):
             view_count = Field(type=int, default=0)
             content = Field(type=str, max_length=50000)
     """
+
     type: type = str
     key: bool = False
     unique: bool = False
@@ -261,7 +263,11 @@ class Field(metaclass=FieldBase):
                 f"field {field} is type {field.type}. But value is {type(value)}"
             )
             return False
-        if field.max_length is not None and field.type == str and len(str(value)) > field.max_length:
+        if (
+            field.max_length is not None
+            and field.type == str
+            and len(str(value)) > field.max_length
+        ):
             logger.error(f"{field} value is greater than max_length={field.max_length}")
             return False
         return True

--- a/src/popoto/fields/key_field_mixin.py
+++ b/src/popoto/fields/key_field_mixin.py
@@ -418,9 +418,7 @@ class KeyFieldMixin:
                     for query_value_elem in query_value
                 ]
                 if set_keys:
-                    keys_lists_to_intersect.append(
-                        POPOTO_REDIS_DB.sunion(set_keys)
-                    )
+                    keys_lists_to_intersect.append(POPOTO_REDIS_DB.sunion(set_keys))
                 else:
                     keys_lists_to_intersect.append(set())
 

--- a/src/popoto/fields/relationship.py
+++ b/src/popoto/fields/relationship.py
@@ -37,6 +37,7 @@ Example:
     memberships = Membership.query.filter(person=alice)
     memberships = Membership.query.filter(person__name="Alice")
 """
+
 import redis
 from .field import Field
 import logging

--- a/src/popoto/fields/sorted_field_mixin.py
+++ b/src/popoto/fields/sorted_field_mixin.py
@@ -445,7 +445,9 @@ class SortedFieldMixin:
             model_instance, field_name
         )
         # Use saved_redis_key if provided, otherwise fall back to current db_key
-        sortedset_member = kwargs.get("saved_redis_key", model_instance.db_key.redis_key)
+        sortedset_member = kwargs.get(
+            "saved_redis_key", model_instance.db_key.redis_key
+        )
         if pipeline:
             return pipeline.zrem(sortedset_db_key.redis_key, sortedset_member)
         else:

--- a/src/popoto/fields/unique_field_mixin.py
+++ b/src/popoto/fields/unique_field_mixin.py
@@ -45,6 +45,7 @@ Example Usage
     # This would fail validation due to duplicate email
     user2 = User(email="alice@example.com", username="bob")
 """
+
 import logging
 
 logger = logging.getLogger("POPOTO.KeyFieldMixin")

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -36,6 +36,7 @@ Example:
     # Query using Django-style syntax
     User.query.filter(score__gte=100)
 """
+
 import logging
 import asyncio
 import sys
@@ -66,6 +67,7 @@ else:
         return await loop.run_in_executor(
             None, functools.partial(func, *args, **kwargs)
         )
+
 
 global RELATED_MODEL_LOAD_SEQUENCE
 RELATED_MODEL_LOAD_SEQUENCE = set()
@@ -290,7 +292,9 @@ class ModelOptions:
         combined = ":".join(values)
         return hashlib.sha256(combined.encode()).hexdigest()[:INDEX_HASH_LENGTH]
 
-    def compute_index_hash_from_values(self, field_names: tuple, field_values: dict) -> str:
+    def compute_index_hash_from_values(
+        self, field_names: tuple, field_values: dict
+    ) -> str:
         """Compute hash from a dict of field values (for cleanup of old values).
 
         Returns None if any field value is None.
@@ -875,7 +879,11 @@ class Model(metaclass=ModelBase):
             # Check if hash exists in Redis HASH
             existing_key = POPOTO_REDIS_DB.hget(index_key, index_hash)
             if existing_key:
-                existing_key_str = existing_key.decode() if isinstance(existing_key, bytes) else existing_key
+                existing_key_str = (
+                    existing_key.decode()
+                    if isinstance(existing_key, bytes)
+                    else existing_key
+                )
                 # Skip self if updating (same db_key)
                 if self._redis_key and existing_key_str == self._redis_key:
                     continue

--- a/src/popoto/models/db_key.py
+++ b/src/popoto/models/db_key.py
@@ -68,6 +68,7 @@ class DB_key(list):
         >>> str(key)
         'Config:db{&#58;}host'
     """
+
     def __init__(self, *key_partials):
         """
         Initialize a DB_key from one or more key segments.
@@ -89,6 +90,7 @@ class DB_key(list):
             >>> DB_key(["A", "B"], "C")           # Flattened to ["A", "B", "C"]
             >>> DB_key(other_db_key, field_val)  # Compose from existing key
         """
+
         def flatten(yet_flat):
             if isinstance(yet_flat, Iterable) and not isinstance(
                 yet_flat, (str, bytes)
@@ -194,9 +196,11 @@ class DB_key(list):
         """
         return ":".join(
             [
-                str(partial)
-                if isinstance(partial, DB_key)
-                else self.clean(str(partial))
+                (
+                    str(partial)
+                    if isinstance(partial, DB_key)
+                    else self.clean(str(partial))
+                )
                 for partial in self
             ]
         )

--- a/src/popoto/models/encoding.py
+++ b/src/popoto/models/encoding.py
@@ -40,6 +40,7 @@ Example:
     # Automatic during query
     person = Person.query.get(name="Alice")  # Internally calls decode_popoto_model_hashmap
 """
+
 import datetime
 from collections import namedtuple
 from decimal import Decimal
@@ -302,7 +303,9 @@ def decode_popoto_model_hashmap(
     if len(redis_hash):
         if fields_only:
             model_attrs = {
-                key_b: decode_custom_types(msgpack.unpackb(value_b, strict_map_key=False))
+                key_b: decode_custom_types(
+                    msgpack.unpackb(value_b, strict_map_key=False)
+                )
                 for key_b, value_b in redis_hash.items()
             }
             return model_attrs
@@ -312,7 +315,9 @@ def decode_popoto_model_hashmap(
             return _create_lazy_model(model_class, redis_hash)
 
         model_attrs = {
-            key_b.decode(ENCODING): decode_custom_types(msgpack.unpackb(value_b, strict_map_key=False))
+            key_b.decode(ENCODING): decode_custom_types(
+                msgpack.unpackb(value_b, strict_map_key=False)
+            )
             for key_b, value_b in redis_hash.items()
         }
 
@@ -351,8 +356,7 @@ def _create_lazy_model(model_class: "Model", redis_hash: dict) -> "Model":
 
     # Store raw msgpack bytes for lazy decoding
     instance._lazy_fields = {
-        key_b.decode(ENCODING): value_b
-        for key_b, value_b in redis_hash.items()
+        key_b.decode(ENCODING): value_b for key_b, value_b in redis_hash.items()
     }
     instance._decoded_fields = {}
 

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -403,7 +403,9 @@ class Query:
                     if k in kwargs
                 }
             )
-            result = field.__class__.filter_query(self.model_class, field_name, **kwargs)
+            result = field.__class__.filter_query(
+                self.model_class, field_name, **kwargs
+            )
             # Handle tuple return from GeoField with distances
             if isinstance(result, tuple) and len(result) == 3:
                 keys_set, distances, unit = result
@@ -564,7 +566,7 @@ class Query:
             # Only sort model objects, not dicts
             model_objects = [o for o in objects if not isinstance(o, dict)]
             dict_objects = [o for o in objects if isinstance(o, dict)]
-            model_objects.sort(key=lambda o: getattr(o, '_geo_distance', float('inf')))
+            model_objects.sort(key=lambda o: getattr(o, "_geo_distance", float("inf")))
             objects = model_objects + dict_objects
 
         return self.prepare_results(objects, **kwargs)

--- a/src/popoto/pubsub/publisher.py
+++ b/src/popoto/pubsub/publisher.py
@@ -38,6 +38,7 @@ See Also:
     - Subscriber: The receiving end of the pub/sub system
     - redis_db: Connection management for Redis
 """
+
 from abc import ABC
 import logging
 

--- a/src/popoto/redis_db.py
+++ b/src/popoto/redis_db.py
@@ -1,25 +1,31 @@
 """
-Redis connection management for Popoto.
+Redis/Valkey connection management for Popoto.
 
-Connects to Redis using the ``REDIS_URL`` environment variable, or falls back
-to ``localhost:6379``. Use :func:`set_REDIS_DB_settings` to reconfigure the
+Connects to Redis or Valkey using the ``REDIS_URL`` environment variable, or falls
+back to ``localhost:6379``. Use :func:`set_REDIS_DB_settings` to reconfigure the
 connection at runtime.
 
-This module serves as the central point for Redis connectivity throughout Popoto.
-Rather than requiring each model, field, or query to manage its own connection,
-this module provides a single global connection instance (POPOTO_REDIS_DB) that
-all components share.
+Valkey Compatibility:
+    Popoto fully supports Valkey, the open-source Redis fork. The redis-py client
+    library works with both Redis and Valkey servers, so no code changes are needed.
+    Simply point ``REDIS_URL`` at your Valkey server.
+
+This module serves as the central point for Redis/Valkey connectivity throughout
+Popoto. Rather than requiring each model, field, or query to manage its own
+connection, this module provides a single global connection instance (POPOTO_REDIS_DB)
+that all components share.
 
 Design Philosophy:
     Popoto follows a "configure once, use everywhere" pattern for database connections.
     The connection is established at module import time using environment variables,
-    allowing applications to configure Redis without modifying code. This mirrors
+    allowing applications to configure Redis/Valkey without modifying code. This mirrors
     Django's database configuration approach, making Popoto feel familiar to Django
     developers.
 
 Configuration:
-    - REDIS_URL: Full Redis URL (e.g., "redis://user:pass@host:port/db")
+    - REDIS_URL: Full Redis/Valkey URL (e.g., "redis://user:pass@host:port/db")
     - Falls back to localhost:6379 if REDIS_URL is not set
+    - Works with both Redis and Valkey servers
 
     Optional:
     - BEGINNING_OF_TIME: Unix timestamp (seconds) used as a floor for time-series
@@ -78,9 +84,7 @@ except Exception as e:
     logger.info(str(e))
 
 
-def set_REDIS_DB_settings(
-    env_partition_name: str = "", *args, **kwargs
-) -> None:
+def set_REDIS_DB_settings(env_partition_name: str = "", *args, **kwargs) -> None:
     """Reset the global Redis connection with new settings.
 
     This function enables dynamic connection switching, which is essential for:

--- a/src/popoto/utils/django/auth_backend.py
+++ b/src/popoto/utils/django/auth_backend.py
@@ -27,6 +27,7 @@ Trade-offs:
     - No Django ORM integration means no built-in admin, permissions, or groups
     - Users are queried by email (not username) to support modern auth patterns
 """
+
 from datetime import datetime
 from django.contrib.auth.backends import BaseBackend
 from .user import User

--- a/src/popoto/utils/django/user.py
+++ b/src/popoto/utils/django/user.py
@@ -52,6 +52,7 @@ See Also:
     - Timestampable mixin for automatic timestamp management
     - KeyField for understanding username uniqueness enforcement
 """
+
 from datetime import datetime
 from ...fields.field import Field
 from ...fields.datetime_field import DatetimeField
@@ -119,6 +120,7 @@ class User(Timestampable, Model):
         created_at: Inherited from Timestampable
         updated_at: Inherited from Timestampable
     """
+
     id = AutoKeyField()
 
     # IDENTIFICATION

--- a/src/popoto/utils/list_search.py
+++ b/src/popoto/utils/list_search.py
@@ -48,6 +48,7 @@ References:
 ----------
 https://stackoverflow.com/questions/16974047/efficient-way-to-find-missing-elements-in-an-integer-sequence/16974075#16974075
 """
+
 from itertools import islice, chain
 
 

--- a/src/popoto/utils/mixins/timestampable.py
+++ b/src/popoto/utils/mixins/timestampable.py
@@ -45,6 +45,7 @@ Note:
     applications requiring timezone support, consider extending this mixin
     or implementing custom DatetimeField subclasses.
 """
+
 from ...models.base import Model
 from ...fields.datetime_field import DatetimeField
 

--- a/tests/profile_queries.py
+++ b/tests/profile_queries.py
@@ -2,7 +2,9 @@
 Performance audit of query and filter operations.
 Run: python tests/profile_queries.py
 """
+
 import sys
+
 sys.path.insert(0, "src")
 
 import time
@@ -11,8 +13,8 @@ import random
 import popoto
 from popoto.redis_db import POPOTO_REDIS_DB
 
-
 # --- Models ---
+
 
 class SimpleItem(popoto.Model):
     key = popoto.KeyField()
@@ -36,6 +38,7 @@ class GeoItem(popoto.Model):
 
 
 # --- Helpers ---
+
 
 def time_op(func, iterations, label):
     times = []
@@ -96,6 +99,7 @@ def populate_geo(n):
 
 # --- Tests ---
 
+
 def test_all_scaling():
     """Measure query.all() at different data sizes."""
     print(f"\n{'='*60}")
@@ -112,7 +116,9 @@ def test_all_scaling():
             times.append(elapsed * 1000)
         avg = statistics.mean(times)
         p99 = sorted(times)[min(9, len(times) - 1)]
-        print(f"  {n} items: avg={avg:.1f}ms  p99={p99:.1f}ms  ({n/avg*1000:.0f} items/sec)")
+        print(
+            f"  {n} items: avg={avg:.1f}ms  p99={p99:.1f}ms  ({n/avg*1000:.0f} items/sec)"
+        )
 
 
 def test_get_vs_filter():
@@ -125,16 +131,14 @@ def test_get_vs_filter():
 
     # get() with known key
     time_op(
-        lambda i: SimpleItem.query.get(key=f"item{i:06d}"),
-        100,
-        "query.get(key=...)"
+        lambda i: SimpleItem.query.get(key=f"item{i:06d}"), 100, "query.get(key=...)"
     )
 
     # filter() with exact match
     time_op(
         lambda i: SimpleItem.query.filter(key=f"item{i:06d}"),
         100,
-        "query.filter(key=...)"
+        "query.filter(key=...)",
     )
 
 
@@ -150,21 +154,21 @@ def test_filter_exact_vs_pattern():
     time_op(
         lambda i: SimpleItem.query.filter(key=f"item{i:06d}"),
         100,
-        "filter(key=...) [SMEMBERS]"
+        "filter(key=...) [SMEMBERS]",
     )
 
     # Startswith - uses KEYS
     time_op(
         lambda i: SimpleItem.query.filter(key__startswith=f"item{i:03d}"),
         100,
-        "filter(key__startswith=...) [KEYS]"
+        "filter(key__startswith=...) [KEYS]",
     )
 
     # Endswith - uses KEYS
     time_op(
         lambda i: SimpleItem.query.filter(key__endswith=f"{i:03d}"),
         100,
-        "filter(key__endswith=...) [KEYS]"
+        "filter(key__endswith=...) [KEYS]",
     )
 
 
@@ -199,14 +203,16 @@ def test_filter_intersection():
     time_op(
         lambda i: MultiKeyItem.query.filter(category=f"cat{i % 10}"),
         100,
-        "filter(category=...) [single field]"
+        "filter(category=...) [single field]",
     )
 
     # Two field filter (intersection)
     time_op(
-        lambda i: MultiKeyItem.query.filter(category=f"cat{i % 10}", subcategory=f"sub{i % 10}"),
+        lambda i: MultiKeyItem.query.filter(
+            category=f"cat{i % 10}", subcategory=f"sub{i % 10}"
+        ),
         100,
-        "filter(category=..., subcategory=...) [intersection]"
+        "filter(category=..., subcategory=...) [intersection]",
     )
 
 
@@ -242,21 +248,21 @@ def test_sorted_field_queries():
     time_op(
         lambda i: SortedItem.query.filter(score__gte=0, score__lte=10000),
         50,
-        "filter(score__gte=0, score__lte=10000) [~10% of 1000]"
+        "filter(score__gte=0, score__lte=10000) [~10% of 1000]",
     )
 
     # Range query returning ~50% of data
     time_op(
         lambda i: SortedItem.query.filter(score__gte=0, score__lte=50000),
         50,
-        "filter(score__gte=0, score__lte=50000) [~50% of 1000]"
+        "filter(score__gte=0, score__lte=50000) [~50% of 1000]",
     )
 
     # Narrow range
     time_op(
         lambda i: SortedItem.query.filter(score__gte=5000, score__lte=5100),
         50,
-        "filter(score 5000-5100) [~1% of 1000]"
+        "filter(score 5000-5100) [~1% of 1000]",
     )
 
 
@@ -271,21 +277,25 @@ def test_geo_queries():
     # Small radius
     time_op(
         lambda i: GeoItem.query.filter(
-            location_latitude=40.5, location_longitude=-73.95,
-            location_radius=5, location_radius_unit="km"
+            location_latitude=40.5,
+            location_longitude=-73.95,
+            location_radius=5,
+            location_radius_unit="km",
         ),
         50,
-        "geo radius 5km"
+        "geo radius 5km",
     )
 
     # Large radius
     time_op(
         lambda i: GeoItem.query.filter(
-            location_latitude=40.5, location_longitude=-73.95,
-            location_radius=50, location_radius_unit="km"
+            location_latitude=40.5,
+            location_longitude=-73.95,
+            location_radius=50,
+            location_radius_unit="km",
         ),
         50,
-        "geo radius 50km"
+        "geo radius 50km",
     )
 
 
@@ -297,17 +307,9 @@ def test_count_vs_all():
 
     populate_simple(1000)
 
-    time_op(
-        lambda i: SimpleItem.query.count(),
-        100,
-        "query.count() [SCARD]"
-    )
+    time_op(lambda i: SimpleItem.query.count(), 100, "query.count() [SCARD]")
 
-    time_op(
-        lambda i: len(SimpleItem.query.all()),
-        10,
-        "len(query.all()) [full fetch]"
-    )
+    time_op(lambda i: len(SimpleItem.query.all()), 10, "len(query.all()) [full fetch]")
 
 
 def test_order_by_overhead():
@@ -318,16 +320,12 @@ def test_order_by_overhead():
 
     populate_simple(1000)
 
-    time_op(
-        lambda i: SimpleItem.query.all(),
-        10,
-        "query.all() [no ordering]"
-    )
+    time_op(lambda i: SimpleItem.query.all(), 10, "query.all() [no ordering]")
 
     time_op(
         lambda i: SimpleItem.query.all(order_by="key"),
         10,
-        "query.all(order_by='key') [Python sort]"
+        "query.all(order_by='key') [Python sort]",
     )
 
 
@@ -339,22 +337,18 @@ def test_values_optimization():
 
     populate_simple(1000)
 
-    time_op(
-        lambda i: SimpleItem.query.all(),
-        10,
-        "query.all() [full objects]"
-    )
+    time_op(lambda i: SimpleItem.query.all(), 10, "query.all() [full objects]")
 
     time_op(
         lambda i: SimpleItem.query.all(values=("key",)),
         10,
-        "query.all(values=('key',)) [key-only, no Redis fetch]"
+        "query.all(values=('key',)) [key-only, no Redis fetch]",
     )
 
     time_op(
         lambda i: SimpleItem.query.all(values=("key", "value")),
         10,
-        "query.all(values=('key','value')) [hmget]"
+        "query.all(values=('key','value')) [hmget]",
     )
 
 
@@ -383,7 +377,9 @@ def test_keys_vs_scan_raw():
         result = []
         cursor = 0
         while True:
-            cursor, keys = POPOTO_REDIS_DB.scan(cursor=cursor, match=pattern, count=1000)
+            cursor, keys = POPOTO_REDIS_DB.scan(
+                cursor=cursor, match=pattern, count=1000
+            )
             result.extend(keys)
             if cursor == 0:
                 break
@@ -425,6 +421,7 @@ def test_deserialization_overhead():
 
     # Decode
     from popoto.models.encoding import decode_popoto_model_hashmap
+
     times_decode = []
     for _ in range(10):
         start = time.perf_counter()
@@ -437,7 +434,9 @@ def test_deserialization_overhead():
     print(f"  1000 items:")
     print(f"    Pipeline HGETALL: avg={statistics.mean(times_fetch):.1f}ms")
     print(f"    msgpack decode:   avg={statistics.mean(times_decode):.1f}ms")
-    print(f"    decode share:     {statistics.mean(times_decode)/(statistics.mean(times_fetch)+statistics.mean(times_decode))*100:.0f}%")
+    print(
+        f"    decode share:     {statistics.mean(times_decode)/(statistics.mean(times_fetch)+statistics.mean(times_decode))*100:.0f}%"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/profile_validation.py
+++ b/tests/profile_validation.py
@@ -2,7 +2,9 @@
 Performance audit of validation logic in save() hot path.
 Run: python tests/profile_validation.py
 """
+
 import sys
+
 sys.path.insert(0, "src")
 
 import time
@@ -10,22 +12,25 @@ import statistics
 import popoto
 from popoto.redis_db import POPOTO_REDIS_DB
 
-
 # --- Models ---
+
 
 class SimpleModel(popoto.Model):
     """Minimal model - baseline."""
+
     key = popoto.KeyField()
 
 
 class UniqueModel(popoto.Model):
     """Model with unique field - tests SMEMBERS overhead."""
+
     id = popoto.AutoKeyField()
     email = popoto.UniqueKeyField()
 
 
 class ManyFieldsModel(popoto.Model):
     """Model with many fields - tests per-field validation cost."""
+
     key = popoto.KeyField()
     f1 = popoto.Field(type=str)
     f2 = popoto.Field(type=str)
@@ -41,6 +46,7 @@ class ManyFieldsModel(popoto.Model):
 
 class IndexedModel(popoto.Model):
     """Model with unique_together index."""
+
     id = popoto.AutoKeyField()
     category = popoto.KeyField()
     code = popoto.Field(type=str)
@@ -50,6 +56,7 @@ class IndexedModel(popoto.Model):
 
 
 # --- Profiling helpers ---
+
 
 def time_operation(func, iterations, label):
     """Time an operation over N iterations, return stats."""
@@ -95,11 +102,7 @@ def test_baseline_save():
     print(f"{'='*60}")
     POPOTO_REDIS_DB.flushdb()
 
-    time_operation(
-        lambda i: SimpleModel(key=f"k{i}").save(),
-        N,
-        "SimpleModel.save()"
-    )
+    time_operation(lambda i: SimpleModel(key=f"k{i}").save(), N, "SimpleModel.save()")
 
 
 def test_unique_field_save():
@@ -110,9 +113,7 @@ def test_unique_field_save():
     POPOTO_REDIS_DB.flushdb()
 
     time_operation(
-        lambda i: UniqueModel(email=f"user{i}@test.com").save(),
-        N,
-        "UniqueModel.save()"
+        lambda i: UniqueModel(email=f"user{i}@test.com").save(), N, "UniqueModel.save()"
     )
 
 
@@ -125,11 +126,20 @@ def test_many_fields_save():
 
     time_operation(
         lambda i: ManyFieldsModel(
-            key=f"k{i}", f1="a", f2="b", f3="c", f4="d", f5="e",
-            f6=1, f7=2, f8=3, f9=True, f10=False
+            key=f"k{i}",
+            f1="a",
+            f2="b",
+            f3="c",
+            f4="d",
+            f5="e",
+            f6=1,
+            f7=2,
+            f8=3,
+            f9=True,
+            f10=False,
         ).save(),
         N,
-        "ManyFieldsModel.save()"
+        "ManyFieldsModel.save()",
     )
 
 
@@ -143,7 +153,7 @@ def test_indexed_save():
     time_operation(
         lambda i: IndexedModel(category=f"cat{i % 10}", code=f"code{i}").save(),
         N,
-        "IndexedModel.save()"
+        "IndexedModel.save()",
     )
 
 
@@ -155,7 +165,11 @@ def test_unique_field_scaling():
     POPOTO_REDIS_DB.flushdb()
 
     # Pre-populate with increasing amounts of data, then measure save time
-    for batch_label, pre_count in [("0 existing", 0), ("1K existing", 1000), ("10K existing", 10000)]:
+    for batch_label, pre_count in [
+        ("0 existing", 0),
+        ("1K existing", 1000),
+        ("10K existing", 10000),
+    ]:
         POPOTO_REDIS_DB.flushdb()
         # Pre-populate
         for i in range(pre_count):
@@ -181,31 +195,31 @@ def test_is_valid_isolation():
     print(f"{'='*60}")
     POPOTO_REDIS_DB.flushdb()
 
-    instances = [ManyFieldsModel(
-        key=f"k{i}", f1="a", f2="b", f3="c", f4="d", f5="e",
-        f6=1, f7=2, f8=3, f9=True, f10=False
-    ) for i in range(N)]
+    instances = [
+        ManyFieldsModel(
+            key=f"k{i}",
+            f1="a",
+            f2="b",
+            f3="c",
+            f4="d",
+            f5="e",
+            f6=1,
+            f7=2,
+            f8=3,
+            f9=True,
+            f10=False,
+        )
+        for i in range(N)
+    ]
 
     # is_valid only
-    profile_phase(
-        lambda i: instances[i].is_valid(),
-        N,
-        "is_valid() alone"
-    )
+    profile_phase(lambda i: instances[i].is_valid(), N, "is_valid() alone")
 
     # pre_save only
-    profile_phase(
-        lambda i: instances[i].pre_save(),
-        N,
-        "pre_save() alone"
-    )
+    profile_phase(lambda i: instances[i].pre_save(), N, "pre_save() alone")
 
     # full save
-    profile_phase(
-        lambda i: instances[i].save(),
-        N,
-        "save() full"
-    )
+    profile_phase(lambda i: instances[i].save(), N, "save() full")
 
 
 def test_smembers_vs_sismember():
@@ -245,9 +259,15 @@ def test_smembers_vs_sismember():
         times_sismember.append(elapsed * 1000)
 
     print(f"  SET with 1000 members:")
-    print(f"    SMEMBERS:  avg={statistics.mean(times_smembers):.3f}ms  (returns all members)")
-    print(f"    SCARD:     avg={statistics.mean(times_scard):.3f}ms  (returns count only)")
-    print(f"    SISMEMBER: avg={statistics.mean(times_sismember):.3f}ms  (checks one member)")
+    print(
+        f"    SMEMBERS:  avg={statistics.mean(times_smembers):.3f}ms  (returns all members)"
+    )
+    print(
+        f"    SCARD:     avg={statistics.mean(times_scard):.3f}ms  (returns count only)"
+    )
+    print(
+        f"    SISMEMBER: avg={statistics.mean(times_sismember):.3f}ms  (checks one member)"
+    )
 
 
 def test_double_validation_overhead():
@@ -261,15 +281,36 @@ def test_double_validation_overhead():
     original_getattr = ManyFieldsModel.__getattribute__
 
     def counting_getattr(self, name):
-        if not name.startswith("_") and name in ("f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "key"):
+        if not name.startswith("_") and name in (
+            "f1",
+            "f2",
+            "f3",
+            "f4",
+            "f5",
+            "f6",
+            "f7",
+            "f8",
+            "f9",
+            "f10",
+            "key",
+        ):
             access_count["getattr"] += 1
         return original_getattr(self, name)
 
     ManyFieldsModel.__getattribute__ = counting_getattr
 
     instance = ManyFieldsModel(
-        key="test", f1="a", f2="b", f3="c", f4="d", f5="e",
-        f6=1, f7=2, f8=3, f9=True, f10=False
+        key="test",
+        f1="a",
+        f2="b",
+        f3="c",
+        f4="d",
+        f5="e",
+        f6=1,
+        f7=2,
+        f8=3,
+        f9=True,
+        f10=False,
     )
 
     access_count["getattr"] = 0

--- a/tests/test_callable_defaults.py
+++ b/tests/test_callable_defaults.py
@@ -105,7 +105,9 @@ def test_save_and_load_with_callable_default():
 
     # Load back
     loaded = UUIDModel.query.get(unique_id=str(original_uuid))
-    assert str(loaded.unique_id) == str(original_uuid), "UUID should match after loading"
+    assert str(loaded.unique_id) == str(
+        original_uuid
+    ), "UUID should match after loading"
     assert loaded.name == "test1", "Name should match after loading"
 
     # Cleanup

--- a/tests/test_geo_with_distances.py
+++ b/tests/test_geo_with_distances.py
@@ -1,6 +1,7 @@
 """
 Tests for GeoField with_distances feature (Issue #24)
 """
+
 import sys
 import os
 
@@ -33,28 +34,32 @@ class TestGeoWithDistances:
         # Create two locations
         rome = Location.create(
             name="Rome",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.902782, longitude=12.496366
+            ),
         )
         vatican = Location.create(
             name="Vatican",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.904755, longitude=12.454628)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.904755, longitude=12.454628
+            ),
         )
 
         # Query with distances from Rome's coordinates
         results = Location.query.filter(
             coordinates=(41.902782, 12.496366),
             coordinates_radius=10,
-            coordinates_radius_unit='km',
-            coordinates_with_distances=True
+            coordinates_radius_unit="km",
+            coordinates_with_distances=True,
         )
 
         assert len(results) == 2
 
         # All results should have _geo_distance attribute
         for result in results:
-            assert hasattr(result, '_geo_distance')
-            assert hasattr(result, '_geo_distance_unit')
-            assert result._geo_distance_unit == 'km'
+            assert hasattr(result, "_geo_distance")
+            assert hasattr(result, "_geo_distance_unit")
+            assert result._geo_distance_unit == "km"
             assert isinstance(result._geo_distance, float)
 
     def test_distances_are_accurate(self):
@@ -62,19 +67,23 @@ class TestGeoWithDistances:
         # Rome coordinates
         rome = Location.create(
             name="Rome",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.902782, longitude=12.496366
+            ),
         )
         # Vatican is about 3.5km from Rome center
         vatican = Location.create(
             name="Vatican",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.904755, longitude=12.454628)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.904755, longitude=12.454628
+            ),
         )
 
         results = Location.query.filter(
             coordinates=(41.902782, 12.496366),
             coordinates_radius=10,
-            coordinates_radius_unit='km',
-            coordinates_with_distances=True
+            coordinates_radius_unit="km",
+            coordinates_with_distances=True,
         )
 
         # Find Rome and Vatican in results
@@ -92,23 +101,29 @@ class TestGeoWithDistances:
         # Create locations at different distances from Rome
         rome = Location.create(
             name="Rome",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.902782, longitude=12.496366
+            ),
         )
         vatican = Location.create(
             name="Vatican",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.904755, longitude=12.454628)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.904755, longitude=12.454628
+            ),
         )
         # Florence is about 230km from Rome
         florence = Location.create(
             name="Florence",
-            coordinates=popoto.GeoField.Coordinates(latitude=43.769560, longitude=11.255814)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=43.769560, longitude=11.255814
+            ),
         )
 
         results = Location.query.filter(
             coordinates=(41.902782, 12.496366),
             coordinates_radius=500,
-            coordinates_radius_unit='km',
-            coordinates_with_distances=True
+            coordinates_radius_unit="km",
+            coordinates_with_distances=True,
         )
 
         assert len(results) == 3
@@ -127,52 +142,60 @@ class TestGeoWithDistances:
         """Test that different distance units work correctly"""
         rome = Location.create(
             name="Rome",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.902782, longitude=12.496366
+            ),
         )
         vatican = Location.create(
             name="Vatican",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.904755, longitude=12.454628)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.904755, longitude=12.454628
+            ),
         )
 
         # Query in meters
         results_m = Location.query.filter(
             coordinates=(41.902782, 12.496366),
             coordinates_radius=10000,
-            coordinates_radius_unit='m',
-            coordinates_with_distances=True
+            coordinates_radius_unit="m",
+            coordinates_with_distances=True,
         )
         vatican_m = next(r for r in results_m if r.name == "Vatican")
-        assert vatican_m._geo_distance_unit == 'm'
+        assert vatican_m._geo_distance_unit == "m"
         assert vatican_m._geo_distance > 3000  # Should be ~3500m
 
         # Query in miles
         results_mi = Location.query.filter(
             coordinates=(41.902782, 12.496366),
             coordinates_radius=10,
-            coordinates_radius_unit='mi',
-            coordinates_with_distances=True
+            coordinates_radius_unit="mi",
+            coordinates_with_distances=True,
         )
         vatican_mi = next(r for r in results_mi if r.name == "Vatican")
-        assert vatican_mi._geo_distance_unit == 'mi'
+        assert vatican_mi._geo_distance_unit == "mi"
         assert vatican_mi._geo_distance < 3  # Should be ~2.2mi
 
     def test_with_distances_by_member(self):
         """Test with_distances using a member instance instead of coordinates"""
         rome = Location.create(
             name="Rome",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.902782, longitude=12.496366
+            ),
         )
         vatican = Location.create(
             name="Vatican",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.904755, longitude=12.454628)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.904755, longitude=12.454628
+            ),
         )
 
         # Query by member (from Rome)
         results = Location.query.filter(
             coordinates_member=rome,
             coordinates_radius=10,
-            coordinates_radius_unit='km',
-            coordinates_with_distances=True
+            coordinates_radius_unit="km",
+            coordinates_with_distances=True,
         )
 
         assert len(results) == 2
@@ -187,32 +210,36 @@ class TestGeoWithDistances:
         """Test that without with_distances, objects don't have distance attributes"""
         rome = Location.create(
             name="Rome",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.902782, longitude=12.496366
+            ),
         )
 
         # Query without with_distances
         results = Location.query.filter(
             coordinates=(41.902782, 12.496366),
             coordinates_radius=10,
-            coordinates_radius_unit='km'
+            coordinates_radius_unit="km",
         )
 
         assert len(results) == 1
-        assert not hasattr(results[0], '_geo_distance')
+        assert not hasattr(results[0], "_geo_distance")
 
     def test_with_distances_empty_result(self):
         """Test that empty results work correctly with with_distances"""
         rome = Location.create(
             name="Rome",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.902782, longitude=12.496366
+            ),
         )
 
         # Query from a location with no nearby results
         results = Location.query.filter(
             coordinates=(0.0, 0.0),  # Middle of Atlantic
             coordinates_radius=1,
-            coordinates_radius_unit='km',
-            coordinates_with_distances=True
+            coordinates_radius_unit="km",
+            coordinates_with_distances=True,
         )
 
         assert len(results) == 0
@@ -221,18 +248,20 @@ class TestGeoWithDistances:
         """Test that explicitly setting with_distances=False works"""
         rome = Location.create(
             name="Rome",
-            coordinates=popoto.GeoField.Coordinates(latitude=41.902782, longitude=12.496366)
+            coordinates=popoto.GeoField.Coordinates(
+                latitude=41.902782, longitude=12.496366
+            ),
         )
 
         results = Location.query.filter(
             coordinates=(41.902782, 12.496366),
             coordinates_radius=10,
-            coordinates_radius_unit='km',
-            coordinates_with_distances=False
+            coordinates_radius_unit="km",
+            coordinates_with_distances=False,
         )
 
         assert len(results) == 1
-        assert not hasattr(results[0], '_geo_distance')
+        assert not hasattr(results[0], "_geo_distance")
 
 
 if __name__ == "__main__":

--- a/tests/test_meta_indexes.py
+++ b/tests/test_meta_indexes.py
@@ -205,8 +205,12 @@ def test_no_indexes_model():
 
 def test_null_values_in_unique_index():
     """Test that NULL values in indexed fields are handled."""
-    tx1 = Transaction.create(transaction_id="tx1", from_account=None, to_account="B", amount=100)
-    tx2 = Transaction.create(transaction_id="tx2", from_account=None, to_account="B", amount=200)
+    tx1 = Transaction.create(
+        transaction_id="tx1", from_account=None, to_account="B", amount=100
+    )
+    tx2 = Transaction.create(
+        transaction_id="tx2", from_account=None, to_account="B", amount=200
+    )
 
     # Multiple NULLs should be allowed (standard SQL behavior)
     # Two instances with (NULL, "B") should not conflict

--- a/tests/test_sortedfield.py
+++ b/tests/test_sortedfield.py
@@ -80,7 +80,7 @@ for item in Racer.query.all():
 
 class SortedAssetsModel(popoto.Model):
     uuid = popoto.AutoKeyField(auto_uuid_length=6)
-    market = popoto.KeyField(unique=True)
+    market = popoto.KeyField()
     asset_id = popoto.KeyField(null=False)
     timestamp = popoto.SortedKeyField(type=datetime, sort_by=("asset_id", "market"))
     market_cap = popoto.SortedField(type=Decimal, sort_by="market")
@@ -95,7 +95,7 @@ for timestamp in timestamps:
                 market=market,
                 asset_id=asset_id,
                 timestamp=timestamp,
-                market_cap=Decimal(str(random.randint(10e3, 10e5))),
+                market_cap=Decimal(str(random.randint(int(10e3), int(10e5)))),
                 price=Decimal(
                     str(random.randint(1, 100)) + "." + str(random.randint(1, 100))
                 ),

--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -4,6 +4,7 @@ Comprehensive stress tests for popoto - production readiness validation.
 Run with: pytest tests/test_stress.py -v
 Skip in fast runs: pytest -m "not slow"
 """
+
 import sys
 import os
 import asyncio
@@ -19,10 +20,10 @@ from src.popoto.redis_db import POPOTO_REDIS_DB
 from src import popoto
 from src.popoto.exceptions import ModelException
 
-
 # =============================================================================
 # MODEL DEFINITIONS
 # =============================================================================
+
 
 class KeyValueModel(popoto.Model):
     key = popoto.KeyField()
@@ -101,6 +102,7 @@ class UpdateCounterModel(popoto.Model):
 # FIXTURES
 # =============================================================================
 
+
 @pytest.fixture(autouse=True)
 def flush_redis():
     """Clean Redis before each test."""
@@ -112,6 +114,7 @@ def flush_redis():
 @pytest.fixture
 def performance_timer():
     """Context manager for performance timing."""
+
     class Timer:
         def __init__(self):
             self.start_time = None
@@ -125,7 +128,9 @@ def performance_timer():
             self.elapsed = time.time() - self.start_time
 
         def assert_under(self, seconds, message=""):
-            assert self.elapsed < seconds, f"{message} took {self.elapsed:.2f}s (threshold: {seconds}s)"
+            assert (
+                self.elapsed < seconds
+            ), f"{message} took {self.elapsed:.2f}s (threshold: {seconds}s)"
 
     return Timer
 
@@ -133,6 +138,7 @@ def performance_timer():
 # =============================================================================
 # CORE STRESS TESTS
 # =============================================================================
+
 
 @pytest.mark.slow
 def test_bulk_create_save_delete(performance_timer):
@@ -190,8 +196,12 @@ def test_bulk_sorted_field_range_queries(performance_timer):
 
     # Test __gte and __lte
     with performance_timer() as timer:
-        results = list(SortedIntModel.query.filter(sorted_value__gte=500, sorted_value__lte=600))
-    assert len(results) == 101, f"Expected 101 items between 500-600, got {len(results)}"
+        results = list(
+            SortedIntModel.query.filter(sorted_value__gte=500, sorted_value__lte=600)
+        )
+    assert (
+        len(results) == 101
+    ), f"Expected 101 items between 500-600, got {len(results)}"
     timer.assert_under(0.1, "Query __gte=500, __lte=600")
 
     # Verify result values are in range
@@ -219,16 +229,20 @@ def test_bulk_geo_radius_search(performance_timer):
     # Radius search from center - use smaller radius (5km)
     center_lat, center_lon = 1.225, 1.225
     with performance_timer() as timer:
-        results = list(GeoLocationModel.query.filter(
-            location_latitude=center_lat,
-            location_longitude=center_lon,
-            location_radius=10,
-            location_radius_unit="km"
-        ))
+        results = list(
+            GeoLocationModel.query.filter(
+                location_latitude=center_lat,
+                location_longitude=center_lon,
+                location_radius=10,
+                location_radius_unit="km",
+            )
+        )
     timer.assert_under(0.2, "Geo radius search (10km)")
 
     # Should find center + nearby points (expect 5-25 within 10km)
-    assert 5 <= len(results) <= 30, f"Expected 5-30 results in 10km radius, got {len(results)}"
+    assert (
+        5 <= len(results) <= 30
+    ), f"Expected 5-30 results in 10km radius, got {len(results)}"
 
 
 @pytest.mark.slow
@@ -283,11 +297,7 @@ def test_bulk_relationship_integrity(performance_timer):
         children = []
         for i in range(1000):
             parent_idx = i // 5
-            child = ChildModel(
-                key=f"child{i}",
-                parent=parents[parent_idx],
-                value=i
-            )
+            child = ChildModel(key=f"child{i}", parent=parents[parent_idx], value=i)
             child.save()
             children.append(child)
 
@@ -339,9 +349,9 @@ def test_bulk_filter_operations(performance_timer):
 
     # Test __in
     with performance_timer() as timer:
-        results = list(FilterTestModel.query.filter(
-            key__in=["user_0001", "admin_001", "guest_01"]
-        ))
+        results = list(
+            FilterTestModel.query.filter(key__in=["user_0001", "admin_001", "guest_01"])
+        )
     assert len(results) == 3
     timer.assert_under(0.15, "Filter __in with 3 values")
 
@@ -358,13 +368,19 @@ def test_bulk_mixed_field_types(performance_timer):
                 int_field=i if i % 2 == 0 else -i,
                 float_field=i * 1.5,
                 decimal_field=Decimal(f"{i}.{i:03d}"),
-                string_field=f"string_{i}" if i % 10 != 0 else "",  # Include empty strings
+                string_field=(
+                    f"string_{i}" if i % 10 != 0 else ""
+                ),  # Include empty strings
                 bool_field=i % 2 == 0,
                 bytes_field=f"bytes{i}".encode(),
-                list_field=[i, i+1, i+2] if i % 5 != 0 else [],  # Include empty lists
-                dict_field={"id": i, "value": i*2} if i % 7 != 0 else {},  # Include empty dicts
-                set_field={i, i+1} if i % 3 != 0 else set(),
-                tuple_field=(i, i+1),
+                list_field=(
+                    [i, i + 1, i + 2] if i % 5 != 0 else []
+                ),  # Include empty lists
+                dict_field=(
+                    {"id": i, "value": i * 2} if i % 7 != 0 else {}
+                ),  # Include empty dicts
+                set_field={i, i + 1} if i % 3 != 0 else set(),
+                tuple_field=(i, i + 1),
                 date_field=date(2020 + (i % 5), 1 + (i % 12), 1 + (i % 28)),
                 datetime_field=datetime(2020, 1, 1, i % 24, i % 60, i % 60),
                 time_field=dt_time(i % 24, i % 60, i % 60),
@@ -515,6 +531,7 @@ def test_rapid_update_cycles(performance_timer):
 # EDGE CASE & ERROR TESTS
 # =============================================================================
 
+
 @pytest.mark.slow
 def test_ttl_expiration_at_scale():
     """Save 200 items with 2s TTL, verify expiration."""
@@ -651,6 +668,7 @@ def test_memory_efficiency():
     # Check object count (rough memory check)
     # This is a basic sanity check - not precise memory profiling
     import gc
+
     gc.collect()
     obj_count = len(gc.get_objects())
     # Just verify it's not absurdly high (< 1M objects)
@@ -660,6 +678,7 @@ def test_memory_efficiency():
 # =============================================================================
 # PERFORMANCE BENCHMARKING TESTS
 # =============================================================================
+
 
 @pytest.mark.slow
 @pytest.mark.benchmark
@@ -671,7 +690,9 @@ def test_benchmark_save_operations(performance_timer):
             KeyValueModel(key=f"bench{i}", value=f"value{i}").save()
 
     ops_per_sec = 1000 / timer.elapsed
-    print(f"\n  Sequential saves: {ops_per_sec:.0f} ops/sec ({timer.elapsed:.2f}s total)")
+    print(
+        f"\n  Sequential saves: {ops_per_sec:.0f} ops/sec ({timer.elapsed:.2f}s total)"
+    )
 
     assert ops_per_sec > 100, f"Save throughput too low: {ops_per_sec:.0f} ops/sec"
 
@@ -690,7 +711,9 @@ def test_benchmark_query_operations(performance_timer):
             KeyValueModel.query.get(key=f"qbench{i}")
 
     ops_per_sec = 100 / timer.elapsed
-    print(f"\n  Individual gets: {ops_per_sec:.0f} ops/sec ({timer.elapsed:.2f}s total)")
+    print(
+        f"\n  Individual gets: {ops_per_sec:.0f} ops/sec ({timer.elapsed:.2f}s total)"
+    )
 
     # Bulk query
     with performance_timer() as timer:


### PR DESCRIPTION
## Summary
- Add full Valkey compatibility to Popoto
- Update all documentation to reference Redis/Valkey
- Add CI workflow for testing against Valkey 8

## Changes
- **Documentation**: Updated README, configuration docs, and index to reference both Redis and Valkey
- **CLAUDE.md**: Added `valkey-cli` instructions for debugging
- **redis_db.py**: Added Valkey compatibility notes to module docstring
- **CI**: New GitHub Actions workflow (`test-valkey.yml`) runs full test suite against Valkey 8

## Why Valkey?
Valkey is the Linux Foundation's open-source fork of Redis (after Redis changed to a non-OSS license). Popoto uses only standard Redis commands (no modules), so it works with both out of the box.

## Test plan
- [x] All existing tests pass against Redis
- [ ] CI workflow runs tests against Valkey 8

Closes #55