### PR TITLE
Add to_dict() method for cleaner data access (#127)

### DIFF
--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -1315,6 +1315,146 @@ class Model(metaclass=ModelBase):
             "query_filters": query_filters,
         }
 
+    def to_dict(
+        self,
+        include=None,
+        exclude=None,
+        relationships=False,
+        max_depth=None,
+        _seen=None,
+    ) -> dict:
+        """Convert the model instance to a plain dictionary.
+
+        Iterates over all explicit (public) fields and collects their current
+        values via ``getattr()``.  Relationship fields receive special handling
+        so that circular references are safely detected and the caller can
+        choose between shallow (redis_key string) and deep (nested dict)
+        representations.
+
+        Args:
+            include: Optional set or list of field names to include.  When
+                provided, only these fields appear in the output.
+            exclude: Optional set or list of field names to exclude.
+            relationships: If ``True``, recursively call ``to_dict()`` on
+                related Model instances to produce nested dicts.  Defaults
+                to ``False``, which emits the redis_key string instead.
+            max_depth: Maximum recursion depth for nested relationships.
+                ``None`` means unlimited.  When the depth counter reaches
+                ``0``, related instances fall back to their redis_key string
+                regardless of the ``relationships`` flag.
+            _seen: Internal set of redis_key strings used for circular
+                reference detection.  Callers should not pass this directly.
+
+        Returns:
+            A dict mapping field names to their Python values.
+
+        Examples:
+            Basic usage -- all fields, relationships as redis_key strings::
+
+                user = User(email="alice@example.com", name="Alice")
+                user.to_dict()
+                # {'email': 'alice@example.com', 'name': 'Alice'}
+
+            With include/exclude filtering::
+
+                user.to_dict(include={'email'})
+                # {'email': 'alice@example.com'}
+
+                user.to_dict(exclude={'name'})
+                # {'email': 'alice@example.com'}
+
+            Expanding relationships into nested dicts::
+
+                class Author(Model):
+                    name = KeyField()
+
+                class Book(Model):
+                    title = KeyField()
+                    author = Relationship(model=Author)
+
+                book.to_dict(relationships=True)
+                # {'title': 'Hobbit', 'author': {'name': 'Tolkien'}}
+
+            Circular reference protection::
+
+                # When two models reference each other, the second occurrence
+                # is serialised as the redis_key string to break the cycle.
+                a.to_dict(relationships=True)
+                # {'friend': {'friend': 'Person:a'}}
+        """
+        # Import Relationship at function level to avoid circular imports
+        from ..fields.relationship import Relationship
+
+        if include is not None:
+            include = set(include)
+        if exclude is not None:
+            exclude = set(exclude)
+
+        if _seen is None:
+            _seen = set()
+
+        # Register current instance to detect circular references
+        current_key = self.db_key.redis_key
+        _seen = _seen | {current_key}
+
+        result = {}
+        for field_name, field in self._meta.explicit_fields.items():
+            # Apply include/exclude filtering
+            if include is not None and field_name not in include:
+                continue
+            if exclude is not None and field_name in exclude:
+                continue
+
+            value = getattr(self, field_name)
+
+            if isinstance(field, Relationship):
+                if value is None:
+                    result[field_name] = None
+                elif isinstance(value, str):
+                    # Lazy-loaded redis_key string
+                    if relationships and (max_depth is None or max_depth > 0):
+                        if value not in _seen:
+                            # Try to load the related instance for expansion
+                            related_instance = field.model.query.get(redis_key=value)
+                            if related_instance is not None:
+                                next_depth = (
+                                    None if max_depth is None else max_depth - 1
+                                )
+                                result[field_name] = related_instance.to_dict(
+                                    relationships=relationships,
+                                    max_depth=next_depth,
+                                    _seen=_seen,
+                                )
+                            else:
+                                result[field_name] = value
+                        else:
+                            result[field_name] = value
+                    else:
+                        result[field_name] = value
+                elif isinstance(value, Model):
+                    related_key = value.db_key.redis_key
+                    should_expand = (
+                        relationships
+                        and (max_depth is None or max_depth > 0)
+                        and related_key not in _seen
+                    )
+                    if should_expand:
+                        next_depth = None if max_depth is None else max_depth - 1
+                        result[field_name] = value.to_dict(
+                            relationships=relationships,
+                            max_depth=next_depth,
+                            _seen=_seen,
+                        )
+                    else:
+                        result[field_name] = related_key
+                else:
+                    # Unexpected type -- include raw value
+                    result[field_name] = value
+            else:
+                result[field_name] = value
+
+        return result
+
     # Async methods using native redis.asyncio
     #
     # Note: async_save and async_delete use to_thread() because they involve

