### PR TITLE
Update docs for index cleanup and save() params

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -58,22 +58,39 @@ restaurant = Restaurant.create(name="Taco Town", cuisine="Mexican", rating=4.2)
 ### Model.save()
 
 ```python
-Model.save(pipeline: redis.client.Pipeline = None, ignore_errors: bool = False, **kwargs)
+Model.save(
+    pipeline: redis.client.Pipeline = None,
+    ignore_errors: bool = False,
+    skip_auto_now: bool = False,
+    update_fields: list = None,
+    **kwargs,
+)
 ```
 
 Persist the instance to Redis using `HSET`. Also triggers all field `on_save` hooks (sorted-set indexes,
 geo indexes, relationship sets, unique constraints, etc.).
 
+If a `KeyField` value has changed since the instance was loaded, `save()` automatically handles the key
+migration: it deletes the old Redis hash, removes the old key from the class set, migrates all field
+indexes to the new key, and adds the new key to the class set. This applies to both full saves and
+partial saves via `update_fields`.
+
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `pipeline` | `redis.client.Pipeline` | Optional pipeline for batching. |
 | `ignore_errors` | `bool` | If `True`, log validation errors instead of raising `ModelException`. |
+| `skip_auto_now` | `bool` | If `True`, suppress `auto_now` timestamp updates. Useful during migrations. |
+| `update_fields` | `list` | Optional list of field names for partial save. Only the listed fields are written to Redis and only their `on_save` hooks fire. An empty list is a no-op. `auto_now` fields are excluded unless explicitly listed. |
 
 **Returns:** Redis `HSET` response (int) or pipeline.
 
 ```python
 restaurant = Restaurant(name="Sushi Spot", cuisine="Japanese", rating=4.8)
 restaurant.save()
+
+# Partial save -- only update the rating field
+restaurant.rating = 4.9
+restaurant.save(update_fields=["rating"])
 ```
 
 ### Model.delete()

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -48,6 +48,31 @@ Because `name` is a `KeyField`, the lookup is a single Redis GET -- the fastest
 possible read operation. See [Making Queries](query.md) for additional ways to
 retrieve instances.
 
+### Changing a KeyField Value
+
+When you change a `KeyField` value and call `save()`, the Redis key itself changes.
+Popoto handles the transition automatically: it deletes the old hash, removes the old
+key from the class set, migrates all field indexes (sorted sets, geo sets, unique
+constraints) from the old key to the new one, and adds the new key to the class set.
+Both full saves and partial saves (`save(update_fields=[...])`) handle this correctly.
+
+```python
+restaurant = Restaurant.create(name="Taco Shack", cuisine="Mexican", rating=4.0)
+
+# Change the KeyField value
+restaurant.name = "Taco Palace"
+restaurant.save()
+
+# Old key is cleaned up, new key is active
+loaded = Restaurant.load(name="Taco Palace")
+print(loaded.cuisine)
+# => "Mexican"
+
+# The old key no longer exists
+print(Restaurant.load(name="Taco Shack"))
+# => None
+```
+
 ## Uniqueness
 
 When two restaurants share the same `name`, the second save overwrites the first. If

--- a/docs/relationship.md
+++ b/docs/relationship.md
@@ -212,7 +212,11 @@ $RelationshipF:MenuItem:restaurant:Restaurant:Burger Palace
 ```
 
 Indexes are created on `save()`, updated when the relationship changes,
-and cleaned up on `delete()`.
+and cleaned up on `delete()`. When you reassign a relationship (e.g.,
+moving a `MenuItem` from one `Restaurant` to another), `save()` removes
+the instance from the old relationship's index set and adds it to the
+new one. This ensures that `filter(restaurant=old_restaurant)` no longer
+returns the moved item.
 
 ### Circular Reference Protection
 


### PR DESCRIPTION
## Summary
- Retroactive documentation update for merged PRs #161, #162, #163
- **fields.md**: New "Changing a KeyField Value" section documenting automatic index cleanup when KeyField values change via `save()`
- **relationship.md**: Expanded Relationship Index section to document that reassigning a relationship properly removes the old index entry
- **api-reference.md**: Added `skip_auto_now` and `update_fields` parameters to `Model.save()` signature, documented obsolete key migration behavior, added partial save example

## Test plan
- [ ] Verify docs render correctly with `mkdocs serve`
- [ ] Confirm code examples match actual API signatures