### PR TITLE
Add OR query support with Q objects

### DIFF
--- a/src/popoto/__init__.py
+++ b/src/popoto/__init__.py
@@ -27,6 +27,7 @@ except ImportError:
 from .fields.datetime_field import DatetimeField
 from .fields.relationship import Relationship
 from .models.base import Model, ModelBase
+from .models.q import Q
 from .pubsub.publisher import Publisher
 from .pubsub.subscriber import Subscriber
 
@@ -55,6 +56,7 @@ __all__ = [
     "Relationship",
     "Model",
     "ModelBase",
+    "Q",
     "Publisher",
     "Subscriber",
 ]

--- a/src/popoto/models/__init__.py
+++ b/src/popoto/models/__init__.py
@@ -1,0 +1,3 @@
+from .q import Q
+
+__all__ = ["Q"]

--- a/src/popoto/models/q.py
+++ b/src/popoto/models/q.py
@@ -1,0 +1,245 @@
+"""
+Q Objects for Complex Query Expressions.
+
+This module provides Django-style Q objects that enable complex query logic
+with OR, AND, and NOT operators. Q objects can be combined using Python
+operators to build expressive filter expressions.
+
+Usage Examples:
+--------------
+    from popoto import Q
+
+    # OR logic - find active OR premium users
+    users = User.query.filter(Q(status="active") | Q(type="premium"))
+
+    # AND logic (explicit) - same as passing multiple kwargs
+    users = User.query.filter(Q(status="active") & Q(rating__gt=4.0))
+
+    # Complex combinations - active OR premium, with high rating
+    users = User.query.filter(
+        (Q(status="active") | Q(type="premium")) & Q(rating__gt=3.0)
+    )
+
+    # Negation - find users who are NOT inactive
+    users = User.query.filter(~Q(status="inactive"))
+
+Design Notes:
+------------
+Q objects build an expression tree that is evaluated at query time. Each Q
+object can be either:
+
+1. A leaf node containing filter kwargs (e.g., Q(status="active"))
+2. An internal node combining child Q objects with AND/OR connectors
+
+The Query class evaluates Q expressions by recursively computing result sets:
+- AND: set intersection of children's results
+- OR: set union of children's results
+- NOT: set difference from all keys
+
+This approach leverages Redis's efficient set operations while providing
+a familiar Django-like query interface.
+"""
+
+
+class Q:
+    """Django-style Q object for complex query expressions.
+
+    Q objects enable OR logic and complex query combinations that aren't
+    possible with simple kwargs. They can be combined using Python operators:
+
+    - ``|`` (OR): Union of results
+    - ``&`` (AND): Intersection of results
+    - ``~`` (NOT): Negation (exclusion from all results)
+
+    Attributes:
+        filters: Dict of filter kwargs for leaf nodes
+        connector: 'AND' or 'OR' for combined Q objects
+        children: List of child Q objects for combined expressions
+        negated: Whether this Q object is negated
+
+    Example:
+        # Basic Q object
+        q = Q(status="active")
+
+        # Combined with OR
+        q = Q(status="active") | Q(type="premium")
+
+        # Negated
+        q = ~Q(status="inactive")
+
+        # Complex expression
+        q = (Q(status="active") | Q(type="premium")) & ~Q(rating__lt=2.0)
+    """
+
+    AND = "AND"
+    OR = "OR"
+
+    def __init__(self, **kwargs):
+        """Create a Q object with filter kwargs.
+
+        Args:
+            **kwargs: Filter parameters matching those supported by
+                     Model.query.filter(). These become the leaf-level
+                     filter criteria.
+
+        Example:
+            Q(status="active")
+            Q(price__gte=10.0, price__lte=100.0)
+            Q(category__in=["electronics", "books"])
+        """
+        self.filters = kwargs
+        self.connector = self.AND
+        self.children = []
+        self.negated = False
+
+    def __or__(self, other):
+        """Combine two Q objects with OR logic.
+
+        Creates a new Q object that matches if EITHER operand matches.
+        The result is evaluated as a set union of matching keys.
+
+        Args:
+            other: Another Q object to OR with this one
+
+        Returns:
+            A new Q object representing (self OR other)
+
+        Example:
+            q = Q(status="active") | Q(type="premium")
+        """
+        if not isinstance(other, Q):
+            raise TypeError(f"Cannot OR Q object with {type(other).__name__}")
+        combined = Q()
+        combined.connector = self.OR
+        combined.children = [self, other]
+        return combined
+
+    def __and__(self, other):
+        """Combine two Q objects with AND logic.
+
+        Creates a new Q object that matches only if BOTH operands match.
+        The result is evaluated as a set intersection of matching keys.
+
+        Args:
+            other: Another Q object to AND with this one
+
+        Returns:
+            A new Q object representing (self AND other)
+
+        Example:
+            q = Q(status="active") & Q(rating__gt=4.0)
+        """
+        if not isinstance(other, Q):
+            raise TypeError(f"Cannot AND Q object with {type(other).__name__}")
+        combined = Q()
+        combined.connector = self.AND
+        combined.children = [self, other]
+        return combined
+
+    def __invert__(self):
+        """Negate a Q object.
+
+        Creates a new Q object that matches everything EXCEPT what this
+        Q object matches. The result is evaluated as a set difference
+        from all model keys.
+
+        Returns:
+            A new Q object representing NOT(self)
+
+        Example:
+            q = ~Q(status="inactive")  # Matches everything except inactive
+        """
+        negated = Q()
+        negated.filters = self.filters.copy()
+        negated.connector = self.connector
+        negated.children = self.children.copy()
+        negated.negated = not self.negated
+        return negated
+
+    def __repr__(self):
+        """Return a string representation of this Q object for debugging."""
+        if self.children:
+            connector_str = f" {self.connector} "
+            children_repr = connector_str.join(repr(c) for c in self.children)
+            result = f"({children_repr})"
+        else:
+            filters_str = ", ".join(f"{k}={v!r}" for k, v in self.filters.items())
+            result = f"Q({filters_str})"
+
+        if self.negated:
+            result = f"~{result}"
+        return result
+
+    def is_leaf(self):
+        """Check if this Q object is a leaf node (has filters, no children).
+
+        Returns:
+            True if this Q object has filter kwargs and no children.
+        """
+        return bool(self.filters) and not self.children
+
+    def is_empty(self):
+        """Check if this Q object has no filters and no children.
+
+        Returns:
+            True if this Q object is effectively a no-op.
+        """
+        return not self.filters and not self.children
+
+
+def evaluate_q(query_instance, q_obj, all_keys=None):
+    """Evaluate a Q object expression tree and return matching Redis keys.
+
+    This function recursively evaluates Q object trees, computing result
+    sets at each level using set operations:
+
+    - Leaf nodes: Execute filter query and return matching keys
+    - AND nodes: Return intersection of children's results
+    - OR nodes: Return union of children's results
+    - Negated nodes: Return difference from all_keys
+
+    Args:
+        query_instance: The Query instance to execute filters against
+        q_obj: The Q object to evaluate
+        all_keys: Set of all Redis keys for the model (used for negation).
+                 If None, will be fetched when needed for NOT operations.
+
+    Returns:
+        Set of Redis keys matching the Q expression.
+
+    Note:
+        This function is called internally by Query.filter() when Q objects
+        are passed as arguments. Users should not need to call it directly.
+    """
+    if q_obj.is_empty():
+        # Empty Q() matches everything
+        if all_keys is None:
+            all_keys = set(query_instance.keys())
+        return all_keys
+
+    if q_obj.is_leaf():
+        # Leaf node - execute the filter
+        result = query_instance.filter_for_keys_set(**q_obj.filters)
+    elif q_obj.children:
+        # Internal node - combine children
+        child_results = [
+            evaluate_q(query_instance, child, all_keys) for child in q_obj.children
+        ]
+
+        if q_obj.connector == Q.AND:
+            result = set.intersection(*child_results) if child_results else set()
+        else:  # OR
+            result = set.union(*child_results) if child_results else set()
+    else:
+        # Empty filters, no children - return all keys
+        if all_keys is None:
+            all_keys = set(query_instance.keys())
+        result = all_keys
+
+    # Apply negation if needed
+    if q_obj.negated:
+        if all_keys is None:
+            all_keys = set(query_instance.keys())
+        result = all_keys - result
+
+    return result

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -459,13 +459,66 @@ class Query:
         # return intersection of all the db keys sets, effectively &&-ing all filters
         return set.intersection(*db_keys_sets)
 
