### PR TITLE
Add chainable query builder methods

### DIFF
--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -85,6 +85,180 @@ class QueryException(Exception):
     pass
 
 
+class QueryBuilder:
+    """Chainable query builder that accumulates query state.
+
+    This class provides a fluent interface for building queries incrementally.
+    Each method returns self (or a new QueryBuilder) to enable method chaining.
+
+    The QueryBuilder is returned by Query.filter() and accumulates filter
+    parameters, ordering, and limits until execution methods like all() are called.
+
+    Example:
+        # Chainable query construction
+        results = Model.query.filter(status="active").order_by("name").limit(10).all()
+
+        # Multiple filter chaining
+        results = Model.query.filter(status="active").filter(type="premium").all()
+
+    Note:
+        QueryBuilder also acts as a list-like object for backward compatibility.
+        Iterating over a QueryBuilder or accessing len() will execute the query.
+    """
+
+    def __init__(self, query: "Query", filters: dict = None):
+        """Initialize a QueryBuilder with a reference to the parent Query.
+
+        Args:
+            query: The Query instance this builder operates on
+            filters: Initial filter parameters (optional)
+        """
+        self._query = query
+        self._filters = filters.copy() if filters else {}
+        self._limit_value = None
+        self._order_by_value = None
+        self._values_tuple = None
+
+    def filter(self, **kwargs) -> "QueryBuilder":
+        """Add filter criteria and return a new QueryBuilder.
+
+        Creates a new QueryBuilder with merged filter parameters, allowing
+        multiple filter() calls to be chained.
+
+        Args:
+            **kwargs: Filter parameters to add to the query
+
+        Returns:
+            A new QueryBuilder with the combined filters
+
+        Example:
+            query = Model.query.filter(status="active").filter(type="premium")
+        """
+        # Create a new QueryBuilder with merged filters
+        new_builder = QueryBuilder(self._query, self._filters)
+        new_builder._filters.update(kwargs)
+        new_builder._limit_value = self._limit_value
+        new_builder._order_by_value = self._order_by_value
+        new_builder._values_tuple = self._values_tuple
+        return new_builder
+
+    def limit(self, n: int) -> "QueryBuilder":
+        """Set the maximum number of results to return.
+
+        Args:
+            n: Maximum number of results
+
+        Returns:
+            Self for method chaining
+
+        Example:
+            results = Model.query.filter(status="active").limit(10).all()
+        """
+        self._limit_value = n
+        return self
+
+    def order_by(self, field: str) -> "QueryBuilder":
+        """Set the field to order results by.
+
+        Args:
+            field: Field name to sort by. Prefix with "-" for descending order.
+
+        Returns:
+            Self for method chaining
+
+        Example:
+            results = Model.query.filter(status="active").order_by("-created_at").all()
+        """
+        self._order_by_value = field
+        return self
+
+    def values(self, *fields) -> "QueryBuilder":
+        """Specify fields to return as dicts instead of model instances.
+
+        Args:
+            *fields: Field names to include in the result dicts
+
+        Returns:
+            Self for method chaining
+
+        Example:
+            results = Model.query.filter(status="active").values("name", "email").all()
+        """
+        self._values_tuple = fields
+        return self
+
+    def all(self) -> list:
+        """Execute the query and return all matching results.
+
+        Combines all accumulated filters, ordering, and limits into a single
+        query execution.
+
+        Returns:
+            List of Model instances, or list of dicts if values() was called.
+        """
+        kwargs = self._filters.copy()
+        if self._limit_value is not None:
+            kwargs["limit"] = self._limit_value
+        if self._order_by_value is not None:
+            kwargs["order_by"] = self._order_by_value
+        if self._values_tuple is not None:
+            kwargs["values"] = self._values_tuple
+        return self._query._execute_filter(**kwargs)
+
+    def count(self) -> int:
+        """Count matching results without loading objects.
+
+        Returns:
+            Integer count of matching instances
+        """
+        return self._query.count(**self._filters)
+
+    def first(self) -> "Model":
+        """Return the first matching result, or None if no matches.
+
+        Returns:
+            First Model instance or None
+        """
+        results = self.limit(1).all()
+        return results[0] if results else None
+
+    # List-like behavior for backward compatibility
+    def __iter__(self):
+        """Iterate over query results (executes query)."""
+        return iter(self.all())
+
+    def __len__(self):
+        """Return the number of results (executes query)."""
+        return len(self.all())
+
+    def __getitem__(self, index):
+        """Access results by index (executes query)."""
+        return self.all()[index]
+
+    def __bool__(self):
+        """Check if any results exist (executes query)."""
+        return len(self.all()) > 0
+
+    def __eq__(self, other):
+        """Compare with another object (executes query for comparison).
+
+        Supports comparison with lists and other QueryBuilders for backward
+        compatibility with code like: `assert Model.query.filter(...) == []`
+        """
+        if isinstance(other, list):
+            return self.all() == other
+        if isinstance(other, QueryBuilder):
+            return self.all() == other.all()
+        return NotImplemented
+
+    def __contains__(self, item):
+        """Check if item is in query results (executes query)."""
+        return item in self.all()
+
+    def __repr__(self):
+        return f"<QueryBuilder for {self._query.model_class.__name__} filters={self._filters}>"
+
+
 class Query:
     """Query interface for a Popoto Model.
 
@@ -108,6 +282,24 @@ class Query:
 
     This delegation pattern allows new field types to add query capabilities
     without modifying the Query class.
+
+    Chainable Query API:
+    -------------------
+    In addition to the original kwargs-based API, Query now supports a fluent
+    chainable interface via QueryBuilder:
+
+        # Original API (still fully supported)
+        results = Model.query.filter(status="active", limit=10, order_by="name")
+
+        # Chainable API
+        results = Model.query.filter(status="active").order_by("name").limit(10).all()
+
+        # Chain multiple filters
+        results = Model.query.filter(status="active").filter(type="premium").all()
+
+    The filter() method returns a QueryBuilder when no limit/order_by/values kwargs
+    are provided, enabling chaining. The QueryBuilder is also iterable for backward
+    compatibility with code that iterates over filter() results directly.
 
     Attributes:
         model_class: The Model subclass this Query operates on
@@ -459,13 +651,17 @@ class Query:
         # return intersection of all the db keys sets, effectively &&-ing all filters
         return set.intersection(*db_keys_sets)
 
-    def filter(self, **kwargs) -> list:
+    def filter(self, **kwargs) -> "QueryBuilder":
         """
         Query for Model instances matching the specified criteria.
 
         This is the primary query method for Popoto, providing Django-like filtering
         syntax with Redis-optimized execution. All filter parameters are AND-ed
         together; OR queries require multiple calls combined in application code.
