### PR TITLE
Add sortable ID strategies to AutoKeyField (ULID/KSUID)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dataframe = [
     "numpy>=1.23.1",
     "msgpack-numpy>=0.4.8",
 ]
+ulid = ["ulid-py>=1.1.0"]
+ksuid = ["cyksuid>=1.0.0"]
 dev = [
     "pytest>=7.1.2",
     "pytest-asyncio>=0.21.0",

--- a/src/popoto/fields/auto_field_mixin.py
+++ b/src/popoto/fields/auto_field_mixin.py
@@ -1,7 +1,7 @@
 """
 Auto Field Mixin for Popoto Redis ORM.
 
-This module provides automatic UUID-based key generation for models that need
+This module provides automatic ID generation for models that need
 guaranteed uniqueness without requiring the developer to manage identifiers.
 
 Design Philosophy:
@@ -16,6 +16,20 @@ without requiring coordination (unlike auto-increment, which needs a central
 counter). This makes it ideal for distributed systems and eliminates a
 potential Redis bottleneck.
 
+ID Generation Strategies:
+-------------------------
+AutoFieldMixin supports multiple ID generation strategies:
+
+- uuid4 (default): Random UUID4 hex string, 32 characters. Not time-sortable
+  but provides excellent uniqueness without dependencies.
+
+- ulid: Universally Unique Lexicographically Sortable Identifier, 26 characters.
+  Time-sortable, making it ideal for chronological ordering. Requires the
+  ulid-py package: pip install ulid-py
+
+- ksuid: K-Sortable Unique Identifier, 27 characters. Similar to ULID but with
+  a different encoding. Requires the cyksuid package: pip install cyksuid
+
 Integration with Popoto's Field System:
 ---------------------------------------
 AutoFieldMixin is designed for multiple inheritance with Field via the
@@ -26,7 +40,7 @@ to create the full AutoKeyField:
         ...
 
 This layered approach allows each mixin to handle its specific concern:
-- AutoFieldMixin: UUID generation and validation
+- AutoFieldMixin: ID generation and validation
 - KeyFieldMixin: Index maintenance via Redis Sets
 - UniqueKeyField: Uniqueness constraints
 
@@ -39,19 +53,32 @@ developers to think about keys for simple use cases.
 
 Example::
 
-    # Explicit AutoKeyField
+    # Explicit AutoKeyField with default UUID4 strategy
     class Article(popoto.Model):
         uuid = popoto.AutoKeyField()
         title = popoto.Field()
+
+    # Time-sortable ULID strategy
+    class Order(popoto.Model):
+        id = popoto.AutoKeyField(strategy="ulid")
+        product = popoto.Field()
+
+    # K-Sortable ID strategy
+    class Event(popoto.Model):
+        id = popoto.AutoKeyField(strategy="ksuid")
+        name = popoto.Field()
 
     # Implicit _auto_key (added automatically since no KeyFields defined)
     class LogEntry(popoto.Model):
         message = popoto.Field()
         # _auto_key is silently added
 
-    # Both can be saved and retrieved:
+    # All can be saved and retrieved:
     article = Article.create(title="Hello")
     print(article.uuid)  # e.g., "a1b2c3d4e5f6..."
+
+    order = Order.create(product="Widget")
+    print(order.id)  # e.g., "01ARZ3NDEKTSV4RRFFQ69G5FAV"
 
     entry = LogEntry.create(message="Something happened")
     print(entry._auto_key)  # e.g., "f6e5d4c3b2a1..."
@@ -67,7 +94,7 @@ logger = logging.getLogger("POPOTO.field")
 
 class AutoFieldMixin:
     """
-    Mixin that provides automatic UUID-based value generation for key fields.
+    Mixin that provides automatic ID generation for key fields.
 
     This mixin adds auto-generation capabilities to any field, though it's
     typically used with KeyFieldMixin to create AutoKeyField. The auto-generated
@@ -81,15 +108,21 @@ class AutoFieldMixin:
     AND part of a compound key. This flexibility mirrors Django's field design
     while adapting to Redis's key-value paradigm.
 
-    Key Generation Strategy:
-    ------------------------
-    Uses UUID4 (random-based) rather than UUID1 (time-based) for several reasons:
+    ID Generation Strategies:
+    -------------------------
+    Supports multiple strategies via the `strategy` parameter:
 
-    1. No MAC address leakage (privacy)
-    2. No clock synchronization requirements (distributed-friendly)
-    3. Sufficient uniqueness for typical use cases (122 bits of randomness)
+    - "uuid4" (default): Random UUID4 hex string, 32 characters.
+      No MAC address leakage (privacy), no clock synchronization requirements
+      (distributed-friendly), and sufficient uniqueness (122 bits of randomness).
 
-    The default 32-character length uses the full UUID4 hex representation.
+    - "ulid": Universally Unique Lexicographically Sortable Identifier, 26 chars.
+      Time-sortable, ideal for chronological ordering. Requires ulid-py package.
+
+    - "ksuid": K-Sortable Unique Identifier, 27 characters.
+      Similar to ULID with different encoding. Requires cyksuid package.
+
+    The default 32-character length for UUID4 uses the full hex representation.
     Shorter lengths can be configured via `auto_uuid_length` for cases where
     collision probability is acceptable in exchange for shorter keys.
 
@@ -105,7 +138,9 @@ class AutoFieldMixin:
               Always True for this mixin; exists for field introspection.
         auto_uuid_length: Length of the generated UUID string (default 32).
                           Shorter values increase collision probability.
+                          Only applies to uuid4 strategy.
         auto_id: Deprecated/unused attribute for potential future use.
+        strategy: ID generation strategy ("uuid4", "ulid", or "ksuid").
     """
 
     # todo: add support for https://github.com/ai/nanoid
@@ -113,28 +148,52 @@ class AutoFieldMixin:
     auto: bool = True
     auto_uuid_length: int = 32
     auto_id: str = ""
+    strategy: str = "uuid4"
+
+    # Valid strategies and their expected ID lengths
+    STRATEGY_LENGTHS = {
+        "uuid4": 32,
+        "ulid": 26,
+        "ksuid": 27,
+    }
 
     def __init__(self, **kwargs):
         """
-        Initialize the auto-field mixin with UUID generation settings.
+        Initialize the auto-field mixin with ID generation settings.
 
         Follows Popoto's field initialization pattern: call super().__init__
         first to let other mixins in the MRO initialize, then merge this
         mixin's defaults into field_defaults and apply any kwargs overrides.
 
-        This ordering ensures that subclasses can override auto_uuid_length
-        or other settings through kwargs while maintaining sensible defaults.
+        This ordering ensures that subclasses can override auto_uuid_length,
+        strategy, or other settings through kwargs while maintaining sensible
+        defaults.
 
         Args:
             **kwargs: Field configuration options. Relevant options:
-                - auto_uuid_length: Override the UUID length (default 32)
+                - strategy: ID generation strategy ("uuid4", "ulid", "ksuid")
+                - auto_uuid_length: Override the UUID length (default 32,
+                    only applies to uuid4 strategy)
                 - auto: Override auto-generation (rarely needed)
+
+        Raises:
+            ValueError: If an invalid strategy is provided.
         """
         super().__init__(**kwargs)
+
+        # Validate strategy if provided
+        strategy = kwargs.get("strategy", "uuid4")
+        if strategy not in self.STRATEGY_LENGTHS:
+            raise ValueError(
+                f"Invalid strategy '{strategy}'. "
+                f"Valid strategies are: {', '.join(self.STRATEGY_LENGTHS.keys())}"
+            )
+
         autokeyfield_defaults = {
             "auto": True,
             "auto_uuid_length": 32,
             "auto_id": "",
+            "strategy": "uuid4",
         }
         self.field_defaults.update(autokeyfield_defaults)
         # set field options, let kwargs override
@@ -153,32 +212,75 @@ class AutoFieldMixin:
 
         Args:
             field: The Field instance being validated.
-            value: The value to validate (should be a UUID string or None).
+            value: The value to validate (should be an ID string or None).
             null_check: If True, null values will be checked against field.null.
             **kwargs: Additional validation context (passed to parent).
 
         Returns:
             True if valid, False otherwise. Logs an error on invalid length.
         """
-        if value and len(value) != field.auto_uuid_length:
-            logger.error(
-                f"auto key value is length {len(value)}. It should be {field.auto_uuid_length}"
+        if value:
+            # Get expected length based on strategy
+            expected_length = cls.STRATEGY_LENGTHS.get(
+                field.strategy, field.auto_uuid_length
             )
-            return False
+            # For uuid4 strategy, allow custom auto_uuid_length
+            if field.strategy == "uuid4":
+                expected_length = field.auto_uuid_length
+
+            if len(value) != expected_length:
+                logger.error(
+                    f"auto key value is length {len(value)}. "
+                    f"It should be {expected_length} for strategy '{field.strategy}'"
+                )
+                return False
         return super().is_valid(field, value, null_check=null_check, **kwargs)
 
     def get_new_auto_key_value(self):
         """
-        Generate a new UUID4-based identifier string.
+        Generate a new identifier string based on the configured strategy.
 
-        Uses uuid.uuid4().hex to get a lowercase hexadecimal string without
-        hyphens, then truncates to the configured length. The hex format
-        ensures URL-safe and Redis-key-safe characters.
+        Strategies:
+        - uuid4 (default): Uses uuid.uuid4().hex for a lowercase hexadecimal
+          string without hyphens, truncated to auto_uuid_length. URL-safe and
+          Redis-key-safe characters.
+        - ulid: Generates a ULID (Universally Unique Lexicographically Sortable
+          Identifier) using the ulid-py package. Time-sortable, 26 characters.
+        - ksuid: Generates a KSUID (K-Sortable Unique Identifier) using the
+          cyksuid package. Time-sortable, 27 characters.
 
         Returns:
-            A string of length `auto_uuid_length` containing hex characters.
+            A string identifier. Length depends on strategy:
+            - uuid4: `auto_uuid_length` (default 32)
+            - ulid: 26 characters
+            - ksuid: 27 characters
+
+        Raises:
+            ImportError: If ulid or ksuid strategy is used but the required
+                package is not installed.
         """
-        return uuid.uuid4().hex[: self.auto_uuid_length]
+        if self.strategy == "ulid":
+            try:
+                import ulid
+
+                return str(ulid.new())
+            except ImportError:
+                raise ImportError(
+                    "ulid-py package required for ULID strategy. "
+                    "Install with: pip install ulid-py"
+                )
+        elif self.strategy == "ksuid":
+            try:
+                from cyksuid.ksuid import ksuid
+
+                return str(ksuid())
+            except ImportError:
+                raise ImportError(
+                    "cyksuid package required for KSUID strategy. "
+                    "Install with: pip install cyksuid"
+                )
+        else:  # uuid4 (default)
+            return uuid.uuid4().hex[: self.auto_uuid_length]
 
     def set_auto_key_value(self, force: bool = False):
         """

--- a/tests/test_sortable_ids.py
+++ b/tests/test_sortable_ids.py
@@ -1,0 +1,400 @@
+"""
+Tests for sortable ID strategies (ULID/KSUID) in AutoKeyField.
+
+This module tests the strategy parameter for AutoKeyField, which allows
+choosing between UUID4 (default), ULID, and KSUID ID generation strategies.
+"""
+
+import pytest
+import time
+
+
+class TestUUID4Strategy:
+    """Tests for the default UUID4 strategy."""
+
+    def test_default_strategy_is_uuid4(self):
+        """AutoKeyField should default to uuid4 strategy."""
+        import popoto
+
+        class DefaultModel(popoto.Model):
+            uuid = popoto.AutoKeyField()
+            name = popoto.Field()
+
+        # Check that the field has uuid4 strategy
+        assert DefaultModel._meta.fields["uuid"].strategy == "uuid4"
+
+    def test_uuid4_generates_32_char_hex(self):
+        """UUID4 strategy should generate 32-character hex string."""
+        import popoto
+
+        class UUIDModel(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="uuid4")
+            name = popoto.Field()
+
+        instance = UUIDModel(name="test")
+        assert len(instance.uuid) == 32
+        # Verify it's a valid hex string
+        int(instance.uuid, 16)  # Should not raise
+
+    def test_uuid4_custom_length(self):
+        """UUID4 strategy should respect auto_uuid_length parameter."""
+        import popoto
+
+        class ShortUUIDModel(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="uuid4", auto_uuid_length=16)
+            name = popoto.Field()
+
+        instance = ShortUUIDModel(name="test")
+        assert len(instance.uuid) == 16
+
+    def test_uuid4_backward_compatibility(self):
+        """Models without explicit strategy should work as before."""
+        import popoto
+
+        class LegacyModel(popoto.Model):
+            uuid = popoto.AutoKeyField()
+            name = popoto.Field()
+
+        instance = LegacyModel(name="test")
+        # Should generate a valid 32-char hex ID
+        assert len(instance.uuid) == 32
+        int(instance.uuid, 16)  # Should not raise
+
+    def test_uuid4_uniqueness(self):
+        """UUID4 should generate unique IDs."""
+        import popoto
+
+        class UniqueModel(popoto.Model):
+            uuid = popoto.AutoKeyField()
+            name = popoto.Field()
+
+        ids = set()
+        for i in range(100):
+            instance = UniqueModel(name=f"test_{i}")
+            ids.add(instance.uuid)
+
+        assert len(ids) == 100  # All IDs should be unique
+
+
+class TestULIDStrategy:
+    """Tests for the ULID strategy."""
+
+    def test_ulid_strategy_generates_26_chars(self):
+        """ULID strategy should generate 26-character string."""
+        pytest.importorskip("ulid", reason="ulid-py not installed")
+        import popoto
+
+        class ULIDModel(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="ulid")
+            name = popoto.Field()
+
+        instance = ULIDModel(name="test")
+        assert len(instance.uuid) == 26
+
+    def test_ulid_is_time_sortable(self):
+        """ULID IDs generated later should sort after earlier ones."""
+        pytest.importorskip("ulid", reason="ulid-py not installed")
+        import popoto
+
+        class TimeSortedModel(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="ulid")
+            name = popoto.Field()
+
+        # Generate IDs with small delays
+        ids = []
+        for i in range(5):
+            instance = TimeSortedModel(name=f"test_{i}")
+            ids.append(instance.uuid)
+            time.sleep(0.002)  # Small delay to ensure different timestamps
+
+        # Sorted order should match generation order
+        assert ids == sorted(ids)
+
+    def test_ulid_uniqueness(self):
+        """ULID should generate unique IDs."""
+        pytest.importorskip("ulid", reason="ulid-py not installed")
+        import popoto
+
+        class UniqueULIDModel(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="ulid")
+            name = popoto.Field()
+
+        ids = set()
+        for i in range(100):
+            instance = UniqueULIDModel(name=f"test_{i}")
+            ids.add(instance.uuid)
+
+        assert len(ids) == 100
+
+    def test_ulid_import_error_message(self):
+        """Should raise ImportError with helpful message when ulid-py not installed."""
+        import popoto
+        import sys
+        from unittest.mock import patch
+
+        # Create a field directly and test ID generation with mocked import
+        field = popoto.AutoKeyField(strategy="ulid")
+
+        # Mock import failure
+        original_modules = sys.modules.copy()
+        # Remove ulid from modules temporarily
+        ulid_mod = sys.modules.pop("ulid", None)
+
+        try:
+            # Patch the import to fail
+            def mock_import(name, *args, **kwargs):
+                if name == "ulid":
+                    raise ImportError("No module named 'ulid'")
+                return original_modules.get(name) or __import__(name, *args, **kwargs)
+
+            with patch("builtins.__import__", side_effect=mock_import):
+                with pytest.raises(ImportError) as exc_info:
+                    field.get_new_auto_key_value()
+                assert "ulid-py" in str(exc_info.value)
+                assert "pip install ulid-py" in str(exc_info.value)
+        finally:
+            # Restore ulid module if it was installed
+            if ulid_mod:
+                sys.modules["ulid"] = ulid_mod
+
+
+class TestKSUIDStrategy:
+    """Tests for the KSUID strategy."""
+
+    def test_ksuid_strategy_generates_27_chars(self):
+        """KSUID strategy should generate 27-character string."""
+        pytest.importorskip("cyksuid", reason="cyksuid not installed")
+        import popoto
+
+        class KSUIDModel(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="ksuid")
+            name = popoto.Field()
+
+        instance = KSUIDModel(name="test")
+        assert len(instance.uuid) == 27
+
+    def test_ksuid_is_time_sortable(self):
+        """KSUID IDs generated with >1s apart should sort after earlier ones.
+
+        Note: KSUID has 1-second timestamp granularity, so IDs generated within
+        the same second may not be strictly sortable. This test uses 1.1s delays
+        to ensure different timestamps.
+        """
+        pytest.importorskip("cyksuid", reason="cyksuid not installed")
+        import popoto
+
+        class TimeSortedKSUID(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="ksuid")
+            name = popoto.Field()
+
+        # Generate IDs with delays >1s to ensure different timestamps
+        # (KSUID has 1-second timestamp granularity)
+        ids = []
+        for i in range(3):
+            instance = TimeSortedKSUID(name=f"test_{i}")
+            ids.append(instance.uuid)
+            if i < 2:  # Don't sleep after last iteration
+                time.sleep(1.1)
+
+        # Sorted order should match generation order
+        assert ids == sorted(ids)
+
+    def test_ksuid_uniqueness(self):
+        """KSUID should generate unique IDs."""
+        pytest.importorskip("cyksuid", reason="cyksuid not installed")
+        import popoto
+
+        class UniqueKSUIDModel(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="ksuid")
+            name = popoto.Field()
+
+        ids = set()
+        for i in range(100):
+            instance = UniqueKSUIDModel(name=f"test_{i}")
+            ids.add(instance.uuid)
+
+        assert len(ids) == 100
+
+    def test_ksuid_import_error_message(self):
+        """Should raise ImportError with helpful message when cyksuid not installed."""
+        import popoto
+        import sys
+        from unittest.mock import patch
+
+        # Create a field directly and test ID generation with mocked import
+        field = popoto.AutoKeyField(strategy="ksuid")
+
+        # Mock import failure
+        original_modules = sys.modules.copy()
+        # Remove cyksuid from modules temporarily
+        cyksuid_mod = sys.modules.pop("cyksuid", None)
+        cyksuid_ksuid_mod = sys.modules.pop("cyksuid.ksuid", None)
+
+        try:
+
+            def mock_import(name, *args, **kwargs):
+                if name.startswith("cyksuid"):
+                    raise ImportError("No module named 'cyksuid'")
+                return original_modules.get(name) or __import__(name, *args, **kwargs)
+
+            with patch("builtins.__import__", side_effect=mock_import):
+                with pytest.raises(ImportError) as exc_info:
+                    field.get_new_auto_key_value()
+                assert "cyksuid" in str(exc_info.value)
+                assert "pip install cyksuid" in str(exc_info.value)
+        finally:
+            # Restore cyksuid modules if they were installed
+            if cyksuid_mod:
+                sys.modules["cyksuid"] = cyksuid_mod
+            if cyksuid_ksuid_mod:
+                sys.modules["cyksuid.ksuid"] = cyksuid_ksuid_mod
+
+
+class TestInvalidStrategy:
+    """Tests for invalid strategy handling."""
+
+    def test_invalid_strategy_raises_error(self):
+        """Invalid strategy should raise ValueError."""
+        import popoto
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class InvalidModel(popoto.Model):
+                uuid = popoto.AutoKeyField(strategy="invalid")
+                name = popoto.Field()
+
+        assert "Invalid strategy" in str(exc_info.value)
+        assert "invalid" in str(exc_info.value)
+        assert "uuid4" in str(exc_info.value)
+
+    def test_error_message_lists_valid_strategies(self):
+        """Error message should list all valid strategies."""
+        import popoto
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class InvalidModel2(popoto.Model):
+                uuid = popoto.AutoKeyField(strategy="nanoid")
+                name = popoto.Field()
+
+        error_msg = str(exc_info.value)
+        assert "uuid4" in error_msg
+        assert "ulid" in error_msg
+        assert "ksuid" in error_msg
+
+
+class TestValidation:
+    """Tests for ID validation."""
+
+    def test_uuid4_validation(self):
+        """UUID4 IDs should pass validation."""
+        import popoto
+
+        class ValidUUID(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="uuid4")
+            name = popoto.Field()
+
+        instance = ValidUUID(name="test")
+        field = ValidUUID._meta.fields["uuid"]
+        assert field.is_valid(field, instance.uuid)
+
+    def test_ulid_validation(self):
+        """ULID IDs should pass validation."""
+        pytest.importorskip("ulid", reason="ulid-py not installed")
+        import popoto
+
+        class ValidULID(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="ulid")
+            name = popoto.Field()
+
+        instance = ValidULID(name="test")
+        field = ValidULID._meta.fields["uuid"]
+        assert field.is_valid(field, instance.uuid)
+
+    def test_ksuid_validation(self):
+        """KSUID IDs should pass validation."""
+        pytest.importorskip("cyksuid", reason="cyksuid not installed")
+        import popoto
+
+        class ValidKSUID(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="ksuid")
+            name = popoto.Field()
+
+        instance = ValidKSUID(name="test")
+        field = ValidKSUID._meta.fields["uuid"]
+        assert field.is_valid(field, instance.uuid)
+
+    def test_wrong_length_fails_validation(self):
+        """IDs with wrong length should fail validation."""
+        import popoto
+
+        class LengthCheck(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="uuid4")
+            name = popoto.Field()
+
+        field = LengthCheck._meta.fields["uuid"]
+        # A 26-char string (ULID length) should fail for uuid4 strategy
+        assert not field.is_valid(field, "a" * 26)
+
+
+class TestModelPersistence:
+    """Tests for model save/load with different strategies."""
+
+    def test_uuid4_save_and_load(self):
+        """Models with UUID4 strategy should save and load correctly."""
+        import popoto
+
+        class PersistUUID(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="uuid4")
+            name = popoto.Field()
+
+        instance = PersistUUID(name="test_uuid4")
+        instance.save()
+
+        loaded = PersistUUID.query.get(uuid=instance.uuid)
+        assert loaded is not None
+        assert loaded.uuid == instance.uuid
+        assert loaded.name == "test_uuid4"
+
+        # Cleanup
+        instance.delete()
+
+    def test_ulid_save_and_load(self):
+        """Models with ULID strategy should save and load correctly."""
+        pytest.importorskip("ulid", reason="ulid-py not installed")
+        import popoto
+
+        class PersistULID(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="ulid")
+            name = popoto.Field()
+
+        instance = PersistULID(name="test_ulid")
+        instance.save()
+
+        loaded = PersistULID.query.get(uuid=instance.uuid)
+        assert loaded is not None
+        assert loaded.uuid == instance.uuid
+        assert loaded.name == "test_ulid"
+
+        # Cleanup
+        instance.delete()
+
+    def test_ksuid_save_and_load(self):
+        """Models with KSUID strategy should save and load correctly."""
+        pytest.importorskip("cyksuid", reason="cyksuid not installed")
+        import popoto
+
+        class PersistKSUID(popoto.Model):
+            uuid = popoto.AutoKeyField(strategy="ksuid")
+            name = popoto.Field()
+
+        instance = PersistKSUID(name="test_ksuid")
+        instance.save()
+
+        loaded = PersistKSUID.query.get(uuid=instance.uuid)
+        assert loaded is not None
+        assert loaded.uuid == instance.uuid
+        assert loaded.name == "test_ksuid"
+
+        # Cleanup
+        instance.delete()


### PR DESCRIPTION
## Summary
- Adds `strategy` parameter to AutoKeyField with support for `uuid4` (default), `ulid`, and `ksuid` strategies
- ULID generates 26-character time-sortable IDs (requires ulid-py package)
- KSUID generates 27-character time-sortable IDs (requires cyksuid package)
- UUID4 remains the default for backward compatibility
- Optional dependencies: `pip install popoto[ulid]` or `pip install popoto[ksuid]`
- Includes helpful ImportError messages when optional packages are not installed

## Usage
```python
class Order(Model):
    id = AutoKeyField(strategy="ulid")   # Time-sortable, 26 chars

class Event(Model):
    id = AutoKeyField(strategy="ksuid")  # K-Sortable ID, 27 chars

class Article(Model):
    id = AutoKeyField()                  # Default: UUID4 hex (current behavior)
```

## Test plan
- [x] Verify UUID4 strategy generates 32-character hex IDs (backward compatibility)
- [x] Verify ULID strategy generates 26-character time-sortable IDs
- [x] Verify KSUID strategy generates 27-character time-sortable IDs
- [x] Verify invalid strategy raises ValueError with helpful message
- [x] Verify ImportError with installation instructions when packages missing
- [x] Verify models save and load correctly with all strategies
- [x] Verify full test suite passes (87 tests)

Closes #95