-    def filter(self, **kwargs) -> list:
+    def _evaluate_filter_args(self, args, kwargs) -> set:
+        """Evaluate filter arguments including Q objects and return matching keys.
+
+        This method handles both traditional kwargs filtering and Q object
+        expressions. When Q objects are present, they are combined with any
+        kwargs using AND logic.
+
+        Args:
+            args: Tuple of Q objects passed as positional arguments
+            kwargs: Dict of filter parameters and result modifiers
+
+        Returns:
+            Set of Redis keys matching all filter criteria.
+
+        Processing Logic:
+        ----------------
+        1. If no Q objects in args, delegate to filter_for_keys_set()
+        2. If Q objects present:
+           a. Evaluate each Q object to get its result set
+           b. If kwargs filters exist, evaluate them too
+           c. Intersect all result sets (AND logic between args)
+        """
+        from .q import Q, evaluate_q
+
+        # Extract result modifiers from kwargs
+        filter_kwargs = {
+            k: v for k, v in kwargs.items() if k not in {"limit", "order_by", "values"}
+        }
+
+        # Check for Q objects in args
+        q_objects = [arg for arg in args if isinstance(arg, Q)]
+
+        if not q_objects:
+            # No Q objects - use traditional filtering
+            return self.filter_for_keys_set(**kwargs)
+
+        # Evaluate Q objects
+        result_sets = []
+        all_keys = None  # Lazy-loaded for negation operations
+
+        for q_obj in q_objects:
+            result_sets.append(evaluate_q(self, q_obj, all_keys))
+
+        # If there are also kwargs filters, include them
+        if filter_kwargs:
+            kwargs_result = self.filter_for_keys_set(**kwargs)
+            result_sets.append(kwargs_result)
+
+        # Intersect all result sets (AND logic between multiple Q args and kwargs)
+        if not result_sets:
+            return set()
+        return set.intersection(*result_sets) if result_sets else set()
+
+    def filter(self, *args, **kwargs) -> list:
         """
         Query for Model instances matching the specified criteria.
 
         This is the primary query method for Popoto, providing Django-like filtering
         syntax with Redis-optimized execution. All filter parameters are AND-ed
-        together; OR queries require multiple calls combined in application code.
+        together by default. Use Q objects for OR logic and complex combinations.
 
         Filter Parameters:
         -----------------
@@ -486,6 +539,12 @@ class Query:
         - `field__lt=value` - Less than
         - `field__lte=value` - Less than or equal
 
+        **Q Objects (for complex logic):**
+        - `Q(field=value)` - Basic Q object (equivalent to kwargs)
+        - `Q(...) | Q(...)` - OR logic (union of results)
+        - `Q(...) & Q(...)` - AND logic (intersection of results)
+        - `~Q(...)` - NOT logic (exclusion)
+
         Result Modifiers:
         ----------------
         - `order_by="field"` - Sort ascending by field
@@ -495,6 +554,7 @@ class Query:
           instead of full Model instances (projection query, more efficient)
 
         Args:
+            *args: Q objects for complex query expressions
             **kwargs: Filter parameters and result modifiers as described above.
 
         Returns:
@@ -519,12 +579,20 @@ class Query:
                 status="active",
                 values=("email", "name")
             )  # Returns [{"email": "...", "name": "..."}, ...]
+
+            # OR logic with Q objects
+            users = User.query.filter(Q(status="active") | Q(type="premium"))
+
+            # Complex combinations
+            users = User.query.filter(
+                (Q(status="active") | Q(type="premium")) & Q(rating__gt=3.0)
+            )
         """
         # Reset geo distances for this query
         self._geo_distances = {}
         self._geo_distance_unit = None
 
