### PR TITLE
Pre-release cleanup: remove FinanceException and fix test_connection import

### DIFF
--- a/src/popoto/exceptions.py
+++ b/src/popoto/exceptions.py
@@ -25,9 +25,3 @@ class SubscriberException(Exception):
     """Raised when a subscriber's message handler fails."""
 
     pass
-
-
-class FinanceException(Exception):
-    """Base exception for all finance module errors."""
-
-    pass

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -13,6 +13,7 @@ from src.popoto.redis_db import (
     POPOTO_REDIS_DB,
     set_REDIS_DB_settings,
     get_REDIS_DB,
+    check_connection,
 )
 from src.popoto import Model, KeyField, Field
 
@@ -22,19 +23,6 @@ class SimpleModel(Model):
 
     name = KeyField()
     value = Field(type=str, default="")
-
-
-def check_connection() -> bool:
-    """Check if Redis connection is available.
-
-    Returns:
-        True if Redis is reachable, False otherwise.
-    """
-    try:
-        POPOTO_REDIS_DB.ping()
-        return True
-    except (redis.ConnectionError, redis.TimeoutError):
-        return False
 
 
 class TestCheckConnection:


### PR DESCRIPTION
Closes #170

## Changes

- **`src/popoto/exceptions.py`** — Remove `FinanceException`: orphan class from a planned finance module that was never built; not referenced anywhere in the codebase
- **`tests/test_connection.py`** — Remove local `check_connection()` reimplementation; import the real one from `src.popoto.redis_db` so tests exercise the public API

## Test plan

- [ ] `pytest tests/test_connection.py` — all connection tests pass
- [ ] `pytest --ignore=tests/test_dataframe_field.py` — 298 passed, 0 failed