### PR TITLE
Support expression-based queries in addition to kwargs

### DIFF
--- a/src/popoto/__init__.py
+++ b/src/popoto/__init__.py
@@ -27,6 +27,7 @@ except ImportError:
 from .fields.datetime_field import DatetimeField
 from .fields.relationship import Relationship
 from .models.base import Model, ModelBase
+from .models.expressions import Expression, CombinedExpression
 from .pubsub.publisher import Publisher
 from .pubsub.subscriber import Subscriber
 
@@ -55,6 +56,8 @@ __all__ = [
     "Relationship",
     "Model",
     "ModelBase",
+    "Expression",
+    "CombinedExpression",
     "Publisher",
     "Subscriber",
 ]

--- a/src/popoto/fields/field.py
+++ b/src/popoto/fields/field.py
@@ -223,6 +223,124 @@ class Field(metaclass=FieldBase):
         if self.__class__ == Field and self.type not in VALID_FIELD_TYPES:
             raise ModelException(f"{self.type} is not a valid Field type")
 
+    # -------------------------------------------------------------------------
+    # Comparison operators for expression-based queries
+    # -------------------------------------------------------------------------
+    # These methods enable Python comparison syntax on Field class attributes:
+    #   Model.query.filter(Model.price > 100)
+    # instead of:
+    #   Model.query.filter(price__gt=100)
+    #
+    # IMPORTANT: The `name` attribute is set by the Model metaclass when the
+    # field is assigned to a model class. These operators rely on `self.name`
+    # being available, which happens automatically for class-level Field access.
+    # -------------------------------------------------------------------------
+
+    def __eq__(self, value):
+        """Create an equality expression or perform normal Python equality check.
+
+        When comparing a Field to a non-Field value, creates an Expression for
+        query filtering. When comparing two Fields, falls back to Python's
+        normal object equality.
+
+        Args:
+            value: The value to compare against
+
+        Returns:
+            Expression if comparing to a non-Field value, bool otherwise
+
+        Example:
+            Model.status == "active"  # Returns Expression
+            field1 == field2          # Returns bool (normal Python equality)
+        """
+        if isinstance(value, Field):
+            return id(self) == id(value)  # Normal Python object equality
+        from ..models.expressions import Expression
+
+        return Expression(self.name, "__eq", value)
+
+    def __ne__(self, value):
+        """Create an inequality expression or perform normal Python inequality check.
+
+        Args:
+            value: The value to compare against
+
+        Returns:
+            Expression if comparing to a non-Field value, bool otherwise
+
+        Example:
+            Model.status != "inactive"  # Returns Expression
+        """
+        if isinstance(value, Field):
+            return id(self) != id(value)  # Normal Python object inequality
+        from ..models.expressions import Expression
+
+        return Expression(self.name, "__ne", value)
+
+    def __gt__(self, value):
+        """Create a greater-than expression for query filtering.
+
+        Args:
+            value: The value to compare against
+
+        Returns:
+            Expression representing field > value
+
+        Example:
+            Model.price > 100  # Returns Expression(price__gt=100)
+        """
+        from ..models.expressions import Expression
+
+        return Expression(self.name, "__gt", value)
+
+    def __lt__(self, value):
+        """Create a less-than expression for query filtering.
+
+        Args:
+            value: The value to compare against
+
+        Returns:
+            Expression representing field < value
+
+        Example:
+            Model.price < 50  # Returns Expression(price__lt=50)
+        """
+        from ..models.expressions import Expression
+
+        return Expression(self.name, "__lt", value)
+
+    def __ge__(self, value):
+        """Create a greater-than-or-equal expression for query filtering.
+
+        Args:
+            value: The value to compare against
+
+        Returns:
+            Expression representing field >= value
+
+        Example:
+            Model.price >= 100  # Returns Expression(price__gte=100)
+        """
+        from ..models.expressions import Expression
+
+        return Expression(self.name, "__gte", value)
+
+    def __le__(self, value):
+        """Create a less-than-or-equal expression for query filtering.
+
+        Args:
+            value: The value to compare against
+
+        Returns:
+            Expression representing field <= value
+
+        Example:
+            Model.price <= 50  # Returns Expression(price__lte=50)
+        """
+        from ..models.expressions import Expression
+
+        return Expression(self.name, "__lte", value)
+
     @classmethod
     def is_valid(cls, field, value, null_check=True, **kwargs) -> bool:
         """

--- a/src/popoto/fields/sorted_field_mixin.py
+++ b/src/popoto/fields/sorted_field_mixin.py
@@ -516,6 +516,10 @@ class SortedFieldMixin:
             elif "__lt" in query_param:
                 inclusive = query_param.split("__lt")[1]
                 value_range["max"] = f"{'' if inclusive == 'e' else '('}{numeric_value}"
+            elif query_param == field_name:
+                # Exact match: set both min and max to the same value (inclusive)
+                value_range["min"] = f"{numeric_value}"
+                value_range["max"] = f"{numeric_value}"
             else:
                 pass  # this is just a mixin, another subclass may have valid query params
 

--- a/src/popoto/models/__init__.py
+++ b/src/popoto/models/__init__.py
@@ -1,0 +1,3 @@
+from .expressions import Expression, CombinedExpression
+
+__all__ = ["Expression", "CombinedExpression"]

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -204,6 +204,9 @@ class ModelOptions:
         else:
             raise ModelException(f"{field_name} is already a Field on the model")
 
+        # Set the field name for expression-based queries
+        field.name = field_name
+
         if isinstance(field, KeyFieldMixin):
             self.key_field_names.add(field_name)
         if isinstance(field, AutoFieldMixin):
@@ -367,7 +370,10 @@ class ModelBase(type):
                 # save field instance
                 # attr will be overwritten as a field.type
                 # model will handle this and set default values
+                obj.name = obj_name  # Set field name for expression-based queries
                 options.add_field(obj_name, obj)
+                # Keep Field as class attribute for expression queries (Model.field > value)
+                new_attrs[obj_name] = obj
 
             elif callable(obj) or hasattr(obj, "__func__") or hasattr(obj, "__set__"):
                 # a callable method or property

--- a/src/popoto/models/expressions.py
+++ b/src/popoto/models/expressions.py
@@ -1,0 +1,207 @@
+"""
+Expression-Based Query Support for Popoto Redis ORM.
+
+This module provides the Expression class that enables intuitive Python comparison
+syntax for building queries. Instead of using Django-style keyword arguments,
+users can write natural Python comparisons directly on Field objects.
+
+Design Philosophy:
+-----------------
+Expression-based queries provide a more Pythonic alternative to keyword argument
+filters. Both approaches are valid and can be mixed:
+
+    # Keyword argument style (existing)
+    Restaurant.query.filter(rating__gt=4.0, status="active")
+
+    # Expression style (new)
+    Restaurant.query.filter(Restaurant.rating > 4.0, Restaurant.status == "active")
+
+    # Mixed style
+    Restaurant.query.filter(Restaurant.rating > 4.0, status="active")
+
+Expressions support combination using & (AND) and | (OR) operators, creating
+compound queries that are converted to the underlying filter kwargs format.
+
+Implementation Notes:
+--------------------
+The Expression class works by:
+1. Field comparison operators (__gt__, __lt__, etc.) return Expression instances
+2. Expressions store the field name, operator, and comparison value
+3. When passed to filter(), expressions are converted to kwargs format
+4. Combined expressions (using &/|) create nested structures that resolve to
+   multiple filter operations with set intersection/union
+
+Example:
+--------
+    # Single expression
+    expr = Restaurant.rating > 4.0
+    # Becomes: {"rating__gt": 4.0}
+
+    # Combined expressions
+    expr = (Restaurant.rating > 4.0) & (Restaurant.status == "active")
+    # Becomes intersection of two filter results
+
+See Also:
+---------
+- `popoto.fields.field.Field` - Comparison operators defined here
+- `popoto.models.query.Query.filter` - Handles Expression objects in args
+"""
+
+
+class Expression:
+    """Represents a field comparison expression for query building.
+
+    An Expression captures a single comparison operation between a field and
+    a value. It stores the field name, comparison operator, and value, which
+    can later be converted to the kwargs format used by Query.filter().
+
+    Expressions are created automatically when using comparison operators on
+    Field instances (when accessed as class attributes, not instance values).
+
+    Attributes:
+        field_name: The name of the field being compared
+        operator: The comparison operator ('__eq', '__gt', '__lt', '__gte', '__lte', '__ne')
+        value: The value being compared against
+
+    Example:
+        # Created via Field comparison operators
+        expr = MyModel.price > 100  # Expression(field_name='price', operator='__gt', value=100)
+
+        # Convert to kwargs for filter()
+        expr.to_kwargs()  # {'price__gt': 100}
+
+        # Combine expressions
+        combined = (MyModel.price > 100) & (MyModel.active == True)
+    """
+
+    def __init__(self, field_name: str, operator: str, value):
+        """Initialize an Expression.
+
+        Args:
+            field_name: The name of the field (e.g., 'price', 'status')
+            operator: The comparison operator string ('__eq', '__gt', '__lt',
+                     '__gte', '__lte', '__ne')
+            value: The value to compare against
+        """
+        self.field_name = field_name
+        self.operator = operator
+        self.value = value
+
+    def __and__(self, other: "Expression") -> "CombinedExpression":
+        """Combine this expression with another using AND logic.
+
+        Args:
+            other: Another Expression or CombinedExpression
+
+        Returns:
+            A CombinedExpression that represents the AND of both expressions
+
+        Example:
+            (Model.price > 100) & (Model.active == True)
+        """
+        return CombinedExpression(self, other, connector="AND")
+
+    def __or__(self, other: "Expression") -> "CombinedExpression":
+        """Combine this expression with another using OR logic.
+
+        Args:
+            other: Another Expression or CombinedExpression
+
+        Returns:
+            A CombinedExpression that represents the OR of both expressions
+
+        Example:
+            (Model.status == "active") | (Model.status == "pending")
+        """
+        return CombinedExpression(self, other, connector="OR")
+
+    def __repr__(self) -> str:
+        """Return a readable representation of this expression."""
+        return f"Expression({self.field_name}{self.operator}={self.value!r})"
+
+    def to_kwargs(self) -> dict:
+        """Convert this expression to filter kwargs format.
+
+        Returns:
+            A dictionary suitable for passing to Query.filter() as kwargs.
+            For equality checks, returns {field_name: value}.
+            For other operators, returns {field_name + operator: value}.
+
+        Example:
+            Expression('price', '__gt', 100).to_kwargs()  # {'price__gt': 100}
+            Expression('status', '__eq', 'active').to_kwargs()  # {'status': 'active'}
+        """
+        if self.operator == "__eq":
+            return {self.field_name: self.value}
+        else:
+            return {f"{self.field_name}{self.operator}": self.value}
+
+
+class CombinedExpression:
+    """Represents multiple expressions combined with AND or OR logic.
+
+    CombinedExpressions are created when using & or | operators between
+    Expression objects. They can be nested to create complex query logic.
+
+    When evaluated, AND combinations perform set intersection on results,
+    while OR combinations perform set union.
+
+    Attributes:
+        left: The left-hand Expression or CombinedExpression
+        right: The right-hand Expression or CombinedExpression
+        connector: Either "AND" or "OR"
+
+    Example:
+        # AND combination
+        expr = (Model.price > 100) & (Model.active == True)
+
+        # OR combination
+        expr = (Model.status == "active") | (Model.status == "pending")
+
+        # Nested combination
+        expr = ((Model.price > 100) & (Model.active == True)) | (Model.featured == True)
+    """
+
+    def __init__(self, left, right, connector: str = "AND"):
+        """Initialize a CombinedExpression.
+
+        Args:
+            left: The left-hand Expression or CombinedExpression
+            right: The right-hand Expression or CombinedExpression
+            connector: The logical connector, either "AND" or "OR"
+        """
+        self.left = left
+        self.right = right
+        self.connector = connector
+
+    def __and__(self, other) -> "CombinedExpression":
+        """Combine this expression with another using AND logic."""
+        return CombinedExpression(self, other, connector="AND")
+
+    def __or__(self, other) -> "CombinedExpression":
+        """Combine this expression with another using OR logic."""
+        return CombinedExpression(self, other, connector="OR")
+
+    def __repr__(self) -> str:
+        """Return a readable representation of this combined expression."""
+        return f"({self.left!r} {self.connector} {self.right!r})"
+
+    def get_all_expressions(self) -> list:
+        """Recursively collect all leaf Expression objects.
+
+        Returns:
+            A list of all Expression objects in this tree.
+        """
+        expressions = []
+
+        if isinstance(self.left, Expression):
+            expressions.append(self.left)
+        elif isinstance(self.left, CombinedExpression):
+            expressions.extend(self.left.get_all_expressions())
+
+        if isinstance(self.right, Expression):
+            expressions.append(self.right)
+        elif isinstance(self.right, CombinedExpression):
+            expressions.extend(self.right.get_all_expressions())
+
+        return expressions

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -336,6 +336,100 @@ class Query:
             **kwargs,
         )
 
+    def _filter_for_keys_set_with_expressions(self, *args, **kwargs) -> set:
+        """
+        Execute filter logic with support for Expression objects.
+
+        This method handles both traditional kwargs filtering and expression-based
+        filtering. It processes Expression and CombinedExpression objects passed
+        as positional arguments, converting them to kwargs or handling OR logic.
+
+        Args:
+            *args: Expression or CombinedExpression objects
+            **kwargs: Traditional filter parameters
+
+        Returns:
+            Set of Redis key strings (bytes) matching the filter criteria.
+        """
+        from .expressions import Expression, CombinedExpression
+
+        # Separate expressions from other args (shouldn't be any other args, but be safe)
+        expressions = [
+            arg for arg in args if isinstance(arg, (Expression, CombinedExpression))
+        ]
+
+        # Handle combined expressions with OR logic separately
+        or_result_sets = []
+        and_expressions = []
+
+        for expr in expressions:
+            if isinstance(expr, CombinedExpression):
+                # Process the combined expression tree
+                result = self._evaluate_combined_expression(expr)
+                if result is not None:
+                    or_result_sets.append(result)
+            elif isinstance(expr, Expression):
+                # Simple expressions are AND-ed together via kwargs
+                and_expressions.append(expr)
+
+        # Convert simple AND expressions to kwargs
+        for expr in and_expressions:
+            expr_kwargs = expr.to_kwargs()
+            kwargs.update(expr_kwargs)
+
+        # Get keys from kwargs filtering
+        kwargs_keys = self.filter_for_keys_set(**kwargs)
+
+        # Combine with OR expression results
+        if or_result_sets:
+            # Start with kwargs result (or all keys if no kwargs)
+            if kwargs_keys:
+                all_sets = [kwargs_keys] + or_result_sets
+            else:
+                all_sets = or_result_sets
+
+            # If we have both kwargs AND or_expressions, we need intersection
+            # If we only have or_expressions, we already have the union from evaluation
+            if kwargs_keys and or_result_sets:
+                return set.intersection(*all_sets)
+            elif or_result_sets:
+                # Just OR expressions, return their combined result
+                return (
+                    set.union(*or_result_sets)
+                    if len(or_result_sets) > 1
+                    else or_result_sets[0]
+                )
+
+        return kwargs_keys
+
+    def _evaluate_combined_expression(self, expr) -> set:
+        """
+        Recursively evaluate a CombinedExpression tree.
+
+        Args:
+            expr: A CombinedExpression or Expression object
+
+        Returns:
+            Set of matching Redis keys
+        """
+        from .expressions import Expression, CombinedExpression
+
+        if isinstance(expr, Expression):
+            # Evaluate single expression
+            return self.filter_for_keys_set(**expr.to_kwargs())
+
+        elif isinstance(expr, CombinedExpression):
+            # Recursively evaluate both sides
+            left_keys = self._evaluate_combined_expression(expr.left)
+            right_keys = self._evaluate_combined_expression(expr.right)
+
+            if expr.connector == "AND":
+                return left_keys & right_keys
+            else:  # OR
+                return left_keys | right_keys
+
+        return set()
+
     def filter_for_keys_set(self, **kwargs) -> set:
         """
         Execute filter logic and return matching Redis keys (without loading objects).