+
+        Returns a QueryBuilder that supports method chaining. The QueryBuilder also
+        behaves like a list for backward compatibility - you can iterate over it or
+        pass it to len() and it will execute the query automatically.
 
         Filter Parameters:
         -----------------
@@ -486,26 +682,35 @@ class Query:
         - `field__lt=value` - Less than
         - `field__lte=value` - Less than or equal
 
-        Result Modifiers:
-        ----------------
+        Result Modifiers (kwargs API):
+        -----------------------------
         - `order_by="field"` - Sort ascending by field
         - `order_by="-field"` - Sort descending by field
         - `limit=N` - Return at most N results
         - `values=("field1", "field2")` - Return dicts with only specified fields
           instead of full Model instances (projection query, more efficient)
 
+        Chainable Methods:
+        -----------------
+        - `.filter(**kwargs)` - Add more filter criteria
+        - `.order_by("field")` - Sort results (prefix with "-" for descending)
+        - `.limit(n)` - Limit number of results
+        - `.values("field1", "field2")` - Return dicts instead of objects
+        - `.all()` - Execute and return results
+        - `.first()` - Execute and return first result or None
+        - `.count()` - Count matching results without loading objects
+
         Args:
             **kwargs: Filter parameters and result modifiers as described above.
 
         Returns:
