### PR TITLE
Add bulk_create, bulk_update, bulk_delete methods

### DIFF
--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -1375,3 +1375,240 @@ class Model(metaclass=ModelBase):
             Model instance or None if not found
         """
         return await to_thread(cls.load, db_key=db_key, **kwargs)
+
+    # Bulk operations
+
+    @classmethod
+    def bulk_create(cls, instances, batch_size: int = 1000):
+        """Create multiple instances efficiently using Redis pipeline.
+
+        Uses Redis pipelines to batch multiple save operations, significantly
+        reducing network round-trips compared to individual save() calls.
+        For very large datasets, operations are automatically batched to
+        prevent excessive memory usage.
+
+        Args:
+            instances: List of model instances to create. Each instance should
+                be a fully constructed Model object (not yet saved).
+            batch_size: Number of operations per pipeline execution (default 1000).
+                Lower values use less memory but require more round-trips.
+
+        Returns:
+            List of created instances (the same instances passed in, now saved).
+
+        Example:
+            restaurants = [
+                Restaurant(name="A", rating=4.0),
+                Restaurant(name="B", rating=4.5),
+                Restaurant(name="C", rating=3.8),
+            ]
+            created = Restaurant.bulk_create(restaurants)
+
+        Note:
+            All instances must be of the same Model class (the class on which
+            bulk_create is called). Validation runs on each instance during save.
+        """
+        if not instances:
+            return []
+
+        created = []
+        pipeline = POPOTO_REDIS_DB.pipeline()
+        count = 0
+
+        for instance in instances:
+            instance.save(pipeline=pipeline)
+            created.append(instance)
+            count += 1
+
+            if count >= batch_size:
+                pipeline.execute()
+                pipeline = POPOTO_REDIS_DB.pipeline()
+                count = 0
+
+        if count > 0:
+            pipeline.execute()
+
+        return created
+
+    @classmethod
+    def bulk_update(cls, queryset_or_instances, batch_size: int = 1000, **updates):
+        """Update multiple instances efficiently using Redis pipeline.
+
+        Applies field updates to all instances matching the queryset or in the
+        provided list. Uses Redis pipelines to batch operations for efficiency.
+
+        Args:
+            queryset_or_instances: Either a list of Model instances, or the result
+                of a query.filter() call (list of instances).
+            batch_size: Number of operations per pipeline execution (default 1000).
+            **updates: Field name/value pairs to update on each instance.
+                Must be valid field names defined on the Model.
+
+        Returns:
+            Number of updated instances.
+
+        Raises:
+            ModelException: If validation fails on any instance during update.
+
+        Example:
+            # Update from queryset
+            count = Restaurant.bulk_update(
+                Restaurant.query.filter(status="pending"),
+                status="active"
+            )
+
+            # Update from list
+            restaurants = [r1, r2, r3]
+            count = Restaurant.bulk_update(restaurants, is_featured=True)
+
+        Note:
+            Each instance is fully validated before saving. If an instance
+            fails validation, a ModelException is raised.
+        """
+        if not updates:
+            return 0
+
+        # Handle both queryset results (list) and plain lists
+        if hasattr(queryset_or_instances, "__iter__"):
+            instances = list(queryset_or_instances)
+        else:
+            instances = [queryset_or_instances]
+
+        if not instances:
+            return 0
+
+        pipeline = POPOTO_REDIS_DB.pipeline()
+        count = 0
+        updated_count = 0
+
+        for instance in instances:
+            # Apply updates to the instance
+            for field_name, value in updates.items():
+                setattr(instance, field_name, value)
+
+            instance.save(pipeline=pipeline)
+            updated_count += 1
+            count += 1
+
+            if count >= batch_size:
+                pipeline.execute()
+                pipeline = POPOTO_REDIS_DB.pipeline()
+                count = 0
+
+        if count > 0:
+            pipeline.execute()
+
+        return updated_count
+
+    @classmethod
+    def bulk_delete(cls, queryset_or_instances, batch_size: int = 1000):
+        """Delete multiple instances efficiently using Redis pipeline.
+
+        Removes all instances matching the queryset or in the provided list
+        from Redis. Uses pipelines for efficient batch deletion.
+
+        Args:
+            queryset_or_instances: Either a list of Model instances, or the result
+                of a query.filter() call (list of instances).
+            batch_size: Number of operations per pipeline execution (default 1000).
+
+        Returns:
+            Number of deleted instances.
+
+        Example:
+            # Delete from queryset
+            count = Restaurant.bulk_delete(
+                Restaurant.query.filter(status="inactive")
+            )
+
+            # Delete from list
+            old_restaurants = [r1, r2, r3]
+            count = Restaurant.bulk_delete(old_restaurants)
+
+        Note:
+            This method properly cleans up all associated indexes (sorted fields,
+            geo fields, unique constraints, etc.) by calling delete() on each
+            instance within the pipeline.
+        """
+        # Handle both queryset results (list) and plain lists
+        if hasattr(queryset_or_instances, "__iter__"):
+            instances = list(queryset_or_instances)
+        else:
+            instances = [queryset_or_instances]
+
+        if not instances:
+            return 0
+
+        pipeline = POPOTO_REDIS_DB.pipeline()
+        count = 0
+        deleted_count = 0
+
+        for instance in instances:
+            instance.delete(pipeline=pipeline)
+            deleted_count += 1
+            count += 1
+
+            if count >= batch_size:
+                pipeline.execute()
+                pipeline = POPOTO_REDIS_DB.pipeline()
+                count = 0
+
+        if count > 0:
+            pipeline.execute()
+
+        return deleted_count
+
+    @classmethod
+    async def async_bulk_create(cls, instances, batch_size: int = 1000):
+        """Async version of bulk_create().
+
+        Creates multiple instances using Redis pipeline in a thread pool
+        to avoid blocking the event loop.
+
+        Args:
+            instances: List of model instances to create
+            batch_size: Number of operations per pipeline execution
+
+        Returns:
+            List of created instances
+        """
+        return await to_thread(cls.bulk_create, instances, batch_size=batch_size)
+
+    @classmethod
+    async def async_bulk_update(
+        cls, queryset_or_instances, batch_size: int = 1000, **updates
+    ):
+        """Async version of bulk_update().
+
+        Updates multiple instances using Redis pipeline in a thread pool
+        to avoid blocking the event loop.
+
+        Args:
+            queryset_or_instances: List of instances or queryset result
+            batch_size: Number of operations per pipeline execution
+            **updates: Field values to update
+
+        Returns:
+            Number of updated instances
+        """
+        return await to_thread(
+            cls.bulk_update, queryset_or_instances, batch_size=batch_size, **updates
+        )
+
+    @classmethod
+    async def async_bulk_delete(cls, queryset_or_instances, batch_size: int = 1000):
+        """Async version of bulk_delete().
+
+        Deletes multiple instances using Redis pipeline in a thread pool
+        to avoid blocking the event loop.
+
+        Args:
+            queryset_or_instances: List of instances or queryset result
+            batch_size: Number of operations per pipeline execution
+
+        Returns:
+            Number of deleted instances
+        """
+        return await to_thread(
+            cls.bulk_delete, queryset_or_instances, batch_size=batch_size
+        )

--- a/tests/test_bulk_operations.py
+++ b/tests/test_bulk_operations.py
@@ -1,0 +1,354 @@
+"""Tests for bulk operations (bulk_create, bulk_update, bulk_delete)."""
+
+import sys
+import os
+import pytest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+from src.popoto.redis_db import POPOTO_REDIS_DB
+from src import popoto
+
+
+# Test model for bulk operations
+class Restaurant(popoto.Model):
+    name = popoto.KeyField()
+    rating = popoto.SortedField(type=float, default=0.0)
+    status = popoto.KeyField(type=str)  # KeyField for filtering
+    cuisine = popoto.Field(type=str, default="")
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    """Clean up all Restaurant instances before and after each test."""
+    for item in Restaurant.query.all():
+        item.delete()
+    yield
+    for item in Restaurant.query.all():
+        item.delete()
+
+
+# === Test bulk_create ===
+
+
+def test_bulk_create_basic():
+    """Test basic bulk_create with a list of instances."""
+    restaurants = [
+        Restaurant(
+            name="Restaurant A", rating=4.0, status="pending", cuisine="Italian"
+        ),
+        Restaurant(
+            name="Restaurant B", rating=4.5, status="pending", cuisine="Japanese"
+        ),
+        Restaurant(
+            name="Restaurant C", rating=3.8, status="pending", cuisine="Mexican"
+        ),
+    ]
+
+    created = Restaurant.bulk_create(restaurants)
+
+    assert len(created) == 3
+    assert Restaurant.query.count() == 3
+
+    # Verify all instances are retrievable
+    assert Restaurant.query.get(name="Restaurant A", status="pending") is not None
+    assert Restaurant.query.get(name="Restaurant B", status="pending") is not None
+    assert Restaurant.query.get(name="Restaurant C", status="pending") is not None
+
+    # Verify field values
+    a = Restaurant.query.get(name="Restaurant A", status="pending")
+    assert a.rating == 4.0
+    assert a.status == "pending"
+    assert a.cuisine == "Italian"
+
+
+def test_bulk_create_empty_list():
+    """Test bulk_create with empty list returns empty list."""
+    result = Restaurant.bulk_create([])
+    assert result == []
+    assert Restaurant.query.count() == 0
+
+
+def test_bulk_create_with_batching():
+    """Test bulk_create with small batch_size to verify batching works."""
+    restaurants = [
+        Restaurant(name=f"Batch Restaurant {i}", rating=float(i), status="active")
+        for i in range(10)
+    ]
+
+    # Use batch_size of 3 to ensure multiple batches
+    created = Restaurant.bulk_create(restaurants, batch_size=3)
+
+    assert len(created) == 10
+    assert Restaurant.query.count() == 10
+
+    # Verify all were created
+    for i in range(10):
+        r = Restaurant.query.get(name=f"Batch Restaurant {i}", status="active")
+        assert r is not None
+        assert r.rating == float(i)
+
+
+# === Test bulk_update ===
+
+
+def test_bulk_update_from_all():
+    """Test bulk_update on all instances from query.all()."""
+    # Setup
+    Restaurant.bulk_create(
+        [
+            Restaurant(name="Update Test 1", status="pending"),
+            Restaurant(name="Update Test 2", status="pending"),
+            Restaurant(name="Update Test 3", status="pending"),
+        ]
+    )
+
+    # Update all restaurants using query.all()
+    all_restaurants = Restaurant.query.all()
+    count = Restaurant.bulk_update(all_restaurants, rating=5.0)
+
+    assert count == 3
+
+    # Verify all ratings updated
+    for r in Restaurant.query.all():
+        assert r.rating == 5.0
+
+
+def test_bulk_update_from_list():
+    """Test bulk_update on a plain list of instances."""
+    # Setup
+    r1 = Restaurant.create(
+        name="List Update 1", rating=3.0, status="active", cuisine="Italian"
+    )
+    r2 = Restaurant.create(
+        name="List Update 2", rating=3.0, status="active", cuisine="Italian"
+    )
+    r3 = Restaurant.create(
+        name="List Update 3", rating=3.0, status="active", cuisine="Mexican"
+    )
+
+    # Update the list (just r1 and r2)
+    count = Restaurant.bulk_update([r1, r2], rating=5.0, cuisine="French")
+
+    assert count == 2
+
+    # Verify updates
+    r1_reloaded = Restaurant.query.get(name="List Update 1", status="active")
+    assert r1_reloaded.rating == 5.0
+    assert r1_reloaded.cuisine == "French"
+
+    r2_reloaded = Restaurant.query.get(name="List Update 2", status="active")
+    assert r2_reloaded.rating == 5.0
+    assert r2_reloaded.cuisine == "French"
+
+    # r3 should be unchanged
+    r3_reloaded = Restaurant.query.get(name="List Update 3", status="active")
+    assert r3_reloaded.rating == 3.0
+    assert r3_reloaded.cuisine == "Mexican"
+
+
+def test_bulk_update_empty_list():
+    """Test bulk_update with empty list returns 0."""
+    result = Restaurant.bulk_update([], rating=5.0)
+    assert result == 0
+
+
+def test_bulk_update_no_updates():
+    """Test bulk_update with no update fields returns 0."""
+    Restaurant.create(name="No Update Test", status="pending")
+
+    result = Restaurant.bulk_update(Restaurant.query.all())
+    assert result == 0
+
+
+def test_bulk_update_with_batching():
+    """Test bulk_update with small batch_size."""
+    # Setup 10 restaurants
+    Restaurant.bulk_create(
+        [Restaurant(name=f"Batch Update {i}", status="pending") for i in range(10)]
+    )
+
+    # Update with small batch size
+    all_restaurants = Restaurant.query.all()
+    count = Restaurant.bulk_update(all_restaurants, rating=9.9, batch_size=3)
+
+    assert count == 10
+
+    # Verify all updated
+    for r in Restaurant.query.all():
+        assert r.rating == 9.9
+
+
+def test_bulk_update_sorted_field():
+    """Test bulk_update properly updates sorted field indexes."""
+    # Setup
+    Restaurant.bulk_create(
+        [
+            Restaurant(name="Sorted Update 1", rating=1.0, status="active"),
+            Restaurant(name="Sorted Update 2", rating=2.0, status="active"),
+            Restaurant(name="Sorted Update 3", rating=3.0, status="active"),
+        ]
+    )
+
+    # Update ratings
+    all_restaurants = Restaurant.query.all()
+    Restaurant.bulk_update(all_restaurants, rating=10.0)
+
+    # Verify sorted field queries work correctly with new values
+    high_rated = Restaurant.query.filter(rating__gte=9.0)
+    assert len(high_rated) == 3
+
+
+# === Test bulk_delete ===
+
+
+def test_bulk_delete_from_all():
+    """Test bulk_delete on all instances from query.all()."""
+    # Setup
+    Restaurant.bulk_create(
+        [
+            Restaurant(name="Delete All 1", status="active"),
+            Restaurant(name="Delete All 2", status="active"),
+            Restaurant(name="Delete All 3", status="active"),
+        ]
+    )
+
+    assert Restaurant.query.count() == 3
+
+    # Delete all
+    count = Restaurant.bulk_delete(Restaurant.query.all())
+
+    assert count == 3
+    assert Restaurant.query.count() == 0
+
+
+def test_bulk_delete_from_list():
+    """Test bulk_delete on a plain list of instances."""
+    # Setup
+    r1 = Restaurant.create(name="List Delete 1", status="active")
+    r2 = Restaurant.create(name="List Delete 2", status="active")
+    r3 = Restaurant.create(name="List Delete 3", status="active")
+
+    assert Restaurant.query.count() == 3
+
+    # Delete only r1 and r2
+    count = Restaurant.bulk_delete([r1, r2])
+
+    assert count == 2
+    assert Restaurant.query.count() == 1
+
+    # r3 should still exist
+    assert Restaurant.query.get(name="List Delete 3", status="active") is not None
+
+
+def test_bulk_delete_empty_list():
+    """Test bulk_delete with empty list returns 0."""
+    result = Restaurant.bulk_delete([])
+    assert result == 0
+
+
+def test_bulk_delete_with_batching():
+    """Test bulk_delete with small batch_size."""
+    # Setup 10 restaurants
+    Restaurant.bulk_create(
+        [Restaurant(name=f"Batch Delete {i}", status="active") for i in range(10)]
+    )
+
+    assert Restaurant.query.count() == 10
+
+    # Delete with small batch size
+    count = Restaurant.bulk_delete(Restaurant.query.all(), batch_size=3)
+
+    assert count == 10
+    assert Restaurant.query.count() == 0
+
+
+def test_bulk_delete_partial():
+    """Test bulk_delete on a subset of instances."""
+    # Setup
+    Restaurant.bulk_create(
+        [Restaurant(name=f"Partial Delete {i}", status="active") for i in range(5)]
+    )
+
+    assert Restaurant.query.count() == 5
+
+    # Get only 3 of them and delete
+    to_delete = Restaurant.query.all()[:3]
+    count = Restaurant.bulk_delete(to_delete)
+
+    assert count == 3
+    assert Restaurant.query.count() == 2
+
+
+# === Test sorted field index cleanup ===
+
+
+class ProductWithSortedField(popoto.Model):
+    """Model with sorted field to test index cleanup."""
+
+    sku = popoto.KeyField()
+    price = popoto.SortedField(type=float, default=0.0)
+
+
+@pytest.fixture
+def cleanup_products():
+    """Clean up ProductWithSortedField instances."""
+    for p in ProductWithSortedField.query.all():
+        p.delete()
+    yield
+    for p in ProductWithSortedField.query.all():
+        p.delete()
+
+
+def test_bulk_delete_cleans_sorted_indexes(cleanup_products):
+    """Test that bulk_delete properly cleans up sorted field indexes."""
+    # Setup
+    products = [
+        ProductWithSortedField(sku=f"SKU-{i}", price=float(10 * i)) for i in range(5)
+    ]
+    ProductWithSortedField.bulk_create(products)
+
+    # Verify sorted field queries work
+    expensive = ProductWithSortedField.query.filter(price__gte=30.0)
+    assert len(expensive) == 2  # SKU-3 (30.0) and SKU-4 (40.0)
+
+    # Bulk delete expensive products
+    ProductWithSortedField.bulk_delete(expensive)
+
+    # Verify count
+    assert ProductWithSortedField.query.count() == 3
+
+    # Verify sorted index was cleaned up - no results above 30
+    remaining_expensive = ProductWithSortedField.query.filter(price__gte=30.0)
+    assert len(remaining_expensive) == 0
+
+
+def test_bulk_create_returns_same_instances():
+    """Test that bulk_create returns the same instances that were passed in."""
+    restaurants = [
+        Restaurant(name="Same Instance 1", status="active"),
+        Restaurant(name="Same Instance 2", status="active"),
+    ]
+
+    created = Restaurant.bulk_create(restaurants)
+
+    # Should be the same objects
+    assert created[0] is restaurants[0]
+    assert created[1] is restaurants[1]
+
+    # And they should have their _redis_key set
+    assert created[0]._redis_key is not None
+    assert created[1]._redis_key is not None
+
+
+def test_bulk_update_modifies_instances_in_place():
+    """Test that bulk_update modifies the instances passed to it."""
+    r1 = Restaurant.create(name="In Place 1", rating=1.0, status="active")
+    r2 = Restaurant.create(name="In Place 2", rating=2.0, status="active")
+
+    Restaurant.bulk_update([r1, r2], rating=9.0)
+
+    # Instances should be modified in place
+    assert r1.rating == 9.0
+    assert r2.rating == 9.0


### PR DESCRIPTION
## Summary
- Adds `Model.bulk_create(instances)` for efficient batch creation using Redis pipelines
- Adds `Model.bulk_update(queryset_or_instances, **updates)` for batch field updates
- Adds `Model.bulk_delete(queryset_or_instances)` for batch deletion
- All operations use Redis pipelines for efficiency (reducing network round-trips)
- Supports `batch_size` parameter for very large operations (default: 1000)
- Includes async variants: `async_bulk_create`, `async_bulk_update`, `async_bulk_delete`

## Example Usage
```python
# Bulk create - single pipeline
Restaurant.bulk_create([
    Restaurant(name="A", rating=4.0),
    Restaurant(name="B", rating=4.5),
    Restaurant(name="C", rating=3.8),
])

# Bulk update - update all matching instances
Restaurant.bulk_update(
    Restaurant.query.filter(rating__gte=4.0),
    status="featured"
)

# Bulk delete - delete all inactive
Restaurant.bulk_delete(Restaurant.query.filter(status="inactive"))
```

## Test plan
- [x] Test bulk_create with list of instances
- [x] Test bulk_create with batching (batch_size parameter)
- [x] Test bulk_update from queryset results
- [x] Test bulk_update from plain list
- [x] Test bulk_delete from queryset results  
- [x] Test bulk_delete from plain list
- [x] Test empty input edge cases
- [x] Test sorted field index cleanup on bulk_delete
- [x] All 82 existing tests pass

Closes #93