@@ -459,13 +553,14 @@ class Query:
         # return intersection of all the db keys sets, effectively &&-ing all filters
         return set.intersection(*db_keys_sets)
 
-    def filter(self, **kwargs) -> list:
+    def filter(self, *args, **kwargs) -> list:
         """
         Query for Model instances matching the specified criteria.
 
         This is the primary query method for Popoto, providing Django-like filtering
         syntax with Redis-optimized execution. All filter parameters are AND-ed
-        together; OR queries require multiple calls combined in application code.
+        together; OR queries require multiple calls combined in application code,
+        or by using the | operator with Expression objects.
 
         Filter Parameters:
         -----------------
@@ -486,6 +581,16 @@ class Query:
         - `field__lt=value` - Less than
         - `field__lte=value` - Less than or equal
 
+        **Expression-based syntax (alternative):**
+        - `Model.field == value` - Equality
+        - `Model.field != value` - Inequality
+        - `Model.field > value` - Greater than
+        - `Model.field >= value` - Greater than or equal
+        - `Model.field < value` - Less than
+        - `Model.field <= value` - Less than or equal
+        - Expressions can be combined: `(Model.a > 1) & (Model.b == "x")`
+        - OR is supported: `(Model.status == "active") | (Model.status == "pending")`
+
         Result Modifiers:
         ----------------
         - `order_by="field"` - Sort ascending by field
@@ -495,6 +600,7 @@ class Query:
           instead of full Model instances (projection query, more efficient)
 
         Args:
+            *args: Expression objects created from Field comparison operators
             **kwargs: Filter parameters and result modifiers as described above.
 
         Returns:
@@ -505,7 +611,7 @@ class Query:
             QueryException: If unknown filter parameters are provided.
 
         Example:
-            # Find active premium users created this year
+            # Keyword argument style
             users = User.query.filter(
                 status="active",
                 tier="premium",
@@ -514,17 +620,31 @@ class Query:
                 limit=50
             )
 
-            # Efficient projection - only load specific fields
-            emails = User.query.filter(
-                status="active",
-                values=("email", "name")
-            )  # Returns [{"email": "...", "name": "..."}, ...]
+            # Expression-based style
+            users = User.query.filter(
+                User.status == "active",
+                User.tier == "premium",
+                User.created_at >= datetime(2024, 1, 1),
+                order_by="-created_at",
+                limit=50
+            )
+
+            # Mixed style
+            users = User.query.filter(
+                User.rating > 4.0,
+                status="active"
+            )
+
+            # Combined expressions with OR
+            users = User.query.filter(
+                (User.status == "active") | (User.status == "pending")
+            )
         """
         # Reset geo distances for this query
         self._geo_distances = {}
         self._geo_distance_unit = None
 
