### PR TITLE
Add bulk migration utilities: rebuild_indexes() and raw_update()

### DIFF
--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -2234,3 +2234,84 @@ class Model(metaclass=ModelBase):
             Number of instances processed.
         """
         return await to_thread(cls.rebuild_indexes, batch_size=batch_size)
+
+    @classmethod
+    def raw_update(
+        cls, redis_keys: list, batch_size: int = 1000, **field_values
+    ) -> int:
+        """Perform direct HSET updates on Redis hashes without hooks or validation.
+
+        This is a low-level bulk update method designed for data migrations and
+        transformations. It writes field values directly to Redis using HSET,
+        bypassing all ORM machinery (on_save hooks, sorted set index updates,
+        auto_now fields, validation, and class set membership).
+
+        Values are msgpack-encoded to match the format used by normal Model.save(),
+        so data written by raw_update can be read back by normal Model.query.get().
+
+        Because indexes are NOT updated, you should call rebuild_indexes() after
+        raw_update if any SortedField or other indexed fields were modified.
+
+        Args:
+            redis_keys: List of Redis key strings to update. Each key should be
+                a valid model instance key (e.g., "ClassName:key_value").
+            batch_size: Number of HSET commands to pipeline before executing.
+                Larger values use more memory but reduce round-trips. Default 1000.
+            **field_values: Field name/value pairs to set. Field names must
+                correspond to fields defined on the model. Values are encoded
+                using the same msgpack encoding as Model.save().
+
+        Returns:
+            Number of keys that were updated.
+
+        Example:
+            # Update all instances' name field without triggering hooks
+            keys = [inst.db_key.redis_key for inst in MyModel.query.all()]
+            MyModel.raw_update(keys, name="new_value")
+
+            # Rebuild indexes if sorted/indexed fields were changed
+            MyModel.rebuild_indexes()
+        """
+        if not redis_keys:
+            return 0
+
+        from .encoding import TYPE_ENCODER_DECODERS
+        from ..redis_db import ENCODING
+
+        import msgpack
+
+        # Pre-encode all field values once (same encoding for every key)
+        encoded_mapping = {}
+        for field_name, value in field_values.items():
+            field = cls._meta.fields.get(field_name)
+            field_name_bytes = str(field_name).encode(ENCODING)
+
+            if (
+                value is not None
+                and field is not None
+                and field.type in TYPE_ENCODER_DECODERS
+            ):
+                encoded_value = msgpack.packb(
+                    TYPE_ENCODER_DECODERS[field.type].encoder(value)
+                )
+            else:
+                encoded_value = msgpack.packb(value)
+
+            encoded_mapping[field_name_bytes] = encoded_value
+
+        # Pipeline HSET commands in batches
+        count = 0
+        pipeline = POPOTO_REDIS_DB.pipeline()
+        for i, redis_key in enumerate(redis_keys, start=1):
+            pipeline.hset(redis_key, mapping=encoded_mapping)
+            count += 1
+
+            if i % batch_size == 0:
+                pipeline.execute()
+                pipeline = POPOTO_REDIS_DB.pipeline()
+
+        # Execute any remaining commands in the pipeline
+        if count % batch_size != 0:
+            pipeline.execute()
+
+        return count

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -328,3 +328,105 @@ class TestRebuildIndexes:
 
         results = list(MigrationModel.query.filter(score__gte=0.0, score__lte=3.0))
         assert len(results) == 2
+
+
+class TestRawUpdate:
+    """Test Model.raw_update() behavior."""
+
+    def setup_method(self):
+        MigrationModel.delete_all()
+
+    def teardown_method(self):
+        MigrationModel.delete_all()
+
+    def test_raw_update_changes_field_values(self):
+        """raw_update should change field values readable by normal get()."""
+        instance = MigrationModel.create(key="test1", name="original", score=1.0)
+        redis_key = instance.db_key.redis_key
+
+        MigrationModel.raw_update([redis_key], name="updated_via_raw")
+
+        reloaded = MigrationModel.query.get(key="test1")
+        assert reloaded.name == "updated_via_raw"
+
+    def test_raw_update_does_not_trigger_hooks(self):
+        """raw_update should NOT update sorted set indexes."""
+        instance = MigrationModel.create(key="test1", name="original", score=1.0)
+        redis_key = instance.db_key.redis_key
+
+        # raw_update changes score but doesn't update sorted set
+        MigrationModel.raw_update([redis_key], score=99.0)
+
+        # Normal load should show new value
+        reloaded = MigrationModel.query.get(key="test1")
+        assert reloaded.score == 99.0
+
+        # But sorted set still has old score - query by old range finds it
+        results = list(MigrationModel.query.filter(score__gte=0.5, score__lte=1.5))
+        assert len(results) == 1  # Still indexed at old score
+
+        # Query by new range does NOT find it (stale index)
+        results = list(MigrationModel.query.filter(score__gte=98.0, score__lte=100.0))
+        assert len(results) == 0
+
+    def test_raw_update_plus_rebuild_restores_queries(self):
+        """raw_update + rebuild_indexes should restore full query functionality."""
+        instance = MigrationModel.create(key="test1", name="original", score=1.0)
+        redis_key = instance.db_key.redis_key
+
+        MigrationModel.raw_update([redis_key], score=99.0)
+        MigrationModel.rebuild_indexes()
+
+        # Now query by new range should work
+        results = list(MigrationModel.query.filter(score__gte=98.0, score__lte=100.0))
+        assert len(results) == 1
+        assert results[0].key == "test1"
+
+    def test_raw_update_multiple_keys(self):
+        """raw_update should work with multiple redis keys."""
+        inst1 = MigrationModel.create(key="a", name="name_a", score=1.0)
+        inst2 = MigrationModel.create(key="b", name="name_b", score=2.0)
+        inst3 = MigrationModel.create(key="c", name="name_c", score=3.0)
+
+        keys = [
+            inst1.db_key.redis_key,
+            inst2.db_key.redis_key,
+            inst3.db_key.redis_key,
+        ]
+        count = MigrationModel.raw_update(keys, name="bulk_updated")
+        assert count == 3
+
+        for k in ["a", "b", "c"]:
+            assert MigrationModel.query.get(key=k).name == "bulk_updated"
+
+    def test_raw_update_with_batch_size(self):
+        """raw_update should work with batch_size parameter."""
+        instances = [
+            MigrationModel.create(key=f"item_{i}", score=float(i)) for i in range(5)
+        ]
+        keys = [inst.db_key.redis_key for inst in instances]
+
+        count = MigrationModel.raw_update(keys, name="batched", batch_size=2)
+        assert count == 5
+
+        for i in range(5):
+            assert MigrationModel.query.get(key=f"item_{i}").name == "batched"
+
+    def test_raw_update_does_not_update_auto_now(self):
+        """raw_update should NOT trigger auto_now fields."""
+        instance = MigrationModel.create(key="test1", name="original")
+        original_updated = instance.updated_at
+        redis_key = instance.db_key.redis_key
+
+        time.sleep(0.01)
+
+        MigrationModel.raw_update([redis_key], name="raw_changed")
+
+        reloaded = MigrationModel.query.get(key="test1")
+        assert reloaded.updated_at == original_updated  # NOT updated
+        assert reloaded.name == "raw_changed"
+
+    def test_raw_update_returns_zero_for_empty_list(self):
+        """raw_update with empty key list should return 0."""
+        count = MigrationModel.raw_update([], name="nothing")
+        assert count == 0


### PR DESCRIPTION
## Summary
- Adds `Model.rebuild_indexes(batch_size=1000)` classmethod that deletes all secondary indexes and reconstructs them from source hash data using SCAN iteration
- Adds `Model.raw_update(redis_keys, batch_size=1000, **field_values)` classmethod for direct HSET with msgpack encoding, bypassing all hooks and validation
- Adds `Model.async_rebuild_indexes()` async wrapper via `to_thread()`

## Changes
- `src/popoto/models/base.py` — Added 3 new classmethods (+238 lines)
- `tests/test_migrations.py` — Added 12 new tests in `TestRebuildIndexes` and `TestRawUpdate` classes (+193 lines)

## Testing
- [x] 278 tests passing (12 new + 266 existing)
- [x] Zero regressions in existing test suite
- [x] Black formatting passes
- [x] Ruff linting passes (2 pre-existing warnings only)
- [x] Round-trip verified: raw_update() then Model.query.get() reads correct values
- [x] rebuild_indexes() verified for sorted sets, key field sets, geo indexes, class set

## Definition of Done
- [x] Built: All code implemented and working
- [x] Tested: All tests passing
- [x] Documented: Docstrings with usage examples on all methods
- [x] Quality: Lint and format checks pass

**Depends on**: #144 (Save Path Migration Flags)
Closes #134