### PR TITLE
Fix Relationship validation bug on re-save (#113)

### DIFF
--- a/src/popoto/fields/relationship.py
+++ b/src/popoto/fields/relationship.py
@@ -139,6 +139,46 @@ class Relationship(Field):
         for k, v in relationship_field_defaults.items():
             setattr(self, k, kwargs.get(k, v))
 
+    @classmethod
+    def is_valid(cls, field, value, null_check=True, **kwargs) -> bool:
+        """
+        Validate a Relationship field value.
+
+        Accepts three value types as valid:
+        - A Model instance (the related model)
+        - A str containing a redis_key reference (lazy-loaded, format "ClassName:key")
+        - None (if field.null is True)
+
+        This override is necessary because the base Field.is_valid() only checks
+        isinstance(value, field.type), which rejects the str redis_key values
+        that are set during lazy loading from Redis.
+        """
+        if not null_check and value is None:
+            return True
+        if field.null and value is None:
+            return True
+        if value is None:
+            logger.error(f"Relationship field {field} is null but null=False")
+            return False
+        # Accept redis_key strings (lazy-loaded relationship references)
+        if isinstance(value, str):
+            if ":" not in value:
+                logger.error(
+                    f"Relationship field {field} has invalid redis_key string: {value}"
+                )
+                return False
+            return True
+        # Accept Model instances
+        from ..models.base import Model
+
+        if isinstance(value, Model):
+            return True
+        logger.error(
+            f"Relationship field {field} expected Model instance or redis_key string, "
+            f"got {type(value)}"
+        )
+        return False
+
     def get_filter_query_params(self, field_name) -> set:
         """
         Build the set of valid query parameters for filtering on this relationship.

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -78,7 +78,6 @@ global RELATED_MODEL_LOAD_SEQUENCE
 RELATED_MODEL_LOAD_SEQUENCE = set()
 
 
-
 # Length of hex digest used for index hashes. 16 hex chars = 64 bits,
 # sufficient for index key uniqueness within a single model's field combinations.
 INDEX_HASH_LENGTH = 16
@@ -802,7 +801,16 @@ class Model(metaclass=ModelBase):
             value = getattr(self, field_name)
 
             # Type coercion: convert compatible types before validation
-            if value is not None and not isinstance(value, field.type):
+            # Skip coercion for Relationship fields — they handle their own
+            # validation and legitimately hold str redis_key values when
+            # lazy-loaded from Redis.
+            from ..fields.relationship import Relationship
+
+            if (
+                value is not None
+                and not isinstance(value, field.type)
+                and not isinstance(field, Relationship)
+            ):
                 try:
                     if field.type in VALID_FIELD_TYPES:
                         coerced = field.type(value)

--- a/src/popoto/models/encoding.py
+++ b/src/popoto/models/encoding.py
@@ -239,12 +239,16 @@ def encode_popoto_model_obj(obj: "Model") -> dict:
         from ..fields.relationship import Relationship
 
         if value is not None and isinstance(field, Relationship):
-            if not isinstance(value, field.model):
+            if isinstance(value, str):
+                # Lazy-loaded redis_key string — already in storage format
+                encoded_value = msgpack.packb(value)
+            elif not isinstance(value, field.model):
                 raise ModelException(
                     f"Relationship field requires {field.model} model instance. got {value} instead"
                 )
-            encoded_value = msgpack.packb(value.db_key.redis_key)
-            # todo: refactor to store db_key list, not redis_key
+            else:
+                encoded_value = msgpack.packb(value.db_key.redis_key)
+                # todo: refactor to store db_key list, not redis_key
 
         elif value is not None and field.type in TYPE_ENCODER_DECODERS.keys():
             encoded_value = msgpack.packb(

--- a/tests/test_relationship_edge_cases.py
+++ b/tests/test_relationship_edge_cases.py
@@ -487,6 +487,112 @@ class TestRedisKeyStringHandling:
         person.delete()
 
 
+class TestRelationshipValidationOnResave(TestRelationshipEdgeCases):
+    """
+    Test for Issue #113: Relationship fields fail validation on save when
+    lazy-loaded as redis_key strings.
+
+    When a model with a Relationship field is loaded from Redis, the relationship
+    value is a redis_key string (lazy-loaded). Re-saving that model should work
+    without requiring the relationship to be resolved first.
+    """
+
+    def test_load_and_resave_without_accessing_relationship(self):
+        """
+        The core bug: load a model from Redis and re-save it without
+        accessing the relationship field. The lazy-loaded string value
+        should pass validation.
+        """
+        person = PersonModel.create(name="Zara")
+        group = GroupModel.create(name="Research")
+        membership = MembershipModel.create(person=person, group=group)
+        membership_key = membership.db_key.redis_key
+
+        # Load from Redis via query.all() — uses lazy loading, so
+        # relationship fields remain as redis_key strings
+        loaded = MembershipModel.query.all()[0]
+
+        # Verify relationship is indeed a lazy-loaded string
+        assert isinstance(loaded.person, str)
+
+        # Re-save without accessing .person or .group
+        # Before fix: ModelException("Model instance parameters invalid...")
+        loaded.save()
+
+        # Verify model data is still intact by loading via get()
+        # which resolves relationships through __init__
+        reloaded = MembershipModel.query.get(redis_key=membership_key)
+        assert reloaded.person.name == "Zara"
+        assert reloaded.group.name == "Research"
+
+        # Cleanup
+        reloaded.delete()
+        person.delete()
+        group.delete()
+
+    def test_load_modify_unrelated_field_and_resave(self):
+        """
+        Load a model, modify a non-relationship field, and re-save.
+        The unchanged lazy-loaded relationship should not block the save.
+        """
+        person = PersonModel.create(name="Yuki")
+        group = GroupModel.create(name="Design")
+
+        class TaskModel(Model):
+            title = KeyField()
+            assignee = Relationship(model=PersonModel)
+            status = Field(type=str)
+
+        # Clean up any existing TaskModel data
+        for key in POPOTO_REDIS_DB.keys("TaskModel:*"):
+            POPOTO_REDIS_DB.delete(key)
+        for key in POPOTO_REDIS_DB.keys("$*:TaskModel:*"):
+            POPOTO_REDIS_DB.delete(key)
+
+        task = TaskModel.create(title="task1", assignee=person, status="open")
+
+        # Load and modify only status
+        loaded_task = TaskModel.query.get(title="task1")
+        loaded_task.status = "closed"
+        loaded_task.save()
+
+        # Verify
+        updated = TaskModel.query.get(title="task1")
+        assert updated.status == "closed"
+        assert updated.assignee.name == "Yuki"
+
+        # Cleanup
+        task.delete()
+        person.delete()
+        group.delete()
+        for key in POPOTO_REDIS_DB.keys("TaskModel:*"):
+            POPOTO_REDIS_DB.delete(key)
+        for key in POPOTO_REDIS_DB.keys("$*:TaskModel:*"):
+            POPOTO_REDIS_DB.delete(key)
+
+    def test_relationship_is_valid_accepts_redis_key_string(self):
+        """Test that Relationship.is_valid() accepts valid redis_key strings."""
+        from src.popoto.fields.relationship import Relationship
+
+        field = Relationship(model=PersonModel)
+        assert Relationship.is_valid(field, "PersonModel:Alice") is True
+        assert Relationship.is_valid(field, None) is True
+
+    def test_relationship_is_valid_rejects_invalid_string(self):
+        """Test that Relationship.is_valid() rejects strings without a colon."""
+        from src.popoto.fields.relationship import Relationship
+
+        field = Relationship(model=PersonModel)
+        assert Relationship.is_valid(field, "InvalidNoColon") is False
+
+    def test_relationship_is_valid_rejects_non_null_when_required(self):
+        """Test that Relationship.is_valid() rejects None when null=False."""
+        from src.popoto.fields.relationship import Relationship
+
+        field = Relationship(model=PersonModel, null=False)
+        assert Relationship.is_valid(field, None) is False
+
+
 # Run tests if executed directly
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #113 — Models with `Relationship` fields that are loaded from Redis fail to re-save because lazy-loaded string values (redis_key references like `"Customer:alice123"`) are rejected by type validation.

The save path had three failure points for string relationship values:

- **`Relationship.is_valid()`** — Added override that accepts `str` (redis_key), `Model` instance, or `None` as valid values. The base `Field.is_valid()` only checked `isinstance(value, Model)` which rejected strings.
- **`Model.is_valid()` type coercion** — Skips type coercion for `Relationship` fields. Previously, it tried to coerce a string to `Model(value)`, which raised `TypeError`.
- **`encode_popoto_model_obj()`** — Passes through `str` redis_key values directly (they're already in storage format). Previously raised `ModelException` for non-Model values.

## Test plan

- [x] New test: load model via `query.all()` (lazy), re-save without accessing relationship — previously raised `ModelException`
- [x] New test: load-modify-save pattern with non-relationship field change
- [x] New test: `Relationship.is_valid()` accepts valid redis_key strings
- [x] New test: `Relationship.is_valid()` rejects invalid strings (no colon)
- [x] New test: `Relationship.is_valid()` rejects `None` when `null=False`
- [x] All 177 existing tests pass (full suite)