-        db_keys_set = self.filter_for_keys_set(**kwargs)
+        db_keys_set = self._filter_for_keys_set_with_expressions(*args, **kwargs)
         if not len(db_keys_set):
             return []
 

--- a/tests/test_expression_queries.py
+++ b/tests/test_expression_queries.py
@@ -1,0 +1,274 @@
+"""
+Tests for expression-based query syntax.
+
+This module tests the ability to use Python comparison operators on Field
+class attributes to build queries, as an alternative to keyword arguments.
+"""
+
+import sys
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+from src.popoto.redis_db import POPOTO_REDIS_DB
+from src import popoto
+from src.popoto.models.expressions import Expression, CombinedExpression
+
+
+# Test model with various field types
+class Restaurant(popoto.Model):
+    name = popoto.KeyField()
+    rating = popoto.SortedField(type=float)
+    price_level = popoto.SortedField(type=int)
+    cuisine = popoto.KeyField()
+    is_open = popoto.Field(type=bool, default=True)
+
+
+# Clean up any existing test data
+for r in Restaurant.query.all():
+    r.delete()
+
+
+# Create test data
+restaurant1 = Restaurant.create(
+    name="Burger Palace",
+    rating=4.5,
+    price_level=2,
+    cuisine="American",
+    is_open=True,
+)
+
+restaurant2 = Restaurant.create(
+    name="Sushi Master",
+    rating=4.8,
+    price_level=3,
+    cuisine="Japanese",
+    is_open=True,
+)
+
+restaurant3 = Restaurant.create(
+    name="Pizza Corner",
+    rating=3.5,
+    price_level=1,
+    cuisine="Italian",
+    is_open=False,
+)
+
+restaurant4 = Restaurant.create(
+    name="Taco Town",
+    rating=4.0,
+    price_level=1,
+    cuisine="Mexican",
+    is_open=True,
+)
+
+
+# Test 1: Basic equality expression
+print("Test 1: Basic equality expression")
+expr = Restaurant.name == "Burger Palace"
+assert isinstance(expr, Expression)
+assert expr.field_name == "name"
+assert expr.operator == "__eq"
+assert expr.value == "Burger Palace"
+assert expr.to_kwargs() == {"name": "Burger Palace"}
+print("  PASSED: Expression creation and to_kwargs()")
+
+
+# Test 2: Greater than expression
+print("Test 2: Greater than expression")
+expr = Restaurant.rating > 4.0
+assert isinstance(expr, Expression)
+assert expr.field_name == "rating"
+assert expr.operator == "__gt"
+assert expr.value == 4.0
+assert expr.to_kwargs() == {"rating__gt": 4.0}
+print("  PASSED: Greater than expression")
+
+
+# Test 3: Less than expression
+print("Test 3: Less than expression")
+expr = Restaurant.rating < 4.0
+assert expr.operator == "__lt"
+assert expr.to_kwargs() == {"rating__lt": 4.0}
+print("  PASSED: Less than expression")
+
+
+# Test 4: Greater than or equal expression
+print("Test 4: Greater than or equal expression")
+expr = Restaurant.rating >= 4.0
+assert expr.operator == "__gte"
+assert expr.to_kwargs() == {"rating__gte": 4.0}
+print("  PASSED: Greater than or equal expression")
+
+
+# Test 5: Less than or equal expression
+print("Test 5: Less than or equal expression")
+expr = Restaurant.rating <= 4.0
+assert expr.operator == "__lte"
+assert expr.to_kwargs() == {"rating__lte": 4.0}
+print("  PASSED: Less than or equal expression")
+
+
+# Test 6: Not equal expression
+print("Test 6: Not equal expression")
+expr = Restaurant.cuisine != "American"
+assert expr.operator == "__ne"
+assert expr.to_kwargs() == {"cuisine__ne": "American"}
+print("  PASSED: Not equal expression")
+
+
+# Test 7: Filter with single expression (equality)
+print("Test 7: Filter with single expression (equality)")
+results = Restaurant.query.filter(Restaurant.name == "Burger Palace")
+assert len(results) == 1
+assert results[0].name == "Burger Palace"
+print("  PASSED: Filter with equality expression")
+
+
+# Test 8: Filter with single expression (greater than)
+print("Test 8: Filter with single expression (greater than)")
+results = Restaurant.query.filter(Restaurant.rating > 4.0)
+assert len(results) == 2  # Sushi Master (4.8) and Burger Palace (4.5)
+assert all(r.rating > 4.0 for r in results)
+print("  PASSED: Filter with greater than expression")
+
+
+# Test 9: Filter with single expression (less than or equal)
+print("Test 9: Filter with single expression (less than or equal)")
+results = Restaurant.query.filter(Restaurant.rating <= 4.0)
+assert len(results) == 2  # Pizza Corner (3.5) and Taco Town (4.0)
+assert all(r.rating <= 4.0 for r in results)
+print("  PASSED: Filter with less than or equal expression")
+
+
+# Test 10: Combined expressions with AND
+print("Test 10: Combined expressions with AND")
+combined = (Restaurant.rating > 4.0) & (Restaurant.price_level <= 2)
+assert isinstance(combined, CombinedExpression)
+assert combined.connector == "AND"
+results = Restaurant.query.filter(combined)
+assert len(results) == 1  # Only Burger Palace (rating 4.5, price_level 2)
+assert results[0].name == "Burger Palace"
+print("  PASSED: Combined expressions with AND")
+
+
+# Test 11: Combined expressions with OR
+print("Test 11: Combined expressions with OR")
+combined = (Restaurant.cuisine == "American") | (Restaurant.cuisine == "Japanese")
+assert isinstance(combined, CombinedExpression)
+assert combined.connector == "OR"
+results = Restaurant.query.filter(combined)
+assert len(results) == 2  # Burger Palace and Sushi Master
+cuisines = {r.cuisine for r in results}
+assert cuisines == {"American", "Japanese"}
+print("  PASSED: Combined expressions with OR")
+
+
+# Test 12: Mixed expressions and kwargs
+print("Test 12: Mixed expressions and kwargs")
+results = Restaurant.query.filter(Restaurant.rating > 3.5, cuisine="Italian")
+# Italian with rating > 3.5 - but Pizza Corner has rating 3.5, not > 3.5
+assert len(results) == 0
+print("  PASSED: Mixed expressions and kwargs (no results)")
+
+results = Restaurant.query.filter(Restaurant.rating >= 3.5, cuisine="Italian")
+assert len(results) == 1
+assert results[0].name == "Pizza Corner"
+print("  PASSED: Mixed expressions and kwargs (with results)")
+
+
+# Test 13: Multiple simple expressions (implicit AND)
+print("Test 13: Multiple simple expressions (implicit AND)")
+results = Restaurant.query.filter(Restaurant.rating >= 4.0, Restaurant.price_level <= 2)
+# rating >= 4.0 AND price_level <= 2
+# Burger Palace (4.5, 2), Taco Town (4.0, 1)
+assert len(results) == 2
+names = {r.name for r in results}
+assert names == {"Burger Palace", "Taco Town"}
+print("  PASSED: Multiple simple expressions")
+
+
+# Test 14: Complex nested expressions
+print("Test 14: Complex nested expressions")
+# (rating > 4.0 AND price_level == 3) OR (rating <= 4.0 AND price_level == 1)
+combined = ((Restaurant.rating > 4.0) & (Restaurant.price_level == 3)) | (
+    (Restaurant.rating <= 4.0) & (Restaurant.price_level == 1)
+)
+results = Restaurant.query.filter(combined)
+# Sushi Master (4.8, 3) OR (Pizza Corner (3.5, 1) and Taco Town (4.0, 1))
+assert len(results) == 3
+names = {r.name for r in results}
+assert names == {"Sushi Master", "Pizza Corner", "Taco Town"}
+print("  PASSED: Complex nested expressions")
+
+
+# Test 15: Expression with order_by and limit
+print("Test 15: Expression with order_by and limit")
+results = Restaurant.query.filter(Restaurant.rating >= 3.5, order_by="-rating", limit=2)
+assert len(results) == 2
+assert results[0].rating >= results[1].rating  # Descending order
+print("  PASSED: Expression with order_by and limit")
+
+
+# Test 16: Expression on integer field
+print("Test 16: Expression on integer field")
+results = Restaurant.query.filter(Restaurant.price_level == 1)
+assert len(results) == 2  # Pizza Corner and Taco Town
+assert all(r.price_level == 1 for r in results)
+print("  PASSED: Expression on integer field")
+
+
+# Test 17: Field equality comparison (should return bool, not Expression)
+print("Test 17: Field equality comparison returns bool")
+field1 = Restaurant.name
+field2 = Restaurant.cuisine
+field3 = Restaurant.name
+# Comparing two different fields should return False
+assert (field1 == field2) == False
+# Comparing same field reference should return True
+assert (field1 == field3) == True
+print("  PASSED: Field equality comparison")
+
+
+# Test 18: Expression repr
+print("Test 18: Expression repr")
+expr = Restaurant.rating > 4.0
+repr_str = repr(expr)
+assert "rating" in repr_str
+assert "__gt" in repr_str
+assert "4.0" in repr_str
+print(f"  Expression repr: {repr_str}")
+print("  PASSED: Expression repr")
+
+
+# Test 19: CombinedExpression repr
+print("Test 19: CombinedExpression repr")
+combined = (Restaurant.rating > 4.0) & (Restaurant.cuisine == "American")
+repr_str = repr(combined)
+assert "AND" in repr_str
+print(f"  CombinedExpression repr: {repr_str}")
+print("  PASSED: CombinedExpression repr")
+
+
+# Test 20: Empty filter with expression returns all (when combined with no other filters)
+print("Test 20: Filter with tautology-like expression")
+# This tests that expressions work alongside the normal filter behavior
+results = Restaurant.query.filter(
+    Restaurant.rating >= 0
+)  # All restaurants have rating >= 0
+assert len(results) == 4
+print("  PASSED: Filter returns all matching records")
+
+
+# Cleanup
+print("\nCleaning up test data...")
+for r in Restaurant.query.all():
+    r.delete()
+
+assert Restaurant.query.count() == 0
+print("Cleanup complete.")
+
+print("\n" + "=" * 50)
+print("ALL EXPRESSION QUERY TESTS PASSED!")
+print("=" * 50)