-            List of Model instances matching all criteria, or list of dicts if
-            `values` is specified. Empty list if no matches.
+            QueryBuilder that can be chained or iterated directly.
 
         Raises:
             QueryException: If unknown filter parameters are provided.
 
         Example:
-            # Find active premium users created this year
+            # Original kwargs API (still fully supported)
             users = User.query.filter(
                 status="active",
                 tier="premium",
@@ -514,11 +719,42 @@ class Query:
                 limit=50
             )
 
+            # Chainable API
+            users = User.query.filter(status="active").order_by("-created_at").limit(50).all()
+
+            # Chain multiple filters
+            users = User.query.filter(status="active").filter(tier="premium").all()
+
             # Efficient projection - only load specific fields
-            emails = User.query.filter(
-                status="active",
-                values=("email", "name")
-            )  # Returns [{"email": "...", "name": "..."}, ...]
+            emails = User.query.filter(status="active").values("email", "name").all()
+        """
+        # Extract result modifiers from kwargs for the QueryBuilder
+        filters = {
+            k: v for k, v in kwargs.items() if k not in {"limit", "order_by", "values"}
+        }
+        builder = QueryBuilder(self, filters)
+
+        # Apply result modifiers if provided in kwargs (for backward compatibility)
+        if "limit" in kwargs:
+            builder._limit_value = kwargs["limit"]
+        if "order_by" in kwargs:
+            builder._order_by_value = kwargs["order_by"]
+        if "values" in kwargs:
+            builder._values_tuple = kwargs["values"]
+
+        return builder
+
+    def _execute_filter(self, **kwargs) -> list:
+        """Internal method to execute filter logic and return results.
+
+        This is the actual filter execution, called by QueryBuilder.all() and
+        the backward-compatible list operations on QueryBuilder.
+
+        Args:
+            **kwargs: Filter parameters and result modifiers
+
+        Returns:
+            List of Model instances or dicts
         """
         # Reset geo distances for this query
         self._geo_distances = {}

--- a/tests/test_chainable_queries.py
+++ b/tests/test_chainable_queries.py
@@ -1,0 +1,251 @@
+"""
+Tests for the chainable query builder interface (Issue #91).
+
+This tests the fluent API for building queries:
+    Model.query.filter(status="active").order_by("name").limit(10).all()
+
+And ensures backward compatibility with the existing kwargs API:
+    Model.query.filter(status="active", order_by="name", limit=10)
+"""
+
+import sys
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+from src.popoto.redis_db import POPOTO_REDIS_DB
+from src import popoto
+from src.popoto.models.query import QueryBuilder
+
+
+# Test Model
+class ChainTestModel(popoto.Model):
+    name = popoto.KeyField()
+    status = popoto.KeyField()
+    priority = popoto.Field(type=int, default=0)
+
+
+# Clean up before tests
+for item in ChainTestModel.query.all():
+    item.delete()
+
+
+# Create test data
+item1 = ChainTestModel.create(name="alpha", status="active", priority=1)
+item2 = ChainTestModel.create(name="beta", status="active", priority=2)
+item3 = ChainTestModel.create(name="gamma", status="inactive", priority=3)
+item4 = ChainTestModel.create(name="delta", status="active", priority=4)
+
+
+# =============================================================================
+# Test 1: Basic backward compatibility - kwargs API still works
+# =============================================================================
+print("Test 1: Backward compatibility with kwargs API")
+
+# Original kwargs API should still work
+results = ChainTestModel.query.filter(status="active", limit=2)
+# QueryBuilder behaves like a list - can iterate, get length, etc.
+assert len(results) == 2, f"Expected 2 results, got {len(results)}"
+
+# Filter with order_by as kwarg
+results = ChainTestModel.query.filter(status="active", order_by="name", limit=10)
+names = [r.name for r in results]
+assert names == sorted(names), f"Expected sorted names, got {names}"
+
+print("  PASSED: kwargs API works correctly")
+
+
+# =============================================================================
+# Test 2: QueryBuilder is returned from filter()
+# =============================================================================
+print("Test 2: filter() returns QueryBuilder")
+
+result = ChainTestModel.query.filter(status="active")
+assert isinstance(result, QueryBuilder), f"Expected QueryBuilder, got {type(result)}"
+
+print("  PASSED: filter() returns QueryBuilder")
+
+
+# =============================================================================
+# Test 3: Basic chaining - filter().limit().all()
+# =============================================================================
+print("Test 3: Basic chaining - filter().limit().all()")
+
+results = ChainTestModel.query.filter(status="active").limit(2).all()
+assert isinstance(results, list), f"Expected list, got {type(results)}"
+assert len(results) == 2, f"Expected 2 results, got {len(results)}"
+
+print("  PASSED: filter().limit().all() works")
+
+
+# =============================================================================
+# Test 4: Order by chaining
+# =============================================================================
+print("Test 4: order_by chaining")
+
+results = ChainTestModel.query.filter(status="active").order_by("name").all()
+names = [r.name for r in results]
+assert names == sorted(names), f"Expected ascending sort, got {names}"
+
+# Descending order
+results = ChainTestModel.query.filter(status="active").order_by("-name").all()
+names = [r.name for r in results]
+assert names == sorted(names, reverse=True), f"Expected descending sort, got {names}"
+
+print("  PASSED: order_by chaining works")
+
+
+# =============================================================================
+# Test 5: Chain multiple filters
+# =============================================================================
+print("Test 5: Chain multiple filter() calls")
+
+# This should return only items that are both active AND have name="alpha"
+results = ChainTestModel.query.filter(status="active").filter(name="alpha").all()
+assert len(results) == 1, f"Expected 1 result, got {len(results)}"
+assert results[0].name == "alpha", f"Expected alpha, got {results[0].name}"
+
+print("  PASSED: Multiple filter() calls chain correctly")
+
+
+# =============================================================================
+# Test 6: Full chain - filter().filter().order_by().limit().all()
+# =============================================================================
+print("Test 6: Full chaining - filter().filter().order_by().limit().all()")
+
+results = ChainTestModel.query.filter(status="active").order_by("name").limit(2).all()
+assert len(results) == 2, f"Expected 2 results, got {len(results)}"
+names = [r.name for r in results]
+assert names == sorted(names), f"Expected sorted names, got {names}"
+
+print("  PASSED: Full chaining works")
+
+
+# =============================================================================
+# Test 7: QueryBuilder is iterable (backward compatibility)
+# =============================================================================
+print("Test 7: QueryBuilder iteration (backward compatibility)")
+
+query = ChainTestModel.query.filter(status="active")
+items_from_iteration = []
+for item in query:
+    items_from_iteration.append(item)
+
+assert (
+    len(items_from_iteration) == 3
+), f"Expected 3 items, got {len(items_from_iteration)}"
+
+print("  PASSED: QueryBuilder iteration works")
+
+
+# =============================================================================
+# Test 8: QueryBuilder indexing (backward compatibility)
+# =============================================================================
+print("Test 8: QueryBuilder indexing (backward compatibility)")
+
+query = ChainTestModel.query.filter(status="active").order_by("name")
+first_item = query[0]
+assert first_item.name == "alpha", f"Expected alpha as first, got {first_item.name}"
+
+print("  PASSED: QueryBuilder indexing works")
+
+
+# =============================================================================
+# Test 9: values() chaining
+# =============================================================================
+print("Test 9: values() chaining")
+
+results = ChainTestModel.query.filter(status="active").values("name", "status").all()
+assert isinstance(results[0], dict), f"Expected dict, got {type(results[0])}"
+assert "name" in results[0], "Expected 'name' in result dict"
+assert "status" in results[0], "Expected 'status' in result dict"
+
+print("  PASSED: values() chaining works")
+
+
+# =============================================================================
+# Test 10: count() on QueryBuilder
+# =============================================================================
+print("Test 10: count() on QueryBuilder")
+
+count = ChainTestModel.query.filter(status="active").count()
+assert count == 3, f"Expected 3, got {count}"
+
+print("  PASSED: count() on QueryBuilder works")
+
+
+# =============================================================================
+# Test 11: first() method
+# =============================================================================
+print("Test 11: first() method")
+
+result = ChainTestModel.query.filter(status="active").order_by("name").first()
+assert result is not None, "Expected a result, got None"
+assert result.name == "alpha", f"Expected alpha, got {result.name}"
+
+# first() on empty result
+empty_result = ChainTestModel.query.filter(status="nonexistent").first()
+assert empty_result is None, f"Expected None, got {empty_result}"
+
+print("  PASSED: first() method works")
+
+
+# =============================================================================
+# Test 12: Boolean evaluation of QueryBuilder
+# =============================================================================
+print("Test 12: Boolean evaluation of QueryBuilder")
+
+query_with_results = ChainTestModel.query.filter(status="active")
+query_without_results = ChainTestModel.query.filter(status="nonexistent")
+
+assert bool(query_with_results) is True, "Expected True for query with results"
+assert bool(query_without_results) is False, "Expected False for query without results"
+
+print("  PASSED: Boolean evaluation works")
+
+
+# =============================================================================
+# Test 13: Immutability - filter() returns new QueryBuilder
+# =============================================================================
+print("Test 13: Immutability - filter() returns new QueryBuilder")
+
+query1 = ChainTestModel.query.filter(status="active")
+query2 = query1.filter(name="alpha")
+
+# query1 should not be affected by query2's additional filter
+assert (
+    len(query1.all()) == 3
+), f"Expected 3 results from query1, got {len(query1.all())}"
+assert len(query2.all()) == 1, f"Expected 1 result from query2, got {len(query2.all())}"
+
+print("  PASSED: filter() returns new QueryBuilder (immutable)")
+
+
+# =============================================================================
+# Test 14: QueryBuilder repr
+# =============================================================================
+print("Test 14: QueryBuilder __repr__")
+
+query = ChainTestModel.query.filter(status="active")
+repr_str = repr(query)
+assert "QueryBuilder" in repr_str, f"Expected 'QueryBuilder' in repr, got {repr_str}"
+assert (
+    "ChainTestModel" in repr_str
+), f"Expected 'ChainTestModel' in repr, got {repr_str}"
+
+print("  PASSED: QueryBuilder __repr__ works")
+
+
+# =============================================================================
+# Cleanup
+# =============================================================================
+print("\nCleaning up test data...")
+for item in ChainTestModel.query.all():
+    item.delete()
+
+assert ChainTestModel.query.count() == 0, "Cleanup failed"
+
+print("\n" + "=" * 60)
+print("ALL CHAINABLE QUERY TESTS PASSED!")
+print("=" * 60)


### PR DESCRIPTION
## Summary
- Adds fluent/chainable query construction alongside current kwargs API
- `Model.query.filter(status="active").order_by("name").limit(10).all()`
- Supports chaining multiple `filter()` calls to combine criteria
- New `QueryBuilder` class accumulates state until execution
- Full backward compatibility - existing code works unchanged

## New Chainable Methods
- `.filter(**kwargs)` - Add filter criteria (can be chained multiple times)
- `.order_by("field")` - Sort results (prefix with "-" for descending)
- `.limit(n)` - Limit number of results
- `.values("field1", "field2")` - Return dicts instead of model instances
- `.all()` - Execute and return results as list
- `.first()` - Execute and return first result or None
- `.count()` - Count matching results without loading objects

## Backward Compatibility
The `QueryBuilder` returned by `filter()` implements list-like behavior:
- Iteration: `for item in Model.query.filter(status="active"):`
- Length: `len(Model.query.filter(status="active"))`
- Indexing: `Model.query.filter(status="active")[0]`
- Equality: `Model.query.filter(status="active") == []`
- Containment: `item in Model.query.filter(status="active")`

## Test plan
- [x] Run `python tests/test_chainable_queries.py` - all 14 tests pass
- [x] Run `python tests/test_queries.py` - existing tests still pass
- [x] Run `pytest tests/` - all 83 tests pass

Closes #91