### PR TITLE
Fix PyPI publish trigger for release-please tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "popoto-v*"
 
 jobs:
   release:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
     ".": {
       "release-type": "python",
       "package-name": "popoto",
+      "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,


### PR DESCRIPTION
## Summary
- Release workflow now triggers on both `v*` and `popoto-v*` tags to match release-please's tag format
- Added `include-component-in-tag: false` so future releases use plain `v*` tags

## Context
PR #187 (v1.0.1) merged but PyPI publish didn't trigger because release-please created tag `popoto-v1.0.1` while the workflow only matched `v*`.

## Test plan
- [x] Verify workflow YAML is valid
- [ ] After merge, re-tag or manually trigger PyPI publish for v1.0.1