### PR DESCRIPTION
## Summary
- Adds Python comparison operators to Field class (`==`, `!=`, `>`, `<`, `>=`, `<=`)
- Enables intuitive query syntax: `Model.query.filter(Model.rating > 4.0)`
- Expressions can be combined with `&` (AND) and `|` (OR) operators
- Works alongside existing kwargs syntax for mixed queries: `Model.query.filter(Model.rating > 4.0, status="active")`

## Changes
- **New `Expression` and `CombinedExpression` classes** in `src/popoto/models/expressions.py`
- **Field comparison operators** added to `Field` class for expression-based queries
- **Query.filter()** now accepts positional Expression arguments
- **Fix for SortedField** to support exact match queries (field_name=value)
- **Set field.name attribute** in `ModelOptions.add_field` for dynamically added fields (like `_auto_key`)

## Examples
```python
# Basic expression
Restaurant.query.filter(Restaurant.rating > 4.0)

# Combined with AND
Restaurant.query.filter(
    (Restaurant.rating > 4.0) & (Restaurant.status == "active")
)

# Combined with OR
Restaurant.query.filter(
    (Restaurant.cuisine == "Italian") | (Restaurant.cuisine == "Japanese")
)

# Mixed with kwargs
Restaurant.query.filter(Restaurant.rating > 4.0, status="active", limit=10)
```

## Test plan
- [x] Basic field comparisons (==, >, <, >=, <=, !=)
- [x] Combined expressions with & (AND)
- [x] Combined expressions with | (OR)
- [x] Complex nested expressions
- [x] Mixed expressions and kwargs
- [x] Expressions on different field types (KeyField, SortedField)
- [x] All existing tests pass

Closes #96