### PR TITLE
DX polish: add last(), get_redis(), and testing module

### DIFF
--- a/src/popoto/__init__.py
+++ b/src/popoto/__init__.py
@@ -37,6 +37,28 @@ from .models.q import Q
 from .models.expressions import Expression, CombinedExpression
 from .pubsub.publisher import Publisher
 from .pubsub.subscriber import Subscriber
+from .redis_db import POPOTO_REDIS_DB, get_async_redis_db
+
+
+def get_redis():
+    """Get the Redis connection for direct Redis operations.
+
+    Use this when you need Redis primitives not exposed by Popoto models:
+    - Sets: SADD, SISMEMBER, SMEMBERS
+    - Lists: RPUSH, LPOP, LRANGE
+    - Pub/Sub: PUBLISH, SUBSCRIBE
+
+    Returns:
+        redis.Redis: The shared Redis connection
+
+    Example:
+        import popoto
+        redis = popoto.get_redis()
+        redis.sadd("my_set", "value")
+        redis.rpush("my_queue", "item")
+    """
+    return POPOTO_REDIS_DB
+
 
 __all__ = [
     "Field",
@@ -72,4 +94,6 @@ __all__ = [
     "QueryException",
     "PublisherException",
     "SubscriberException",
+    "get_redis",
+    "get_async_redis_db",
 ]

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -234,6 +234,18 @@ class QueryBuilder:
         results = self.limit(1).all()
         return results[0] if results else None
 
+    def last(self) -> "Model":
+        """Return the last matching result, or None if no matches.
+
+        Note: For efficient access to the last item in sorted order, use
+        order_by("-field").first() instead. This method fetches all results.
+
+        Returns:
+            Last Model instance or None
+        """
+        results = self.all()
+        return results[-1] if results else None
+
     # List-like behavior for backward compatibility
     def __iter__(self):
         """Iterate over query results (executes query)."""

--- a/src/popoto/testing.py
+++ b/src/popoto/testing.py
@@ -1,0 +1,55 @@
+"""Testing utilities for Popoto.
+
+Provides helpers for test isolation when running tests against Redis.
+
+Example usage in pytest::
+
+    # conftest.py
+    import pytest
+    from popoto.testing import use_test_db, flush_test_db
+
+    @pytest.fixture(scope="session", autouse=True)
+    def setup_test_db():
+        use_test_db(15)
+        yield
+        flush_test_db()
+
+    @pytest.fixture(autouse=True)
+    def clean_db():
+        yield
+        flush_test_db()
+"""
+from .redis_db import set_REDIS_DB_settings, POPOTO_REDIS_DB
+
+
+def use_test_db(db: int = 15):
+    """Switch to a test database for isolated testing.
+
+    Call this in your test setup to use a separate Redis database
+    that won't interfere with development/production data.
+
+    Args:
+        db: Redis database number (0-15). Default is 15.
+
+    Example:
+        from popoto.testing import use_test_db
+
+        def setup_module():
+            use_test_db(15)
+    """
+    set_REDIS_DB_settings(db=db)
+
+
+def flush_test_db():
+    """Flush the current database.
+
+    Use this in test teardown to clean up test data.
+    WARNING: This deletes ALL keys in the current database.
+
+    Example:
+        from popoto.testing import flush_test_db
+
+        def teardown_module():
+            flush_test_db()
+    """
+    POPOTO_REDIS_DB.flushdb()

--- a/tests/test_dx_polish.py
+++ b/tests/test_dx_polish.py
@@ -1,0 +1,110 @@
+"""Tests for DX polish improvements."""
+import pytest
+import popoto
+from popoto import Model, KeyField, Field
+from popoto.testing import use_test_db, flush_test_db
+
+
+class SimpleModel(Model):
+    key = KeyField(type=str)
+    value = Field(type=int, default=0)
+
+
+class TestLast:
+    """Test QueryBuilder.last() method."""
+
+    def setup_method(self):
+        SimpleModel.delete_all()
+
+    def teardown_method(self):
+        SimpleModel.delete_all()
+
+    def test_last_returns_last_result(self):
+        """last() should return the last matching result."""
+        SimpleModel.create(key="a", value=1)
+        SimpleModel.create(key="b", value=2)
+        SimpleModel.create(key="c", value=3)
+
+        # Use filter() to get QueryBuilder, then call last()
+        results = SimpleModel.query.filter().all()
+        last = SimpleModel.query.filter().last()
+
+        assert last is not None
+        assert last.key == results[-1].key
+
+    def test_last_returns_none_when_empty(self):
+        """last() should return None when no results."""
+        result = SimpleModel.query.filter(key="nonexistent").last()
+        assert result is None
+
+    def test_last_with_filter(self):
+        """last() should work with filters."""
+        SimpleModel.create(key="a", value=1)
+        SimpleModel.create(key="b", value=2)
+
+        # Filter to single result
+        result = SimpleModel.query.filter(key="a").last()
+        assert result is not None
+        assert result.key == "a"
+
+    def test_last_with_order_by(self):
+        """last() should respect order_by."""
+        SimpleModel.create(key="a", value=1)
+        SimpleModel.create(key="b", value=2)
+        SimpleModel.create(key="c", value=3)
+
+        # Order by key ascending, last should be "c"
+        result = SimpleModel.query.filter().order_by("key").last()
+        assert result is not None
+        assert result.key == "c"
+
+
+class TestGetRedis:
+    """Test popoto.get_redis() function."""
+
+    def test_get_redis_returns_connection(self):
+        """get_redis() should return a Redis connection."""
+        redis = popoto.get_redis()
+        assert redis is not None
+        # Should be able to ping
+        assert redis.ping() is True
+
+    def test_get_redis_can_do_operations(self):
+        """get_redis() connection should work for Redis operations."""
+        redis = popoto.get_redis()
+        
+        # Test set operations
+        redis.sadd("test_set", "value1", "value2")
+        assert redis.sismember("test_set", "value1")
+        redis.delete("test_set")
+
+        # Test list operations
+        redis.rpush("test_list", "item1", "item2")
+        assert redis.llen("test_list") == 2
+        redis.delete("test_list")
+
+
+class TestGetAsyncRedisDb:
+    """Test popoto.get_async_redis_db() function."""
+
+    @pytest.mark.asyncio
+    async def test_get_async_redis_db_returns_connection(self):
+        """get_async_redis_db() should return an async Redis connection."""
+        redis = await popoto.get_async_redis_db()
+        assert redis is not None
+        # Should be able to ping
+        assert await redis.ping() is True
+
+
+class TestTestingModule:
+    """Test popoto.testing module."""
+
+    def test_use_test_db_import(self):
+        """use_test_db should be importable."""
+        from popoto.testing import use_test_db
+        assert callable(use_test_db)
+
+    def test_flush_test_db_import(self):
+        """flush_test_db should be importable."""
+        from popoto.testing import flush_test_db
+        assert callable(flush_test_db)


### PR DESCRIPTION
## Summary
- Add `QueryBuilder.last()` - returns last matching result
- Add `popoto.get_redis()` - public API for direct Redis access
- Add `popoto.get_async_redis_db` export
- Add `popoto.testing` module with `use_test_db()` and `flush_test_db()`

## Usage

```python
# last() - get last result
result = Model.query.filter(status="active").last()

# get_redis() - direct Redis access
import popoto
redis = popoto.get_redis()
redis.sadd("my_set", "value")

# testing - test isolation
from popoto.testing import use_test_db, flush_test_db
use_test_db(15)  # Switch to DB 15
flush_test_db()  # Clean up after tests
```

## Notes
- Bulk delete already exists via `Model.bulk_delete()`
- Spun off medium items to separate issues:
  - #135 - sort_by → partition_by rename
  - #136 - SortedField ordering in filter
- Dropped KeyField type=int per discussion

## Testing
- [x] 9 new tests passing
- [x] Full test suite passing (233 tests)

Closes #128