### PR TITLE
Add Model.pk property

### DIFF
--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -616,6 +616,18 @@ class Model(metaclass=ModelBase):
         # todo: create set of possible custom field keys
 
     @property
+    def pk(self) -> str:
+        """The primary key string for this instance.
+
+        Returns the cached Redis key if available, otherwise computes it
+        from current KeyField values. Follows Django convention.
+
+        Returns:
+            The Redis key string identifying this instance.
+        """
+        return self._redis_key or self.db_key.redis_key
+
+    @property
     def db_key(self) -> DB_key:
         """Compute the Redis key for this instance.
 


### PR DESCRIPTION
## Summary
- Adds a `pk` property to `Model` that returns the instance's primary key string
- Returns cached `_redis_key` when available, falls back to `db_key.redis_key`
- Follows Django convention (`instance.pk`) for discoverability

## Test plan
- [x] Verified `pk` returns correct key before save, after save, and after load
- [x] Verified `pk` works with auto-key models
- [x] Full test suite passes (177 passed)

Closes #116