### PR TITLE
Fix filter() with no arguments to return all objects

### DIFF
--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -380,7 +380,8 @@ class Query:
             {"limit", "order_by", "values"}
         )
         if not len(yet_employed_kwargs_set):
-            return set()
+            # No filter criteria - return all keys (same as all())
+            return set(self.keys())
 
         # todo: use redis.SINTER for keyfield exact match filters
 


### PR DESCRIPTION
## Summary

- `Model.query.filter()` with no arguments now returns all objects (like Django's ORM)
- Previously returned empty list, which was a bug

## Changes

One-line fix in `filter_for_keys_set()`: when no filter criteria are provided, return all keys via `self.keys()` instead of an empty set.

## Test plan

- [x] All 83 tests pass
- [x] `filter()` behavior now matches `all()` when called with no arguments

Fixes #81

🤖 Generated with [Claude Code](https://claude.ai/code)