### PR TITLE
Range queries on SortedField (__between)

### DIFF
--- a/src/popoto/fields/field.py
+++ b/src/popoto/fields/field.py
@@ -341,6 +341,26 @@ class Field(metaclass=FieldBase):
 
         return Expression(self.name, "__lte", value)
 
+    def between(self, low, high):
+        """Create a between expression for inclusive range query filtering.
+
+        Returns an Expression that matches values where low <= field <= high.
+        This is a convenience method equivalent to combining >= and <= operators.
+
+        Args:
+            low: The lower bound of the range (inclusive)
+            high: The upper bound of the range (inclusive)
+
+        Returns:
+            Expression representing low <= field <= high
+
+        Example:
+            Model.price.between(10, 50)  # Returns Expression(price__between=(10, 50))
+        """
+        from ..models.expressions import Expression
+
+        return Expression(self.name, "__between", (low, high))
+
     @classmethod
     def is_valid(cls, field, value, null_check=True, **kwargs) -> bool:
         """

--- a/src/popoto/fields/sorted_field_mixin.py
+++ b/src/popoto/fields/sorted_field_mixin.py
@@ -194,7 +194,7 @@ class SortedFieldMixin:
                     f"{field_name}__gte",
                     f"{field_name}__lt",
                     f"{field_name}__lte",
-                    # f'{field_name}__range',  # todo: like https://docs.djangoproject.com/en/3.2/ref/models/querysets/#range
+                    f"{field_name}__between",
                     # f'{field_name}__isnull',  # todo: see todo in __init__
                 }
             )
@@ -505,6 +505,20 @@ class SortedFieldMixin:
 
         for query_param, query_value in query_params.items():
             if field_name not in query_param:
+                continue
+
+            if "__between" in query_param:
+                if not isinstance(query_value, (tuple, list)) or len(query_value) != 2:
+                    raise QueryException(
+                        f"{field_name}__between requires a tuple or list of exactly "
+                        f"2 elements (low, high), got {query_value!r}"
+                    )
+                low, high = query_value
+                field_obj = model_class._meta.fields[field_name]
+                numeric_low = cls.convert_to_numeric(field_obj, low)
+                numeric_high = cls.convert_to_numeric(field_obj, high)
+                value_range["min"] = f"{numeric_low}"
+                value_range["max"] = f"{numeric_high}"
                 continue
 
             numeric_value = cls.convert_to_numeric(

--- a/tests/test_expression_queries.py
+++ b/tests/test_expression_queries.py
@@ -260,6 +260,67 @@ assert len(results) == 4
 print("  PASSED: Filter returns all matching records")
 
 
+# ===================================================================
+# .between() expression method tests
+# ===================================================================
+
+# Test 21: Expression creation with .between()
+print("Test 21: Expression creation with .between()")
+expr = Restaurant.rating.between(3.5, 4.5)
+assert isinstance(expr, Expression)
+assert expr.field_name == "rating"
+assert expr.operator == "__between"
+assert expr.value == (3.5, 4.5)
+assert expr.to_kwargs() == {"rating__between": (3.5, 4.5)}
+print("  PASSED: .between() creates correct Expression")
+
+# Test 22: .between() expression in filter
+print("Test 22: .between() expression in filter")
+results = Restaurant.query.filter(Restaurant.rating.between(3.5, 4.5))
+# Burger Palace (4.5), Pizza Corner (3.5), Taco Town (4.0)
+assert len(results) == 3, f"Expected 3, got {len(results)}"
+names = {r.name for r in results}
+assert names == {"Burger Palace", "Pizza Corner", "Taco Town"}, f"Got {names}"
+print("  PASSED: .between() expression in filter")
+
+# Test 23: .between() expression on integer field
+print("Test 23: .between() expression on integer field")
+results = Restaurant.query.filter(Restaurant.price_level.between(1, 2))
+# Burger Palace (2), Pizza Corner (1), Taco Town (1)
+assert len(results) == 3, f"Expected 3, got {len(results)}"
+names = {r.name for r in results}
+assert names == {"Burger Palace", "Pizza Corner", "Taco Town"}, f"Got {names}"
+print("  PASSED: .between() expression on integer field")
+
+# Test 24: .between() combined with other expressions using AND
+print("Test 24: .between() combined with other expressions using AND")
+combined = Restaurant.rating.between(4.0, 5.0) & (Restaurant.cuisine == "Japanese")
+assert isinstance(combined, CombinedExpression)
+results = Restaurant.query.filter(combined)
+assert len(results) == 1, f"Expected 1, got {len(results)}"
+assert results[0].name == "Sushi Master"
+print("  PASSED: .between() combined with AND")
+
+# Test 25: .between() combined with other expressions using OR
+print("Test 25: .between() combined with other expressions using OR")
+combined = Restaurant.rating.between(4.4, 5.0) | (Restaurant.cuisine == "Mexican")
+results = Restaurant.query.filter(combined)
+# Burger Palace (4.5), Sushi Master (4.8) from between, Taco Town from Mexican
+assert len(results) == 3, f"Expected 3, got {len(results)}"
+names = {r.name for r in results}
+assert names == {"Burger Palace", "Sushi Master", "Taco Town"}, f"Got {names}"
+print("  PASSED: .between() combined with OR")
+
+# Test 26: .between() repr
+print("Test 26: .between() repr")
+expr = Restaurant.rating.between(3.0, 5.0)
+repr_str = repr(expr)
+assert "rating" in repr_str
+assert "__between" in repr_str
+print(f"  Expression repr: {repr_str}")
+print("  PASSED: .between() repr")
+
+
 # Cleanup
 print("\nCleaning up test data...")
 for r in Restaurant.query.all():

--- a/tests/test_sortedfield.py
+++ b/tests/test_sortedfield.py
@@ -8,6 +8,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
 
 from src import popoto
+from src.popoto.models.query import QueryException
 
 
 class SortedDateModel(popoto.Model):
@@ -132,3 +133,183 @@ assert list(values_result[4].keys()) == ["timestamp", "price"]
 
 for sam in SortedAssetsModel.objects.all():
     sam.delete()
+
+
+# ===================================================================
+# __between range query tests
+# ===================================================================
+
+
+# Test __between with int SortedField
+print("Test: __between with int SortedField")
+
+
+class BetweenIntModel(popoto.Model):
+    name = popoto.KeyField()
+    score = popoto.SortedField(type=int)
+
+
+bi_a = BetweenIntModel.create(name="a", score=1)
+bi_b = BetweenIntModel.create(name="b", score=5)
+bi_c = BetweenIntModel.create(name="c", score=10)
+bi_d = BetweenIntModel.create(name="d", score=15)
+
+results = BetweenIntModel.query.filter(score__between=(5, 10))
+assert len(results) == 2, f"Expected 2, got {len(results)}"
+names = {r.name for r in results}
+assert names == {"b", "c"}, f"Expected {{'b', 'c'}}, got {names}"
+print("  PASSED: __between with int SortedField")
+
+for item in BetweenIntModel.query.all():
+    item.delete()
+
+# Test __between with float SortedField
+print("Test: __between with float SortedField")
+
+
+class BetweenFloatModel(popoto.Model):
+    name = popoto.KeyField()
+    height = popoto.SortedField(type=float)
+
+
+bf_a = BetweenFloatModel.create(name="a", height=1.5)
+bf_b = BetweenFloatModel.create(name="b", height=2.0)
+bf_c = BetweenFloatModel.create(name="c", height=2.5)
+bf_d = BetweenFloatModel.create(name="d", height=3.0)
+
+results = BetweenFloatModel.query.filter(height__between=(2.0, 2.5))
+assert len(results) == 2, f"Expected 2, got {len(results)}"
+names = {r.name for r in results}
+assert names == {"b", "c"}, f"Expected {{'b', 'c'}}, got {names}"
+print("  PASSED: __between with float SortedField")
+
+for item in BetweenFloatModel.query.all():
+    item.delete()
+
+# Test __between with Decimal SortedField
+print("Test: __between with Decimal SortedField")
+
+
+class BetweenDecimalModel(popoto.Model):
+    name = popoto.KeyField()
+    price = popoto.SortedField(type=Decimal)
+
+
+bd_a = BetweenDecimalModel.create(name="a", price=Decimal("9.99"))
+bd_b = BetweenDecimalModel.create(name="b", price=Decimal("19.99"))
+bd_c = BetweenDecimalModel.create(name="c", price=Decimal("29.99"))
+bd_d = BetweenDecimalModel.create(name="d", price=Decimal("39.99"))
+
+results = BetweenDecimalModel.query.filter(
+    price__between=(Decimal("10.00"), Decimal("30.00"))
+)
+assert len(results) == 2, f"Expected 2, got {len(results)}"
+names = {r.name for r in results}
+assert names == {"b", "c"}, f"Expected {{'b', 'c'}}, got {names}"
+print("  PASSED: __between with Decimal SortedField")
+
+for item in BetweenDecimalModel.query.all():
+    item.delete()
+
+# Test __between with datetime SortedField
+print("Test: __between with datetime SortedField")
+
+
+class BetweenDatetimeModel(popoto.Model):
+    name = popoto.KeyField()
+    created = popoto.SortedField(type=datetime)
+
+
+bdt_a = BetweenDatetimeModel.create(name="a", created=datetime(2022, 1, 1, 0))
+bdt_b = BetweenDatetimeModel.create(name="b", created=datetime(2022, 1, 1, 6))
+bdt_c = BetweenDatetimeModel.create(name="c", created=datetime(2022, 1, 1, 12))
+bdt_d = BetweenDatetimeModel.create(name="d", created=datetime(2022, 1, 1, 18))
+
+results = BetweenDatetimeModel.query.filter(
+    created__between=(datetime(2022, 1, 1, 6), datetime(2022, 1, 1, 12))
+)
+assert len(results) == 2, f"Expected 2, got {len(results)}"
+names = {r.name for r in results}
+assert names == {"b", "c"}, f"Expected {{'b', 'c'}}, got {names}"
+print("  PASSED: __between with datetime SortedField")
+
+for item in BetweenDatetimeModel.query.all():
+    item.delete()
+
+# Test __between with date SortedField
+print("Test: __between with date SortedField")
+
+
+class BetweenDateModel(popoto.Model):
+    name = popoto.KeyField()
+    birthday = popoto.SortedField(type=date)
+
+
+bda_a = BetweenDateModel.create(name="a", birthday=date(1990, 1, 1))
+bda_b = BetweenDateModel.create(name="b", birthday=date(1995, 6, 15))
+bda_c = BetweenDateModel.create(name="c", birthday=date(2000, 12, 31))
+bda_d = BetweenDateModel.create(name="d", birthday=date(2005, 3, 20))
+
+results = BetweenDateModel.query.filter(
+    birthday__between=(date(1995, 1, 1), date(2001, 1, 1))
+)
+assert len(results) == 2, f"Expected 2, got {len(results)}"
+names = {r.name for r in results}
+assert names == {"b", "c"}, f"Expected {{'b', 'c'}}, got {names}"
+print("  PASSED: __between with date SortedField")
+
+for item in BetweenDateModel.query.all():
+    item.delete()
+
+# Test __between with partitioned SortedField (sort_by)
+print("Test: __between with partitioned SortedField (sort_by)")
+
+
+class BetweenPartitionedModel(popoto.Model):
+    uuid = popoto.AutoKeyField(auto_uuid_length=6)
+    category = popoto.KeyField()
+    price = popoto.SortedField(type=float, sort_by="category")
+
+
+bp_a = BetweenPartitionedModel.create(category="fruit", price=1.50)
+bp_b = BetweenPartitionedModel.create(category="fruit", price=3.00)
+bp_c = BetweenPartitionedModel.create(category="fruit", price=5.00)
+bp_d = BetweenPartitionedModel.create(category="veggie", price=3.00)
+
+results = BetweenPartitionedModel.query.filter(
+    category="fruit", price__between=(2.00, 4.00)
+)
+assert len(results) == 1, f"Expected 1, got {len(results)}"
+assert results[0].price == 3.00
+print("  PASSED: __between with partitioned SortedField")
+
+for item in BetweenPartitionedModel.query.all():
+    item.delete()
+
+# Test __between error: non-tuple value
+print("Test: __between error with non-tuple value")
+try:
+    BetweenIntModel.create(name="x", score=5)
+    list(BetweenIntModel.query.filter(score__between=42))
+    assert False, "Should have raised QueryException"
+except QueryException as e:
+    assert "tuple or list" in str(e), f"Unexpected error message: {e}"
+    print(f"  PASSED: Raised QueryException: {e}")
+finally:
+    for item in BetweenIntModel.query.all():
+        item.delete()
+
+# Test __between error: tuple of wrong length
+print("Test: __between error with wrong-length tuple")
+try:
+    BetweenIntModel.create(name="x", score=5)
+    list(BetweenIntModel.query.filter(score__between=(1, 2, 3)))
+    assert False, "Should have raised QueryException"
+except QueryException as e:
+    assert "2 elements" in str(e), f"Unexpected error message: {e}"
+    print(f"  PASSED: Raised QueryException: {e}")
+finally:
+    for item in BetweenIntModel.query.all():
+        item.delete()
+
+print("\nAll __between tests passed!")


### PR DESCRIPTION
## Summary
- Add `__between` range query operator for SortedField, enabling `Model.query.filter(field__between=(low, high))`
- Add `.between(low, high)` expression method on Field for Pythonic syntax: `Model.query.filter(Model.field.between(low, high))`
- Both map to a single Redis `ZRANGEBYSCORE` call with inclusive bounds

## Changes
- `src/popoto/fields/sorted_field_mixin.py` - Register `__between` in `get_filter_query_params()`, handle tuple unpacking in `filter_query()` with input validation
- `src/popoto/fields/field.py` - Add `between(self, low, high)` method returning an Expression
- `tests/test_sortedfield.py` - 8 new tests covering int, float, Decimal, datetime, date, partitioned fields, and error cases
- `tests/test_expression_queries.py` - 6 new tests for expression-based `.between()` with AND/OR combinations

## Testing
- [x] All new __between tests passing (14 tests)
- [x] Full test suite passing (194 tests, 0 failures)
- [x] Black formatting check passing

Closes #124