-        db_keys_set = self.filter_for_keys_set(**kwargs)
+        db_keys_set = self._evaluate_filter_args(args, kwargs)
         if not len(db_keys_set):
             return []
 

--- a/tests/test_q_objects.py
+++ b/tests/test_q_objects.py
@@ -1,0 +1,344 @@
+"""
+Tests for Q objects and complex query expressions.
+
+Tests cover:
+- Basic Q object (equivalent to kwargs)
+- OR with two Q objects
+- AND with two Q objects
+- Complex nested expressions
+- Negation (~Q)
+- Mixed Q objects and kwargs
+"""
+
+import sys
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+import pytest
+from src.popoto import Model, KeyField, SortedField, Q
+from src.popoto.redis_db import POPOTO_REDIS_DB
+
+
+class Product(Model):
+    """Test model for Q object queries."""
+
+    sku = KeyField(type=str)
+    category = KeyField(type=str)
+    status = KeyField(type=str)
+    price = SortedField(type=float)
+    rating = SortedField(type=float)
+
+
+@pytest.fixture(autouse=True)
+def setup_and_teardown():
+    """Set up test data and clean up after each test."""
+    # Clean up any existing test data
+    for product in Product.query.all():
+        product.delete()
+
+    # Create test products
+    Product.create(
+        sku="LAPTOP001",
+        category="electronics",
+        status="active",
+        price=999.99,
+        rating=4.5,
+    )
+    Product.create(
+        sku="PHONE001",
+        category="electronics",
+        status="active",
+        price=599.99,
+        rating=4.8,
+    )
+    Product.create(
+        sku="BOOK001",
+        category="books",
+        status="active",
+        price=29.99,
+        rating=4.2,
+    )
+    Product.create(
+        sku="BOOK002",
+        category="books",
+        status="discontinued",
+        price=19.99,
+        rating=3.5,
+    )
+    Product.create(
+        sku="SHIRT001",
+        category="clothing",
+        status="active",
+        price=49.99,
+        rating=4.0,
+    )
+    Product.create(
+        sku="PANTS001",
+        category="clothing",
+        status="discontinued",
+        price=79.99,
+        rating=2.5,
+    )
+
+    yield
+
+    # Clean up after test
+    for product in Product.query.all():
+        product.delete()
+
+
+class TestBasicQObject:
+    """Tests for basic Q object functionality."""
+
+    def test_basic_q_object_single_filter(self):
+        """Q object with single filter should work like kwargs."""
+        # Using Q object
+        results_q = Product.query.filter(Q(category="electronics"))
+        # Using kwargs
+        results_kwargs = Product.query.filter(category="electronics")
+
+        assert len(results_q) == len(results_kwargs) == 2
+        assert set(p.sku for p in results_q) == set(p.sku for p in results_kwargs)
+
+    def test_basic_q_object_multiple_filters(self):
+        """Q object with multiple filters should AND them together."""
+        results = Product.query.filter(Q(category="electronics", status="active"))
+        assert len(results) == 2
+        for product in results:
+            assert product.category == "electronics"
+            assert product.status == "active"
+
+    def test_empty_q_object_returns_all(self):
+        """Empty Q() should return all objects."""
+        results = Product.query.filter(Q())
+        assert len(results) == 6
+
+
+class TestOrLogic:
+    """Tests for OR logic using Q objects."""
+
+    def test_or_two_q_objects(self):
+        """OR of two Q objects should return union of results."""
+        results = Product.query.filter(Q(category="electronics") | Q(category="books"))
+        assert len(results) == 4
+
+        categories = {p.category for p in results}
+        assert categories == {"electronics", "books"}
+
+    def test_or_with_different_fields(self):
+        """OR should work with different fields."""
+        results = Product.query.filter(
+            Q(category="electronics") | Q(status="discontinued")
+        )
+
+        # Should include: electronics (2) + discontinued (2) - overlap (0) = 4
+        assert len(results) == 4
+
+    def test_or_with_range_filter(self):
+        """OR should work with SortedField range filters."""
+        # High rating OR low price
+        results = Product.query.filter(Q(rating__gte=4.5) | Q(price__lte=30.0))
+
+        # rating >= 4.5: LAPTOP001 (4.5), PHONE001 (4.8) = 2
+        # price <= 30.0: BOOK001 (29.99), BOOK002 (19.99) = 2
+        # No overlap
+        assert len(results) == 4
+
+    def test_multiple_or_chain(self):
+        """Multiple OR operations should chain correctly."""
+        results = Product.query.filter(
+            Q(category="electronics") | Q(category="books") | Q(category="clothing")
+        )
+        assert len(results) == 6
+
+
+class TestAndLogic:
+    """Tests for explicit AND logic using Q objects."""
+
+    def test_and_two_q_objects(self):
+        """AND of two Q objects should return intersection."""
+        results = Product.query.filter(Q(category="books") & Q(status="active"))
+        assert len(results) == 1
+        assert results[0].sku == "BOOK001"
+
+    def test_and_with_range_filters(self):
+        """AND should work with SortedField range filters."""
+        results = Product.query.filter(Q(price__gte=50.0) & Q(rating__gte=4.0))
+
+        # price >= 50: LAPTOP001, PHONE001, PANTS001, SHIRT001 (no, price=49.99)
+        # Actually SHIRT001 is 49.99, so: LAPTOP001, PHONE001, PANTS001
+        # rating >= 4.0: LAPTOP001, PHONE001, BOOK001, SHIRT001
+        # Intersection: LAPTOP001, PHONE001
+        assert len(results) == 2
+        skus = {p.sku for p in results}
+        assert skus == {"LAPTOP001", "PHONE001"}
+
+
+class TestComplexExpressions:
+    """Tests for complex nested Q expressions."""
+
+    def test_or_then_and(self):
+        """(A | B) & C should work correctly."""
+        # (electronics OR books) AND active
+        results = Product.query.filter(
+            (Q(category="electronics") | Q(category="books")) & Q(status="active")
+        )
+
+        # electronics active: LAPTOP001, PHONE001
+        # books active: BOOK001
+        assert len(results) == 3
+
+    def test_and_then_or(self):
+        """(A & B) | C should work correctly."""
+        # (books AND active) OR discontinued
+        results = Product.query.filter(
+            (Q(category="books") & Q(status="active")) | Q(status="discontinued")
+        )
+
+        # books AND active: BOOK001
+        # discontinued: BOOK002, PANTS001
+        # Union: BOOK001, BOOK002, PANTS001
+        assert len(results) == 3
+
+    def test_deeply_nested(self):
+        """Deeply nested expressions should work."""
+        # ((electronics OR books) AND active) OR (clothing AND discontinued)
+        results = Product.query.filter(
+            ((Q(category="electronics") | Q(category="books")) & Q(status="active"))
+            | (Q(category="clothing") & Q(status="discontinued"))
+        )
+
+        # (electronics OR books) AND active: LAPTOP001, PHONE001, BOOK001
+        # clothing AND discontinued: PANTS001
+        assert len(results) == 4
+
+
+class TestNegation:
+    """Tests for NOT logic using ~Q."""
+
+    def test_simple_negation(self):
+        """~Q should return everything except matches."""
+        results = Product.query.filter(~Q(status="discontinued"))
+
+        # All active products
+        assert len(results) == 4
+        for product in results:
+            assert product.status != "discontinued"
+
+    def test_negation_with_or(self):
+        """~Q combined with OR should work."""
+        # NOT electronics OR books
+        results = Product.query.filter(~Q(category="electronics") | Q(category="books"))
+
+        # NOT electronics: books (2), clothing (2) = 4
+        # books: 2 (already included above)
+        # Union: all non-electronics = 4
+        assert len(results) == 4
+
+    def test_negation_with_and(self):
+        """~Q combined with AND should work."""
+        # NOT discontinued AND high rating
+        results = Product.query.filter(~Q(status="discontinued") & Q(rating__gte=4.0))
+
+        # NOT discontinued: LAPTOP001, PHONE001, BOOK001, SHIRT001
+        # rating >= 4.0: LAPTOP001, PHONE001, BOOK001, SHIRT001
+        # Intersection: LAPTOP001, PHONE001, BOOK001, SHIRT001
+        assert len(results) == 4
+
+    def test_double_negation(self):
+        """~~Q should be equivalent to Q."""
+        results_double_neg = Product.query.filter(~~Q(category="electronics"))
+        results_positive = Product.query.filter(Q(category="electronics"))
+
+        assert len(results_double_neg) == len(results_positive)
+        assert set(p.sku for p in results_double_neg) == set(
+            p.sku for p in results_positive
+        )
+
+
+class TestMixedQAndKwargs:
+    """Tests for mixing Q objects with kwargs."""
+
+    def test_q_and_kwargs(self):
+        """Q object combined with kwargs should AND them."""
+        results = Product.query.filter(Q(category="electronics"), status="active")
+
+        assert len(results) == 2
+        for product in results:
+            assert product.category == "electronics"
+            assert product.status == "active"
+
+    def test_multiple_q_and_kwargs(self):
+        """Multiple Q objects with kwargs should all be ANDed."""
+        results = Product.query.filter(
+            Q(category="books") | Q(category="electronics"), status="active"
+        )
+
+        # (books OR electronics) AND active
+        assert len(results) == 3
+
+    def test_q_with_result_modifiers(self):
+        """Q objects should work with limit and order_by."""
+        results = Product.query.filter(Q(status="active"), order_by="-price", limit=2)
+
+        assert len(results) == 2
+        assert results[0].price >= results[1].price
+
+    def test_q_with_values(self):
+        """Q objects should work with values projection."""
+        results = Product.query.filter(
+            Q(category="electronics"), values=("sku", "price")
+        )
+
+        assert len(results) == 2
+        assert all(isinstance(r, dict) for r in results)
+        assert all("sku" in r and "price" in r for r in results)
+
+
+class TestQObjectRepr:
+    """Tests for Q object string representation."""
+
+    def test_simple_repr(self):
+        """Simple Q object should have readable repr."""
+        q = Q(status="active")
+        assert "status" in repr(q)
+        assert "active" in repr(q)
+
+    def test_or_repr(self):
+        """OR expression should show OR in repr."""
+        q = Q(status="active") | Q(category="books")
+        assert "OR" in repr(q)
+
+    def test_and_repr(self):
+        """AND expression should show AND in repr."""
+        q = Q(status="active") & Q(category="books")
+        assert "AND" in repr(q)
+
+    def test_negated_repr(self):
+        """Negated Q should show ~ in repr."""
+        q = ~Q(status="discontinued")
+        assert "~" in repr(q)
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_q_with_no_results(self):
+        """Q that matches nothing should return empty list."""
+        results = Product.query.filter(Q(category="nonexistent"))
+        assert results == []
+
+    def test_complex_q_with_no_results(self):
+        """Complex Q that matches nothing should return empty list."""
+        results = Product.query.filter(Q(category="nonexistent") & Q(status="active"))
+        assert results == []
+
+    def test_q_type_error(self):
+        """Q combined with non-Q should raise TypeError."""
+        with pytest.raises(TypeError):
+            Q(status="active") | "not a Q object"
+
+        with pytest.raises(TypeError):
+            Q(status="active") & 123


### PR DESCRIPTION
## Summary
- Adds Django-style Q objects for complex query logic
- Supports `|` (OR), `&` (AND), and `~` (NOT) operators
- Enables complex query combinations like:
  ```python
  from popoto import Q
  
  # OR logic
  Model.query.filter(Q(status="active") | Q(type="premium"))
  
  # Complex combinations
  Model.query.filter((Q(status="active") | Q(type="premium")) & Q(rating__gt=3.0))
  
  # Negation
  Model.query.filter(~Q(status="inactive"))
  ```

## Changes
- New `src/popoto/models/q.py` with Q class and evaluate_q function
- Modified `Query.filter()` to accept Q objects as positional arguments
- Exported Q from package __init__.py
- 27 new tests covering basic Q objects, OR/AND logic, complex expressions, negation, and edge cases

## Test plan
- [x] All 110 existing tests pass
- [x] 27 new Q object tests pass
- [x] Basic Q object works like kwargs
- [x] OR with two Q objects returns union
- [x] AND with two Q objects returns intersection
- [x] Complex nested expressions work
- [x] Negation (~Q) works
- [x] Mixed Q objects and kwargs work
- [x] Q objects work with result modifiers (order_by, limit, values)

Closes #92