### PR TITLE
Fix mkdocs nav reference to style guide

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ nav:
     - PubSub: 'pubsub.md'
     - API Reference: 'api-reference.md'
     - Contributing:
-        - Style Guide: 'STYLE_GUIDE.md'
+        - Style Guide: 'style-guide.md'
 
 markdown_extensions:
     - admonition


### PR DESCRIPTION
## Summary
- Fix nav entry referencing `STYLE_GUIDE.md` → `style-guide.md` (matching actual filename)
- This was causing `mkdocs build --strict` to fail

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Docs deployed successfully to GitHub Pages