--- a/tests/test_to_dict.py
+++ b/tests/test_to_dict.py
@@ -1,0 +1,359 @@
+"""Tests for Model.to_dict() serialization method."""
+
+import pytest
+from popoto import Model, Field, KeyField, SortedField, Relationship
+from popoto.redis_db import POPOTO_REDIS_DB
+
+# ---------------------------------------------------------------------------
+# Test models
+# ---------------------------------------------------------------------------
+
+
+class SimpleModel(Model):
+    name = KeyField()
+    value = Field(type=str, null=True)
+
+
+class Author(Model):
+    name = KeyField()
+    bio = Field(type=str, null=True)
+
+
+class Book(Model):
+    title = KeyField()
+    pages = Field(type=int, null=True)
+    author = Relationship(model=Author)
+
+
+class PersonA(Model):
+    name = KeyField()
+
+
+class PersonB(Model):
+    name = KeyField()
+
+
+# Add cross-referencing relationships after class definition
+PersonA.friend = Relationship(model=PersonB, null=True)
+PersonA._meta.add_field("friend", PersonA.friend)
+
+PersonB.friend = Relationship(model=PersonA, null=True)
+PersonB._meta.add_field("friend", PersonB.friend)
+
+
+class ScoredItem(Model):
+    label = KeyField()
+    score = SortedField()
+
+
+# Chain models: C -> B -> A (no circular ref)
+class ChainA(Model):
+    name = KeyField()
+
+
+class ChainB(Model):
+    name = KeyField()
+    ref = Relationship(model=ChainA, null=True)
+
+
+class ChainC(Model):
+    name = KeyField()
+    ref = Relationship(model=ChainB, null=True)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MODEL_CLASSES = [
+    SimpleModel,
+    Author,
+    Book,
+    PersonA,
+    PersonB,
+    ScoredItem,
+    ChainA,
+    ChainB,
+    ChainC,
+]
+
+
+def _cleanup():
+    """Clean up Redis test data for all test model classes."""
+    for cls in MODEL_CLASSES:
+        pattern = f"{cls.__name__}:*"
+        for key in POPOTO_REDIS_DB.keys(pattern):
+            POPOTO_REDIS_DB.delete(key)
+        # Clean class sets
+        class_set_key = f"$Class:{cls.__name__}"
+        POPOTO_REDIS_DB.delete(class_set_key)
+    # Clean relationship index keys
+    for pattern in ["$RelationshipF:*"]:
+        for key in POPOTO_REDIS_DB.keys(pattern):
+            POPOTO_REDIS_DB.delete(key)
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    """Clean up test data before and after each test."""
+    _cleanup()
+    yield
+    _cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Basic serialization
+# ---------------------------------------------------------------------------
+
+
+class TestBasicToDict:
+    def test_simple_model_all_fields(self):
+        """to_dict() returns all explicit fields."""
+        obj = SimpleModel.create(name="hello", value="world")
+        d = obj.to_dict()
+        assert d == {"name": "hello", "value": "world"}
+
+    def test_simple_model_null_field(self):
+        """Null field values appear as None in dict."""
+        obj = SimpleModel.create(name="hello")
+        d = obj.to_dict()
+        assert d == {"name": "hello", "value": None}
+
+    def test_sorted_field_included(self):
+        """SortedField values appear in to_dict output."""
+        obj = ScoredItem.create(label="item1", score=42.5)
+        d = obj.to_dict()
+        assert d["label"] == "item1"
+        assert d["score"] == 42.5
+
+    def test_returns_dict_type(self):
+        """Return type is a plain dict."""
+        obj = SimpleModel.create(name="test", value="v")
+        result = obj.to_dict()
+        assert type(result) is dict
+
+    def test_hidden_fields_excluded(self):
+        """Hidden fields (underscore-prefixed) are not in output."""
+        obj = SimpleModel.create(name="test", value="v")
+        d = obj.to_dict()
+        for key in d:
+            assert not key.startswith("_"), f"Hidden field {key} should not appear"
+
+
+# ---------------------------------------------------------------------------
+# Include / exclude filtering
+# ---------------------------------------------------------------------------
+
+
+class TestIncludeExclude:
+    def test_include_single_field(self):
+        """include limits output to specified fields."""
+        obj = SimpleModel.create(name="hello", value="world")
+        d = obj.to_dict(include={"name"})
+        assert d == {"name": "hello"}
+
+    def test_include_as_list(self):
+        """include accepts a list as well as a set."""
+        obj = SimpleModel.create(name="hello", value="world")
+        d = obj.to_dict(include=["name"])
+        assert d == {"name": "hello"}
+
+    def test_exclude_single_field(self):
+        """exclude removes specified fields from output."""
+        obj = SimpleModel.create(name="hello", value="world")
+        d = obj.to_dict(exclude={"value"})
+        assert d == {"name": "hello"}
+
+    def test_exclude_as_list(self):
+        """exclude accepts a list as well as a set."""
+        obj = SimpleModel.create(name="hello", value="world")
+        d = obj.to_dict(exclude=["value"])
+        assert d == {"name": "hello"}
+
+    def test_include_nonexistent_field(self):
+        """Including a nonexistent field simply omits it (no error)."""
+        obj = SimpleModel.create(name="hello", value="world")
+        d = obj.to_dict(include={"name", "nonexistent"})
+        assert d == {"name": "hello"}
+
+    def test_exclude_nonexistent_field(self):
+        """Excluding a nonexistent field has no effect."""
+        obj = SimpleModel.create(name="hello", value="world")
+        d = obj.to_dict(exclude={"nonexistent"})
+        assert d == {"name": "hello", "value": "world"}
+
+    def test_include_relationship_field(self):
+        """include can include a relationship field."""
+        author = Author.create(name="Tolkien", bio="Fantasy author")
+        book = Book.create(title="Hobbit", pages=310, author=author)
+        d = book.to_dict(include={"title", "author"})
+        assert "title" in d
+        assert "author" in d
+        assert "pages" not in d
+
+    def test_exclude_relationship_field(self):
+        """exclude can exclude a relationship field."""
+        author = Author.create(name="Tolkien", bio="Fantasy author")
+        book = Book.create(title="Hobbit", pages=310, author=author)
+        d = book.to_dict(exclude={"author"})
+        assert "author" not in d
+        assert d == {"title": "Hobbit", "pages": 310}
+
+
+# ---------------------------------------------------------------------------
+# Relationship handling (default shallow mode)
+# ---------------------------------------------------------------------------
+
+
+class TestRelationshipShallow:
+    def test_relationship_as_redis_key(self):
+        """By default, relationships are serialized as redis_key strings."""
+        author = Author.create(name="Tolkien", bio="Fantasy author")
+        book = Book.create(title="Hobbit", pages=310, author=author)
+        d = book.to_dict()
+        assert d["title"] == "Hobbit"
+        assert d["pages"] == 310
+        # The relationship should be a redis_key string
+        assert isinstance(d["author"], str)
+        assert "Tolkien" in d["author"]
+
+    def test_null_relationship(self):
+        """Null relationships appear as None."""
+        book = Book.create(title="Orphan", pages=100, author=None)
+        d = book.to_dict()
+        assert d["author"] is None
+
+
+# ---------------------------------------------------------------------------
+# Relationship expansion (relationships=True)
+# ---------------------------------------------------------------------------
+
+
+class TestRelationshipExpansion:
+    def test_expand_relationship(self):
+        """relationships=True produces nested dict for related instance."""
+        author = Author.create(name="Tolkien", bio="Fantasy author")
+        book = Book.create(title="Hobbit", pages=310, author=author)
+        d = book.to_dict(relationships=True)
+        assert isinstance(d["author"], dict)
+        assert d["author"]["name"] == "Tolkien"
+        assert d["author"]["bio"] == "Fantasy author"
+
+    def test_expand_null_relationship(self):
+        """Null relationships remain None even with relationships=True."""
+        book = Book.create(title="Orphan", pages=100, author=None)
+        d = book.to_dict(relationships=True)
+        assert d["author"] is None
+
+    def test_circular_reference_protection(self):
+        """Circular references fall back to redis_key string."""
+        alice = PersonA.create(name="alice", friend=None)
+        bob = PersonB.create(name="bob", friend=alice)
+        # Update alice to point to bob (circular)
+        alice.friend = bob
+        alice.save()
+        # Reload to get fresh state
+        alice = PersonA.query.get(name="alice")
+
+        d = alice.to_dict(relationships=True)
+        # alice -> bob should be expanded
+        assert isinstance(d["friend"], dict)
+        assert d["friend"]["name"] == "bob"
+        # bob -> alice should be a redis_key string (circular ref)
+        friend_of_friend = d["friend"]["friend"]
+        assert isinstance(friend_of_friend, str)
+        assert "alice" in friend_of_friend
+
+
+# ---------------------------------------------------------------------------
+# max_depth limiting
+# ---------------------------------------------------------------------------
+
+
+class TestMaxDepth:
+    def test_max_depth_zero(self):
+        """max_depth=0 prevents any relationship expansion."""
+        author = Author.create(name="Tolkien", bio="Fantasy author")
+        book = Book.create(title="Hobbit", pages=310, author=author)
+        d = book.to_dict(relationships=True, max_depth=0)
+        # Should be redis_key string, not expanded
+        assert isinstance(d["author"], str)
+
+    def test_max_depth_one_chain(self):
+        """max_depth=1 expands one level then falls back to redis_key."""
+        a = ChainA.create(name="alpha")
+        b = ChainB.create(name="beta", ref=a)
+        c = ChainC.create(name="gamma", ref=b)
+
+        d = c.to_dict(relationships=True, max_depth=1)
+        # gamma -> beta should be expanded (depth 1)
+        assert isinstance(d["ref"], dict)
+        assert d["ref"]["name"] == "beta"
+        # beta -> alpha should be redis_key string (depth exhausted)
+        assert isinstance(d["ref"]["ref"], str)
+        assert "alpha" in d["ref"]["ref"]
+
+    def test_max_depth_two_chain(self):
+        """max_depth=2 expands two levels in a chain."""
+        a = ChainA.create(name="alpha")
+        b = ChainB.create(name="beta", ref=a)
+        c = ChainC.create(name="gamma", ref=b)
+
+        d = c.to_dict(relationships=True, max_depth=2)
+        # gamma -> beta should be expanded
+        assert isinstance(d["ref"], dict)
+        assert d["ref"]["name"] == "beta"
+        # beta -> alpha should also be expanded (depth 2 allows it)
+        assert isinstance(d["ref"]["ref"], dict)
+        assert d["ref"]["ref"]["name"] == "alpha"
+
+    def test_max_depth_none_is_unlimited(self):
+        """max_depth=None (default) allows unlimited expansion."""
+        author = Author.create(name="Tolkien", bio="Fantasy author")
+        book = Book.create(title="Hobbit", pages=310, author=author)
+        d = book.to_dict(relationships=True, max_depth=None)
+        assert isinstance(d["author"], dict)
+        assert d["author"]["name"] == "Tolkien"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_unsaved_instance(self):
+        """to_dict works on an unsaved instance."""
+        obj = SimpleModel(name="unsaved", value="data")
+        d = obj.to_dict()
+        assert d == {"name": "unsaved", "value": "data"}
+
+    def test_empty_include_returns_empty_dict(self):
+        """An empty include set produces an empty dict."""
+        obj = SimpleModel.create(name="hello", value="world")
+        d = obj.to_dict(include=set())
+        assert d == {}
+
+    def test_include_and_exclude_combined(self):
+        """When both include and exclude are given, both are applied."""
+        author = Author.create(name="Tolkien", bio="Fantasy author")
+        book = Book.create(title="Hobbit", pages=310, author=author)
+        # Include title and pages, then exclude pages
+        d = book.to_dict(include={"title", "pages"}, exclude={"pages"})
+        assert d == {"title": "Hobbit"}
+
+    def test_to_dict_does_not_modify_instance(self):
+        """Calling to_dict does not alter the model instance."""
+        obj = SimpleModel.create(name="hello", value="world")
+        original_name = obj.name
+        original_value = obj.value
+        obj.to_dict()
+        assert obj.name == original_name
+        assert obj.value == original_value
+
+    def test_to_dict_after_reload(self):
+        """to_dict works correctly on instances loaded from Redis."""
+        SimpleModel.create(name="reloaded", value="data")
+        loaded = SimpleModel.query.get(name="reloaded")
+        d = loaded.to_dict()
+        assert d == {"name": "reloaded", "value": "data"}


### PR DESCRIPTION
## Summary
- Add `Model.to_dict()` method that converts model instances to plain dicts
- Iterates `_meta.explicit_fields` to collect field values, excluding internal state
- Relationship fields default to redis_key strings; opt-in recursive expansion with `relationships=True`
- Circular reference protection via `_seen` set tracking
- `max_depth` parameter limits recursion depth
- `include`/`exclude` parameters for field filtering

## Changes
- `src/popoto/models/base.py` - Added `to_dict()` method to Model class (+142 lines)
- `tests/test_to_dict.py` - 27 tests across 6 test classes covering all scenarios

## Testing
- [x] 27 new tests passing (`pytest tests/test_to_dict.py -v`)
- [x] Full test suite passing (194 passed, 10 skipped)
- [x] No regressions

Closes #127