### PR TITLE
Add CyclicDecayField — temporal rhythms + homeostatic pressure

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -5,7 +5,7 @@ Complete reference for all public classes, methods, and functions in the Popoto 
 ```python
 from popoto import Model, Field, KeyField, AutoKeyField, UniqueKeyField
 from popoto import SortedField, SortedKeyField, GeoField, DatetimeField, Relationship
-from popoto import DecayingSortedField
+from popoto import DecayingSortedField, CyclicDecayField, TemporalPeriod
 from popoto import Publisher, Subscriber
 from popoto import ModelException, QueryException, PublisherException, SubscriberException
 ```
@@ -165,25 +165,52 @@ new_rating = restaurant.atomic_increment("score", 0.5)
 Model.touch(field_name: str, pipeline: redis.client.Pipeline = None)
 ```
 
-Update a `DecayingSortedField`'s timestamp without a full save. Refreshes the decay clock
-by setting the sorted set score to the current time.
+Update a `DecayingSortedField` or `CyclicDecayField` timestamp without a full save. Refreshes
+the decay clock by setting the sorted set score to the current time.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `field_name` | `str` | Name of a `DecayingSortedField` on the model. |
+| `field_name` | `str` | Name of a `DecayingSortedField` or `CyclicDecayField` on the model. |
 | `pipeline` | `redis.client.Pipeline` | Optional pipeline for batching. |
 
 **Returns:** The new timestamp (`float`), or the pipeline if one was provided.
 
 **Raises:**
 
-- `TypeError` if the model has not been saved or the field is not a `DecayingSortedField`.
+- `TypeError` if the model has not been saved or the field is not a `DecayingSortedField` (or subclass).
 - `AttributeError` if `field_name` does not exist on the model.
 
 ```python
 memory = Memory.query.get(agent_id="agent-1")
 new_ts = memory.touch("relevance")
 # The decay clock is reset — this memory will rank higher in top_by_decay()
+```
+
+### Model.resolve\_pressure()
+
+```python
+Model.resolve_pressure(field_name: str, pipeline: redis.client.Pipeline = None)
+```
+
+Reset homeostatic pressure for a `CyclicDecayField` member. Discharges accumulated urgency
+by updating `last_resolved` to the current time in the pressure companion hash.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `field_name` | `str` | Name of a `CyclicDecayField` with `pressure_rate > 0`. |
+| `pipeline` | `redis.client.Pipeline` | Optional pipeline for batching. |
+
+**Returns:** The new `last_resolved` timestamp (`float`), or the pipeline if one was provided.
+
+**Raises:**
+
+- `TypeError` if the model has not been saved, the field is not a `CyclicDecayField`, or `pressure_rate` is 0.
+- `AttributeError` if `field_name` does not exist on the model.
+
+```python
+directive = Directive.query.get(agent_id="agent-1")
+directive.resolve_pressure("relevance")
+# Pressure resets — the record's urgency score drops to 0
 ```
 
 ### Model.load()
@@ -666,17 +693,19 @@ Query.top_by_decay(field_name: str, n: int = 10, decay_rate: float = None, base_
 
 Return top-N instances ranked by time-decayed score. Executes a Lua script server-side
 that computes `base_score * elapsed_days^(-decay_rate)` for each member in the sorted set.
+For `CyclicDecayField`, the Lua script also adds cyclical resonance and homeostatic pressure
+components to the score.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `field_name` | `str` | Name of a `DecayingSortedField` on the model. |
+| `field_name` | `str` | Name of a `DecayingSortedField` or `CyclicDecayField` on the model. |
 | `n` | `int` | Maximum number of results. Default `10`. |
 | `decay_rate` | `float` | Override the field's decay_rate for this query. |
 | `base_score_field` | `str` | Override the field's base_score_field for this query. |
 
 **Returns:** `list` of Model instances in decayed-score order.
 
-**Raises:** `QueryException` if the field is not a `DecayingSortedField` or a required `partition_by` filter is missing.
+**Raises:** `QueryException` if the field is not a `DecayingSortedField` (or subclass) or a required `partition_by` filter is missing.
 
 ```python
 # Top 10 most relevant memories
@@ -839,6 +868,27 @@ usage examples and [Agent Memory](features/agent-memory.md) for the broader cont
 | `decay_rate` | `float` | `0.5` | Controls decay speed. Must be > 0. |
 | `base_score_field` | `str` | `None` | Companion field name for base score multiplier. |
 | `partition_by` | `str` or `tuple` | `()` | Partition the sorted set by key field values. |
+
+### CyclicDecayField
+
+```python
+from popoto.fields.cyclic_decay_field import CyclicDecayField
+
+CyclicDecayField(decay_rate=0.5, base_score_field=None, cycles=[], pressure_rate=0.0, partition_by=(), **kwargs)
+```
+
+A `DecayingSortedField` subclass that adds cyclical resonance and homeostatic pressure
+to time-decayed scoring. All three components are computed atomically in a single Lua script.
+See [CyclicDecayField](features/cyclic-decay-field.md) for usage examples and
+[Agent Memory](features/agent-memory.md) for the broader context.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `decay_rate` | `float` | `0.5` | Controls decay speed (inherited). Must be > 0. |
+| `base_score_field` | `str` | `None` | Companion field name for base score multiplier (inherited). |
+| `cycles` | `list` | `[]` | List of `(period, amplitude, phase)` tuples. Use `TemporalPeriod` constants. |
+| `pressure_rate` | `float` | `0.0` | Rate of urgency buildup per unresolved day. Must be >= 0. |
+| `partition_by` | `str` or `tuple` | `()` | Partition the sorted set by key field values (inherited). |
 
 ### GeoField
 

--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -23,7 +23,7 @@ The primitives ship incrementally. Each builds on the ones before it.
 | Primitive | What it does | Status |
 |-----------|-------------|--------|
 | [DecayingSortedField](#decayingsortedfield) | Time-weighted scoring — records lose relevance over time unless refreshed | Shipped ([PR #199](https://github.com/tomcounsell/popoto/pull/199)) |
-| [CyclicDecayField](#decayingsortedfield) | Temporal rhythms + homeostatic pressure on top of decay | [#196](https://github.com/tomcounsell/popoto/issues/196) |
+| [CyclicDecayField](#cyclicdecayfield) | Temporal rhythms + homeostatic pressure on top of decay | Shipped ([PR #201](https://github.com/tomcounsell/popoto/pull/201)) |
 | [AccessTracker](#accesstracker) | Tracks read patterns — access count, timestamps, spacing effects | [#197](https://github.com/tomcounsell/popoto/issues/197) |
 | [ObservationProtocol](#accesstracker) | Outcome-driven memory effects — acted/dismissed/deferred/contradicted | [#198](https://github.com/tomcounsell/popoto/issues/198) |
 | [WriteFilter](#writefilter) | Gates persistence — low-value records silently discarded at write time | Planned |
@@ -189,6 +189,67 @@ import time
 one_week_ago = time.time() - 86400 * 7
 recent = Memory.query.filter(agent_id="agent-1", relevance__gte=one_week_ago)
 ```
+
+## CyclicDecayField
+
+A `DecayingSortedField` subclass that adds **cyclical resonance** and **homeostatic pressure** to time-weighted scoring. When cycles and pressure are both zero, behavior is identical to `DecayingSortedField`.
+
+The effective score at query time: `decay + cyclic_resonance + pressure`
+
+- **Cyclical resonance** — periodic boosts following cosine curves. A record about Q1 renewals resurfaces every January.
+- **Homeostatic pressure** — urgency that builds linearly while an item goes unresolved. Discharged by calling `resolve_pressure()`.
+
+### Basic usage
+
+```python
+from popoto import Model, KeyField, Field, CyclicDecayField
+from popoto.fields.constants import TemporalPeriod
+
+class Directive(Model):
+    agent_id = KeyField()
+    content = Field(type=str)
+    relevance = CyclicDecayField(
+        decay_rate=0.5,
+        cycles=[(TemporalPeriod.QUARTERLY, 5.0, 0)],
+        pressure_rate=0.1,
+    )
+```
+
+Query with the same `top_by_decay()` interface:
+
+```python
+top = Directive.query.filter(agent_id="agent-1").top_by_decay("relevance", n=10)
+```
+
+Discharge accumulated urgency when the agent acts on a record:
+
+```python
+directive.resolve_pressure("relevance")
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `decay_rate` | `float` | `0.5` | Power-law decay exponent (inherited). |
+| `base_score_field` | `str` | `None` | Companion field whose value multiplies the decay curve (inherited). |
+| `cycles` | `list` | `[]` | List of `(period, amplitude, phase)` tuples. Use `TemporalPeriod` constants for period values. |
+| `pressure_rate` | `float` | `0.0` | Rate of urgency buildup per unresolved day. |
+| `partition_by` | `str`/`tuple` | `()` | Partition sorted set by key fields (inherited). |
+
+### TemporalPeriod constants
+
+Import from `popoto.fields.constants`:
+
+| Constant | Value (seconds) | Usage |
+|----------|----------------|-------|
+| `TemporalPeriod.DAILY` | 86,400 | Daily check-ins |
+| `TemporalPeriod.WEEKLY` | 604,800 | Weekly reviews |
+| `TemporalPeriod.MONTHLY` | 2,592,000 | Monthly reports |
+| `TemporalPeriod.QUARTERLY` | 7,776,000 | Quarterly planning |
+| `TemporalPeriod.YEARLY` | 31,536,000 | Annual cycles |
+
+See [CyclicDecayField feature docs](cyclic-decay-field.md) for the full reference including the scoring formula, Redis data model, and error handling.
 
 ## AccessTracker
 
@@ -377,7 +438,7 @@ These primitives follow Popoto's existing patterns:
 
 2. **Redis-native everything.** No external brokers or job queues. Lua scripts, sorted sets, streams, Bloom filters — all within the Redis process.
 
-3. **Composable.** Each primitive is independently useful. Use `DecayingSortedField` alone for time-weighted ranking, or combine all twelve for a full cognitive memory system.
+3. **Composable.** Each primitive is independently useful. Use `DecayingSortedField` alone for time-weighted ranking, add `CyclicDecayField` for temporal rhythms and urgency, or combine all twelve for a full cognitive memory system.
 
 4. **Pipeline-safe.** Every operation accepts an optional `pipeline` parameter for atomic execution, consistent with all Popoto field hooks.
 

--- a/docs/features/cyclic-decay-field.md
+++ b/docs/features/cyclic-decay-field.md
@@ -1,0 +1,117 @@
+# CyclicDecayField
+
+A `DecayingSortedField` subclass that adds cyclical resonance and homeostatic pressure to time-weighted scoring.
+
+## Overview
+
+`CyclicDecayField` extends `DecayingSortedField` with two additional temporal forces computed atomically in a single Lua script:
+
+1. **Cyclical resonance**: Periodic boosts following cosine curves. A record about Q1 renewals can resurface every January.
+2. **Homeostatic pressure**: Urgency that builds linearly the longer an item goes unresolved. Discharged by calling `resolve_pressure()`.
+
+The effective score is: `decay + cyclic_resonance + pressure`
+
+When `cycles=[]` and `pressure_rate=0.0`, behavior is identical to `DecayingSortedField`.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `decay_rate` | float | 0.5 | Power-law decay exponent (inherited) |
+| `base_score_field` | str | None | Companion field whose value multiplies the decay curve (inherited) |
+| `cycles` | list | `[]` | List of `(period, amplitude, phase)` tuples |
+| `pressure_rate` | float | 0.0 | Rate of urgency buildup per unresolved day |
+| `partition_by` | str/tuple | `()` | Partition sorted set by key fields (inherited) |
+
+### Cycle Tuples
+
+Each cycle is a `(period, amplitude, phase)` tuple:
+
+- **period**: Duration in seconds. Use `TemporalPeriod` constants.
+- **amplitude**: Peak boost value (non-negative).
+- **phase**: Time offset in seconds (shifts the cosine curve).
+
+The resonance formula: `amplitude * cos(2 * pi * (now - phase) / period)`
+
+### TemporalPeriod Constants
+
+Import from `popoto.fields.constants`:
+
+| Constant | Value (seconds) |
+|----------|----------------|
+| `DAILY` | 86,400 |
+| `WEEKLY` | 604,800 |
+| `MONTHLY` | 2,592,000 |
+| `QUARTERLY` | 7,776,000 |
+| `YEARLY` | 31,536,000 |
+
+## Usage
+
+### Basic Model Definition
+
+```python
+from popoto import Model, KeyField, Field, CyclicDecayField
+from popoto.fields.constants import TemporalPeriod
+
+class Directive(Model):
+    agent_id = KeyField()
+    content = Field(type=str)
+    relevance = CyclicDecayField(
+        decay_rate=0.5,
+        cycles=[(TemporalPeriod.QUARTERLY, 5.0, 0)],
+        pressure_rate=0.1,
+    )
+```
+
+### Querying Top Results
+
+```python
+# Top 10 directives by combined decay + cyclic + pressure score
+top = Directive.query.filter(agent_id="agent-1").top_by_decay("relevance", n=10)
+```
+
+### Resolving Pressure
+
+```python
+# Discharge accumulated urgency for a directive
+directive.resolve_pressure("relevance")
+```
+
+### Refreshing the Decay Clock
+
+```python
+# Same as DecayingSortedField — updates the timestamp
+directive.touch("relevance")
+```
+
+## Redis Data Model
+
+CyclicDecayField stores data in three Redis structures:
+
+1. **Sorted set** (inherited): `$CyclicDecayF:{Model}:{field}:{partitions}` — member timestamps
+2. **Cycles hash**: `$CyclicDecayF:{Model}:{field}:{partitions}:cycles` — per-member cycle tuples (msgpack)
+3. **Pressure hash**: `$CyclicDecayF:{Model}:{field}:{partitions}:pressure` — per-member `{rate, last_resolved}` (msgpack)
+
+All three structures are maintained automatically by `on_save()` and `on_delete()`.
+
+## Scoring Formula
+
+The extended Lua script computes per member:
+
+```
+elapsed_days = max((now - last_updated) / 86400, 0.01)
+decay = base_score * elapsed_days ^ (-decay_rate)
+cyclic = sum(amplitude * cos(2 * pi * (now - phase) / period) for each cycle)
+pressure = pressure_rate * max((now - last_resolved) / 86400, 0)
+effective_score = decay + cyclic + pressure
+```
+
+When companion hashes return nil (no cycle/pressure data), the overhead is two nil HGET lookups per member.
+
+## Error Handling
+
+- `CyclicDecayField(cycles=[(0, 1.0, 0)])` raises `ModelException` (zero period)
+- `CyclicDecayField(pressure_rate=-1)` raises `ModelException` (negative rate)
+- `resolve_pressure()` on unsaved model raises `TypeError`
+- `resolve_pressure()` on non-CyclicDecayField raises `TypeError`
+- `resolve_pressure()` with `pressure_rate=0` raises `TypeError`

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -646,6 +646,56 @@ All standard `SortedField` range filters (`__gt`, `__gte`, `__lt`, `__lte`, `__b
 work against the timestamp score. See [Agent Memory](features/agent-memory.md) for the
 full agent memory primitives overview.
 
+## CyclicDecayField
+
+`CyclicDecayField` extends `DecayingSortedField` with two additional temporal forces computed
+atomically in a single Lua script:
+
+1. **Cyclical resonance**: Periodic boosts following cosine curves.
+2. **Homeostatic pressure**: Urgency that builds linearly while an item goes unresolved.
+
+The effective score is: `decay + cyclic_resonance + pressure`. When `cycles=[]` and
+`pressure_rate=0.0`, behavior is identical to `DecayingSortedField`.
+
+```python
+from popoto import Model, KeyField, Field, CyclicDecayField
+from popoto.fields.constants import TemporalPeriod
+
+class Directive(Model):
+    agent_id = KeyField()
+    content = Field(type=str)
+    relevance = CyclicDecayField(
+        decay_rate=0.5,
+        cycles=[(TemporalPeriod.QUARTERLY, 5.0, 0)],
+        pressure_rate=0.1,
+    )
+```
+
+Query with the same `top_by_decay()` interface, and discharge pressure with `resolve_pressure()`:
+
+```python
+# Top 10 by combined decay + cyclic + pressure score
+top = Directive.query.filter(agent_id="agent-1").top_by_decay("relevance", n=10)
+
+# Discharge accumulated urgency
+directive.resolve_pressure("relevance")
+
+# Refresh the decay clock (same as DecayingSortedField)
+directive.touch("relevance")
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `decay_rate` | `float` | `0.5` | Power-law decay exponent (inherited). |
+| `base_score_field` | `str` | `None` | Companion field whose value multiplies the decay curve (inherited). |
+| `cycles` | `list` | `[]` | List of `(period, amplitude, phase)` tuples. Use `TemporalPeriod` constants for period. |
+| `pressure_rate` | `float` | `0.0` | Rate of urgency buildup per unresolved day. |
+| `partition_by` | `str` or `tuple` | `()` | Partition the sorted set by key field values (inherited). |
+
+See [CyclicDecayField feature docs](features/cyclic-decay-field.md) for the full reference including
+the scoring formula, Redis data model, `TemporalPeriod` constants, and error handling.
+See [Agent Memory](features/agent-memory.md) for the broader agent memory primitives overview.
+
 ## partition_by
 
 When you always query a `SortedField` together with a specific `KeyField`, you can

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
     - Async Operations: 'async.md'
     - PubSub: 'pubsub.md'
     - Agent Memory: 'features/agent-memory.md'
+    - CyclicDecayField: 'features/cyclic-decay-field.md'
     - API Reference: 'api-reference.md'
     - Contributing:
         - Style Guide: 'style-guide.md'

--- a/src/popoto/__init__.py
+++ b/src/popoto/__init__.py
@@ -25,6 +25,8 @@ from .fields.shortcuts import (
     SortedKeyField,
 )
 from .fields.decaying_sorted_field import DecayingSortedField
+from .fields.cyclic_decay_field import CyclicDecayField
+from .fields.constants import TemporalPeriod
 from .fields.geo_field import GeoField
 
 try:
@@ -82,6 +84,8 @@ __all__ = [
     "SortedField",
     "SortedKeyField",
     "DecayingSortedField",
+    "CyclicDecayField",
+    "TemporalPeriod",
     "GeoField",
     "DataFrameField",
     "Relationship",

--- a/src/popoto/fields/constants.py
+++ b/src/popoto/fields/constants.py
@@ -1,0 +1,31 @@
+"""Temporal constants for CyclicDecayField cycle definitions.
+
+Provides named constants for standard cycle periods in seconds,
+used as the ``period`` parameter in CyclicDecayField cycle tuples.
+
+Example:
+    from popoto.fields.constants import TemporalPeriod
+
+    relevance = CyclicDecayField(
+        decay_rate=0.5,
+        cycles=[(TemporalPeriod.QUARTERLY, 5.0, 0)],
+    )
+"""
+
+
+class TemporalPeriod:
+    """Named constants for common temporal cycle periods in seconds.
+
+    These values represent the approximate duration of each period:
+        DAILY     = 86,400 seconds (24 hours)
+        WEEKLY    = 604,800 seconds (7 days)
+        MONTHLY   = 2,592,000 seconds (30 days)
+        QUARTERLY = 7,776,000 seconds (90 days)
+        YEARLY    = 31,536,000 seconds (365 days)
+    """
+
+    DAILY = 86_400
+    WEEKLY = 604_800
+    MONTHLY = 2_592_000
+    QUARTERLY = 7_776_000
+    YEARLY = 31_536_000

--- a/src/popoto/fields/cyclic_decay_field.py
+++ b/src/popoto/fields/cyclic_decay_field.py
@@ -1,0 +1,339 @@
+"""CyclicDecayField — Temporal Rhythms + Homeostatic Pressure.
+
+Extends DecayingSortedField with two additional temporal forces computed
+atomically in the same Lua script:
+
+1. **Cyclical resonance**: Periodic boosts following cosine curves.
+   A record about Q1 renewals resurfaces every January.
+
+2. **Homeostatic pressure**: Urgency that builds linearly over time
+   when an item goes unresolved. Discharged by ``resolve_pressure()``.
+
+The effective score is: ``decay + cyclic_resonance + pressure``
+
+When ``cycles=[]`` and ``pressure_rate=0.0``, behavior is identical to
+DecayingSortedField (the Lua script short-circuits on nil HGET lookups).
+
+Companion Redis hashes store per-member cycle and pressure data:
+    - ``$CyclicDecayF:{Model}:{field}:{partitions}:cycles`` — msgpack cycle tuples
+    - ``$CyclicDecayF:{Model}:{field}:{partitions}:pressure`` — msgpack pressure dict
+
+Example:
+    class Directive(Model):
+        agent_id = KeyField()
+        content = Field(type=str)
+        relevance = CyclicDecayField(
+            decay_rate=0.5,
+            cycles=[(TemporalPeriod.QUARTERLY, 5.0, 0)],
+            pressure_rate=0.1,
+        )
+
+    top = Directive.query.filter(agent_id="agent-1").top_by_decay("relevance", n=10)
+    directive.resolve_pressure("relevance")
+"""
+
+import logging
+import time
+
+import msgpack
+import redis
+
+from ..exceptions import ModelException
+from ..redis_db import POPOTO_REDIS_DB
+from .decaying_sorted_field import DecayingSortedField
+
+logger = logging.getLogger("POPOTO.CyclicDecayField")
+
+# Extended Lua script: computes decay + cyclic resonance + pressure atomically.
+#
+# KEYS[1] = sorted set key (member -> last_updated_timestamp)
+# KEYS[2] = cycles companion hash key (member -> msgpack [[period, amp, phase], ...])
+# KEYS[3] = pressure companion hash key (member -> msgpack {rate, last_resolved})
+# ARGV[1] = current timestamp (seconds)
+# ARGV[2] = decay rate (e.g. 0.5)
+# ARGV[3] = max results to return
+# ARGV[4] = base_score_field name (empty string = default 1.0)
+CYCLIC_DECAY_LUA = """
+local zset_key = KEYS[1]
+local cycles_hash_key = KEYS[2]
+local pressure_hash_key = KEYS[3]
+local now = tonumber(ARGV[1])
+local decay_rate = tonumber(ARGV[2])
+local max_results = tonumber(ARGV[3])
+local base_score_field = ARGV[4]
+
+-- Get all members with their last_updated timestamps
+local members = redis.call('ZRANGE', zset_key, 0, -1, 'WITHSCORES')
+
+local scored = {}
+local two_pi = 2 * math.pi
+
+for i = 1, #members, 2 do
+    local member = members[i]
+    local last_updated = tonumber(members[i + 1])
+
+    -- Base score from model hash (same as DecayingSortedField)
+    local base_score = 1.0
+    if base_score_field ~= '' then
+        local raw = redis.call('HGET', member, base_score_field)
+        if raw then
+            local ok, decoded = pcall(cmsgpack.unpack, raw)
+            if ok and type(decoded) == 'number' then
+                base_score = decoded
+            elseif ok and type(decoded) == 'table' and decoded['as_encodable'] then
+                base_score = tonumber(decoded['as_encodable']) or 1.0
+            end
+        end
+    end
+
+    -- Power-law decay: base_score * elapsed_days^(-decay_rate)
+    local elapsed_days = math.max((now - last_updated) / 86400, 0.01)
+    local decayed = base_score * math.pow(elapsed_days, -decay_rate)
+
+    -- Cyclical resonance: sum of cosine curves
+    local cyclic = 0
+    local cycles_raw = redis.call('HGET', cycles_hash_key, member)
+    if cycles_raw then
+        local ok, cycles = pcall(cmsgpack.unpack, cycles_raw)
+        if ok and type(cycles) == 'table' then
+            for _, c in ipairs(cycles) do
+                -- c = {period, amplitude, phase}
+                local period = c[1]
+                local amplitude = c[2]
+                local phase = c[3] or 0
+                if period > 0 then
+                    cyclic = cyclic + amplitude * math.cos(two_pi * (now - phase) / period)
+                end
+            end
+        end
+    end
+
+    -- Homeostatic pressure: linear urgency buildup
+    local pressure = 0
+    local pressure_raw = redis.call('HGET', pressure_hash_key, member)
+    if pressure_raw then
+        local ok, pdata = pcall(cmsgpack.unpack, pressure_raw)
+        if ok and type(pdata) == 'table' then
+            local rate = pdata['rate'] or pdata[1] or 0
+            local last_resolved = pdata['last_resolved'] or pdata[2] or now
+            if rate > 0 then
+                local unresolved_days = math.max((now - last_resolved) / 86400, 0)
+                pressure = rate * unresolved_days
+            end
+        end
+    end
+
+    -- Three-force superposition
+    local effective_score = decayed + cyclic + pressure
+    table.insert(scored, {member, effective_score})
+end
+
+-- Sort by effective score descending
+table.sort(scored, function(a, b) return a[2] > b[2] end)
+
+-- Return top-N as flat array: [member1, score1, member2, score2, ...]
+local result = {}
+for i = 1, math.min(max_results, #scored) do
+    table.insert(result, scored[i][1])
+    table.insert(result, tostring(scored[i][2]))
+end
+return result
+"""
+
+
+class CyclicDecayField(DecayingSortedField):
+    """A DecayingSortedField with cyclical resonance and homeostatic pressure.
+
+    Extends the parent's power-law decay with two additional forces:
+
+    1. **Cyclical resonance** via ``cycles`` parameter: each cycle is a
+       ``(period, amplitude, phase)`` tuple defining a cosine curve.
+       The resonance contribution is ``amplitude * cos(2*pi*(now-phase)/period)``.
+
+    2. **Homeostatic pressure** via ``pressure_rate``: linearly increasing
+       urgency. Pressure = ``pressure_rate * unresolved_days``.
+       Reset by calling ``model.resolve_pressure(field_name)``.
+
+    When ``cycles=[]`` and ``pressure_rate=0.0``, behavior is identical
+    to ``DecayingSortedField``.
+
+    Args:
+        decay_rate: Controls how fast scores drop. Higher = faster decay.
+            Default 0.5. Must be > 0. (Inherited from DecayingSortedField.)
+        base_score_field: Name of a companion field whose value multiplies
+            the decay curve. When None, base score is 1.0. (Inherited.)
+        cycles: List of ``(period, amplitude, phase)`` tuples defining
+            cyclical resonance curves. ``period`` is in seconds (use
+            ``TemporalPeriod`` constants). ``amplitude`` is the peak boost.
+            ``phase`` is a time offset in seconds. Default ``[]``.
+        pressure_rate: Rate at which urgency builds per unresolved day.
+            Default ``0.0`` (no pressure). Must be >= 0.
+        partition_by: Partition the sorted set by key field values.
+            Inherited from SortedFieldMixin.
+
+    Example:
+        from popoto.fields.constants import TemporalPeriod
+
+        class Directive(Model):
+            agent_id = KeyField()
+            content = Field(type=str)
+            relevance = CyclicDecayField(
+                decay_rate=0.5,
+                cycles=[(TemporalPeriod.QUARTERLY, 5.0, 0)],
+                pressure_rate=0.1,
+            )
+    """
+
+    def __init__(self, **kwargs):
+        self.cycles = kwargs.pop("cycles", [])
+        self.pressure_rate = kwargs.pop("pressure_rate", 0.0)
+
+        # Validate cycles
+        for cycle in self.cycles:
+            if len(cycle) < 2 or len(cycle) > 3:
+                raise ModelException(
+                    f"Each cycle must be (period, amplitude) or "
+                    f"(period, amplitude, phase), got {cycle}"
+                )
+            period, amplitude = cycle[0], cycle[1]
+            if period <= 0:
+                raise ModelException(
+                    f"Cycle period must be > 0 (got {period})"
+                )
+            if amplitude < 0:
+                raise ModelException(
+                    f"Cycle amplitude must be >= 0 (got {amplitude})"
+                )
+
+        # Validate pressure_rate
+        if self.pressure_rate < 0:
+            raise ModelException(
+                f"pressure_rate must be >= 0 (got {self.pressure_rate})"
+            )
+
+        super().__init__(**kwargs)
+
+    def _get_cycles_hash_key(self, model_instance, field_name):
+        """Build the Redis key for the cycles companion hash.
+
+        Pattern: $CyclicDecayF:{Model}:{field}:{partitions}:cycles
+        """
+        ss_key = self.get_partitioned_sortedset_db_key(model_instance, field_name)
+        # Replace the $SortedF prefix with $CyclicDecayF and append :cycles
+        key_str = ss_key.redis_key.replace("$SortedF:", "$CyclicDecayF:", 1)
+        return key_str + ":cycles"
+
+    def _get_pressure_hash_key(self, model_instance, field_name):
+        """Build the Redis key for the pressure companion hash.
+
+        Pattern: $CyclicDecayF:{Model}:{field}:{partitions}:pressure
+        """
+        ss_key = self.get_partitioned_sortedset_db_key(model_instance, field_name)
+        key_str = ss_key.redis_key.replace("$SortedF:", "$CyclicDecayF:", 1)
+        return key_str + ":pressure"
+
+    @classmethod
+    def _get_cycles_hash_key_from_parts(cls, model_class, field_name, *partition_values):
+        """Build cycles hash key from model class and partition values."""
+        ss_key = cls.get_sortedset_db_key(model_class, field_name, *partition_values)
+        key_str = ss_key.redis_key.replace("$SortedF:", "$CyclicDecayF:", 1)
+        return key_str + ":cycles"
+
+    @classmethod
+    def _get_pressure_hash_key_from_parts(
+        cls, model_class, field_name, *partition_values
+    ):
+        """Build pressure hash key from model class and partition values."""
+        ss_key = cls.get_sortedset_db_key(model_class, field_name, *partition_values)
+        key_str = ss_key.redis_key.replace("$SortedF:", "$CyclicDecayF:", 1)
+        return key_str + ":pressure"
+
+    @classmethod
+    def on_save(cls, model_instance, field_name, field_value, pipeline=None, **kwargs):
+        """Store timestamp (parent) then store cycle/pressure companion data.
+
+        On first save (no existing entry in pressure hash), writes the full
+        pressure dict with last_resolved=now. On subsequent saves, only
+        updates the rate — never overwrites last_resolved.
+        """
+        # Call parent to store timestamp in sorted set
+        result = super().on_save(
+            model_instance, field_name, field_value, pipeline=pipeline, **kwargs
+        )
+
+        field = model_instance._meta.fields[field_name]
+        if not isinstance(field, CyclicDecayField):
+            return result
+
+        member_key = model_instance.db_key.redis_key
+        cycles_hash_key = field._get_cycles_hash_key(model_instance, field_name)
+        pressure_hash_key = field._get_pressure_hash_key(model_instance, field_name)
+
+        # Normalize cycles to 3-tuples for storage
+        normalized_cycles = []
+        for cycle in field.cycles:
+            period, amplitude = cycle[0], cycle[1]
+            phase = cycle[2] if len(cycle) > 2 else 0
+            normalized_cycles.append([period, amplitude, phase])
+
+        db = pipeline if isinstance(pipeline, redis.client.Pipeline) else POPOTO_REDIS_DB
+
+        # Store cycles data (always write field-level defaults)
+        if normalized_cycles:
+            db.hset(cycles_hash_key, member_key, msgpack.packb(normalized_cycles))
+        else:
+            # Remove any stale cycles data if field now has no cycles
+            db.hdel(cycles_hash_key, member_key)
+
+        # Store pressure data — preserve existing last_resolved
+        if field.pressure_rate > 0:
+            # Check if entry already exists (to preserve last_resolved)
+            existing_raw = POPOTO_REDIS_DB.hget(pressure_hash_key, member_key)
+            if existing_raw:
+                # Only update rate, preserve last_resolved
+                existing = msgpack.unpackb(existing_raw, raw=False)
+                existing["rate"] = field.pressure_rate
+                db.hset(
+                    pressure_hash_key, member_key, msgpack.packb(existing)
+                )
+            else:
+                # First save: set last_resolved to now
+                pressure_data = {
+                    "rate": field.pressure_rate,
+                    "last_resolved": time.time(),
+                }
+                db.hset(
+                    pressure_hash_key, member_key, msgpack.packb(pressure_data)
+                )
+        else:
+            # Remove any stale pressure data
+            db.hdel(pressure_hash_key, member_key)
+
+        return result
+
+    @classmethod
+    def on_delete(cls, model_instance, field_name, field_value, pipeline=None, **kwargs):
+        """Remove companion hash entries then delegate to parent."""
+        field = model_instance._meta.fields[field_name]
+
+        if isinstance(field, CyclicDecayField):
+            member_key = (
+                kwargs.get("saved_redis_key") or model_instance.db_key.redis_key
+            )
+            cycles_hash_key = field._get_cycles_hash_key(model_instance, field_name)
+            pressure_hash_key = field._get_pressure_hash_key(
+                model_instance, field_name
+            )
+
+            db = (
+                pipeline
+                if isinstance(pipeline, redis.client.Pipeline)
+                else POPOTO_REDIS_DB
+            )
+            db.hdel(cycles_hash_key, member_key)
+            db.hdel(pressure_hash_key, member_key)
+
+        # Delegate to parent for sorted set cleanup
+        return super().on_delete(
+            model_instance, field_name, field_value, pipeline=pipeline, **kwargs
+        )

--- a/src/popoto/fields/cyclic_decay_field.py
+++ b/src/popoto/fields/cyclic_decay_field.py
@@ -219,9 +219,7 @@ class CyclicDecayField(DecayingSortedField):
         Pattern: $CyclicDecayF:{Model}:{field}:{partitions}:cycles
         """
         ss_key = self.get_partitioned_sortedset_db_key(model_instance, field_name)
-        # Replace the $SortedF prefix with $CyclicDecayF and append :cycles
-        key_str = ss_key.redis_key.replace("$SortedF:", "$CyclicDecayF:", 1)
-        return key_str + ":cycles"
+        return ss_key.redis_key + ":cycles"
 
     def _get_pressure_hash_key(self, model_instance, field_name):
         """Build the Redis key for the pressure companion hash.
@@ -229,15 +227,13 @@ class CyclicDecayField(DecayingSortedField):
         Pattern: $CyclicDecayF:{Model}:{field}:{partitions}:pressure
         """
         ss_key = self.get_partitioned_sortedset_db_key(model_instance, field_name)
-        key_str = ss_key.redis_key.replace("$SortedF:", "$CyclicDecayF:", 1)
-        return key_str + ":pressure"
+        return ss_key.redis_key + ":pressure"
 
     @classmethod
     def _get_cycles_hash_key_from_parts(cls, model_class, field_name, *partition_values):
         """Build cycles hash key from model class and partition values."""
         ss_key = cls.get_sortedset_db_key(model_class, field_name, *partition_values)
-        key_str = ss_key.redis_key.replace("$SortedF:", "$CyclicDecayF:", 1)
-        return key_str + ":cycles"
+        return ss_key.redis_key + ":cycles"
 
     @classmethod
     def _get_pressure_hash_key_from_parts(
@@ -245,8 +241,7 @@ class CyclicDecayField(DecayingSortedField):
     ):
         """Build pressure hash key from model class and partition values."""
         ss_key = cls.get_sortedset_db_key(model_class, field_name, *partition_values)
-        key_str = ss_key.redis_key.replace("$SortedF:", "$CyclicDecayF:", 1)
-        return key_str + ":pressure"
+        return ss_key.redis_key + ":pressure"
 
     @classmethod
     def on_save(cls, model_instance, field_name, field_value, pipeline=None, **kwargs):
@@ -287,7 +282,8 @@ class CyclicDecayField(DecayingSortedField):
 
         # Store pressure data — preserve existing last_resolved
         if field.pressure_rate > 0:
-            # Check if entry already exists (to preserve last_resolved)
+            # Read directly from Redis (not the pipeline) because we need
+            # the result immediately to decide whether to preserve last_resolved.
             existing_raw = POPOTO_REDIS_DB.hget(pressure_hash_key, member_key)
             if existing_raw:
                 # Only update rate, preserve last_resolved

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -1805,7 +1805,7 @@ class Model(metaclass=ModelBase):
         now = time.time()
         redis_key = self._redis_key or self.db_key.redis_key
 
-        sortedset_db_key = DecayingSortedField.get_partitioned_sortedset_db_key(
+        sortedset_db_key = field.__class__.get_partitioned_sortedset_db_key(
             self, field_name
         )
 

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -1822,6 +1822,71 @@ class Model(metaclass=ModelBase):
                 self._saved_field_values[field_name] = now
             return now
 
+    def resolve_pressure(self, field_name, pipeline=None):
+        """Reset homeostatic pressure for a CyclicDecayField member.
+
+        Discharges accumulated urgency by updating ``last_resolved`` to
+        the current time in the pressure companion hash.
+
+        Args:
+            field_name: Name of a CyclicDecayField on the model.
+            pipeline: Optional Redis pipeline for batched operations.
+
+        Returns:
+            The new last_resolved timestamp (float), or the pipeline
+            if one was provided.
+
+        Raises:
+            TypeError: If model is unsaved, field is not a CyclicDecayField,
+                or pressure_rate is 0.
+            AttributeError: If field_name does not exist.
+        """
+        from ..fields.cyclic_decay_field import CyclicDecayField
+
+        if field_name not in self._meta.fields:
+            raise AttributeError(
+                f"'{self.__class__.__name__}' has no field '{field_name}'"
+            )
+
+        field = self._meta.fields[field_name]
+        if not isinstance(field, CyclicDecayField):
+            raise TypeError(
+                f"resolve_pressure() requires a CyclicDecayField. "
+                f"'{field_name}' is {type(field).__name__}"
+            )
+
+        if field.pressure_rate <= 0:
+            raise TypeError(
+                f"resolve_pressure() requires pressure_rate > 0. "
+                f"'{field_name}' has pressure_rate={field.pressure_rate}"
+            )
+
+        if not self._db_content and not self._saved_field_values:
+            raise TypeError(
+                "Cannot call resolve_pressure() on an unsaved model instance. "
+                "Save the model first."
+            )
+
+        import time
+        import msgpack
+
+        now = time.time()
+        member_key = self._redis_key or self.db_key.redis_key
+        pressure_hash_key = field._get_pressure_hash_key(self, field_name)
+
+        pressure_data = {
+            "rate": field.pressure_rate,
+            "last_resolved": now,
+        }
+        packed = msgpack.packb(pressure_data)
+
+        if isinstance(pipeline, redis.client.Pipeline):
+            pipeline.hset(pressure_hash_key, member_key, packed)
+            return pipeline
+        else:
+            POPOTO_REDIS_DB.hset(pressure_hash_key, member_key, packed)
+            return now
+
     @classmethod
     def get_info(cls) -> dict:
         """Return a dict with the model name, field names, and available query filters.

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -299,7 +299,10 @@ class QueryBuilder:
                 f"{', '.join(missing)}"
             )
 
-        sortedset_db_key = DecayingSortedField.get_sortedset_db_key(
+        # Use actual field class for key generation (CyclicDecayField has
+        # its own field_class_key prefix, distinct from DecayingSortedField)
+        field_cls = type(field)
+        sortedset_db_key = field_cls.get_sortedset_db_key(
             model_class, field_name, *partition_values
         )
 

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -301,8 +301,7 @@ class QueryBuilder:
 
         # Use actual field class for key generation (CyclicDecayField has
         # its own field_class_key prefix, distinct from DecayingSortedField)
-        field_cls = type(field)
-        sortedset_db_key = field_cls.get_sortedset_db_key(
+        sortedset_db_key = field.__class__.get_sortedset_db_key(
             model_class, field_name, *partition_values
         )
 

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -307,15 +307,39 @@ class QueryBuilder:
 
         now = time.time()
 
-        result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA,
-            1,  # number of KEYS
-            sortedset_db_key.redis_key,
-            str(now),
-            str(effective_decay_rate),
-            str(n),
-            effective_base_score_field,
-        )
+        # Use extended Lua script for CyclicDecayField, plain script otherwise
+        from ..fields.cyclic_decay_field import CyclicDecayField, CYCLIC_DECAY_LUA
+
+        if isinstance(field, CyclicDecayField):
+            # Build companion hash keys from partition values
+            cycles_hash_key = CyclicDecayField._get_cycles_hash_key_from_parts(
+                model_class, field_name, *partition_values
+            )
+            pressure_hash_key = CyclicDecayField._get_pressure_hash_key_from_parts(
+                model_class, field_name, *partition_values
+            )
+
+            result = POPOTO_REDIS_DB.eval(
+                CYCLIC_DECAY_LUA,
+                3,  # number of KEYS
+                sortedset_db_key.redis_key,
+                cycles_hash_key,
+                pressure_hash_key,
+                str(now),
+                str(effective_decay_rate),
+                str(n),
+                effective_base_score_field,
+            )
+        else:
+            result = POPOTO_REDIS_DB.eval(
+                DECAY_SCORE_LUA,
+                1,  # number of KEYS
+                sortedset_db_key.redis_key,
+                str(now),
+                str(effective_decay_rate),
+                str(n),
+                effective_base_score_field,
+            )
 
         if not result:
             return []

--- a/tests/test_cyclic_decay_field.py
+++ b/tests/test_cyclic_decay_field.py
@@ -1,0 +1,849 @@
+"""Tests for CyclicDecayField — Temporal Rhythms + Homeostatic Pressure.
+
+Tests cover:
+- Field initialization (cycles, pressure_rate, validation)
+- TemporalPeriod constants
+- on_save() stores companion hash data
+- on_delete() cleans up companion hashes
+- top_by_decay() with cyclic resonance
+- top_by_decay() with homeostatic pressure
+- Three-force superposition against hand-computed values
+- CyclicDecayField with no cycles matches DecayingSortedField
+- partition_by works with CyclicDecayField
+- resolve_pressure() method
+- Error cases: unsaved model, wrong field type, invalid parameters
+- Benchmarks for 1K and 10K member sets
+"""
+
+import math
+import sys
+import os
+import time
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+import msgpack
+import pytest
+from src import popoto
+from src.popoto.fields.cyclic_decay_field import CyclicDecayField, CYCLIC_DECAY_LUA
+from src.popoto.fields.decaying_sorted_field import DecayingSortedField, DECAY_SCORE_LUA
+from src.popoto.fields.constants import TemporalPeriod
+from src.popoto.models.query import QueryException
+
+# --- Test Models ---
+
+
+class CyclicItem(popoto.Model):
+    name = popoto.UniqueKeyField()
+    relevance = CyclicDecayField()
+
+
+class CyclicWithCycles(popoto.Model):
+    name = popoto.UniqueKeyField()
+    relevance = CyclicDecayField(
+        decay_rate=0.5,
+        cycles=[(TemporalPeriod.YEARLY, 5.0, 0)],
+    )
+
+
+class CyclicWithPressure(popoto.Model):
+    name = popoto.UniqueKeyField()
+    relevance = CyclicDecayField(
+        decay_rate=0.5,
+        pressure_rate=0.1,
+    )
+
+
+class CyclicFull(popoto.Model):
+    name = popoto.UniqueKeyField()
+    relevance = CyclicDecayField(
+        decay_rate=0.5,
+        cycles=[(TemporalPeriod.YEARLY, 5.0, 0)],
+        pressure_rate=0.1,
+    )
+    weight = popoto.FloatField(default=1.0)
+
+
+class CyclicWithBase(popoto.Model):
+    name = popoto.UniqueKeyField()
+    relevance = CyclicDecayField(
+        decay_rate=0.5,
+        base_score_field="weight",
+        cycles=[(TemporalPeriod.QUARTERLY, 3.0, 0)],
+        pressure_rate=0.2,
+    )
+    weight = popoto.FloatField(default=1.0)
+
+
+class PartitionedCyclic(popoto.Model):
+    name = popoto.UniqueKeyField()
+    category = popoto.KeyField(null=False)
+    relevance = CyclicDecayField(
+        decay_rate=0.5,
+        cycles=[(TemporalPeriod.MONTHLY, 2.0, 0)],
+        pressure_rate=0.05,
+        partition_by="category",
+    )
+
+
+class PlainDecayItem(popoto.Model):
+    name = popoto.UniqueKeyField()
+    relevance = DecayingSortedField(decay_rate=0.5)
+
+
+ALL_MODELS = [
+    CyclicItem,
+    CyclicWithCycles,
+    CyclicWithPressure,
+    CyclicFull,
+    CyclicWithBase,
+    PartitionedCyclic,
+    PlainDecayItem,
+]
+
+
+# --- Setup / Teardown ---
+
+
+def setup_module():
+    """Clean up test data before running tests."""
+    for model in ALL_MODELS:
+        model.delete_all()
+
+
+def teardown_module():
+    """Clean up test data after running tests."""
+    for model in ALL_MODELS:
+        model.delete_all()
+
+
+# --- TemporalPeriod constants tests ---
+
+
+class TestTemporalPeriod:
+    """Test TemporalPeriod constants."""
+
+    def test_daily(self):
+        assert TemporalPeriod.DAILY == 86_400
+
+    def test_weekly(self):
+        assert TemporalPeriod.WEEKLY == 604_800
+
+    def test_monthly(self):
+        assert TemporalPeriod.MONTHLY == 2_592_000
+
+    def test_quarterly(self):
+        assert TemporalPeriod.QUARTERLY == 7_776_000
+
+    def test_yearly(self):
+        assert TemporalPeriod.YEARLY == 31_536_000
+
+    def test_importable_from_popoto(self):
+        from src.popoto import TemporalPeriod as TP
+
+        assert TP.DAILY == 86_400
+
+
+# --- Field initialization tests ---
+
+
+class TestCyclicDecayFieldInit:
+    """Test field construction and validation."""
+
+    def test_default_cycles_empty(self):
+        field = CyclicItem._meta.fields["relevance"]
+        assert field.cycles == []
+
+    def test_default_pressure_rate_zero(self):
+        field = CyclicItem._meta.fields["relevance"]
+        assert field.pressure_rate == 0.0
+
+    def test_custom_cycles(self):
+        field = CyclicWithCycles._meta.fields["relevance"]
+        assert len(field.cycles) == 1
+        assert field.cycles[0][0] == TemporalPeriod.YEARLY
+        assert field.cycles[0][1] == 5.0
+
+    def test_custom_pressure_rate(self):
+        field = CyclicWithPressure._meta.fields["relevance"]
+        assert field.pressure_rate == 0.1
+
+    def test_inherits_decay_rate(self):
+        field = CyclicFull._meta.fields["relevance"]
+        assert field.decay_rate == 0.5
+
+    def test_is_decaying_sorted_field(self):
+        field = CyclicFull._meta.fields["relevance"]
+        assert isinstance(field, DecayingSortedField)
+
+    def test_is_cyclic_decay_field(self):
+        field = CyclicFull._meta.fields["relevance"]
+        assert isinstance(field, CyclicDecayField)
+
+    def test_invalid_zero_period(self):
+        with pytest.raises(popoto.ModelException):
+
+            class BadCyclic(popoto.Model):
+                name = popoto.UniqueKeyField()
+                score = CyclicDecayField(cycles=[(0, 1.0, 0)])
+
+    def test_invalid_negative_period(self):
+        with pytest.raises(popoto.ModelException):
+
+            class BadCyclic2(popoto.Model):
+                name = popoto.UniqueKeyField()
+                score = CyclicDecayField(cycles=[(-100, 1.0, 0)])
+
+    def test_invalid_negative_amplitude(self):
+        with pytest.raises(popoto.ModelException):
+
+            class BadCyclic3(popoto.Model):
+                name = popoto.UniqueKeyField()
+                score = CyclicDecayField(cycles=[(86400, -1.0, 0)])
+
+    def test_invalid_negative_pressure_rate(self):
+        with pytest.raises(popoto.ModelException):
+
+            class BadCyclic4(popoto.Model):
+                name = popoto.UniqueKeyField()
+                score = CyclicDecayField(pressure_rate=-1)
+
+    def test_exportable_from_popoto(self):
+        from src.popoto import CyclicDecayField as CDF
+
+        assert CDF is CyclicDecayField
+
+
+# --- Save behavior tests ---
+
+
+class TestCyclicDecayFieldSave:
+    """Test that on_save() stores companion hash data."""
+
+    def setup_method(self):
+        CyclicWithCycles.delete_all()
+        CyclicWithPressure.delete_all()
+        CyclicFull.delete_all()
+
+    def teardown_method(self):
+        CyclicWithCycles.delete_all()
+        CyclicWithPressure.delete_all()
+        CyclicFull.delete_all()
+
+    def test_save_stores_timestamp(self):
+        before = time.time()
+        item = CyclicFull.create(name="ts_test")
+        after = time.time()
+        assert before <= item.relevance <= after
+
+    def test_save_stores_cycles_hash(self):
+        item = CyclicWithCycles.create(name="cycles_test")
+        field = CyclicWithCycles._meta.fields["relevance"]
+        cycles_key = field._get_cycles_hash_key(item, "relevance")
+        raw = popoto.POPOTO_REDIS_DB.hget(cycles_key, item.db_key.redis_key)
+        assert raw is not None
+        decoded = msgpack.unpackb(raw, raw=False)
+        assert len(decoded) == 1
+        assert decoded[0][0] == TemporalPeriod.YEARLY
+        assert decoded[0][1] == 5.0
+
+    def test_save_stores_pressure_hash(self):
+        item = CyclicWithPressure.create(name="pressure_test")
+        field = CyclicWithPressure._meta.fields["relevance"]
+        pressure_key = field._get_pressure_hash_key(item, "relevance")
+        raw = popoto.POPOTO_REDIS_DB.hget(pressure_key, item.db_key.redis_key)
+        assert raw is not None
+        decoded = msgpack.unpackb(raw, raw=False)
+        assert decoded["rate"] == 0.1
+        assert "last_resolved" in decoded
+
+    def test_save_preserves_last_resolved(self):
+        """Re-saving does not overwrite last_resolved."""
+        item = CyclicWithPressure.create(name="preserve_lr")
+        field = CyclicWithPressure._meta.fields["relevance"]
+        pressure_key = field._get_pressure_hash_key(item, "relevance")
+
+        raw1 = popoto.POPOTO_REDIS_DB.hget(pressure_key, item.db_key.redis_key)
+        lr1 = msgpack.unpackb(raw1, raw=False)["last_resolved"]
+
+        time.sleep(0.05)
+        item.save()
+
+        raw2 = popoto.POPOTO_REDIS_DB.hget(pressure_key, item.db_key.redis_key)
+        lr2 = msgpack.unpackb(raw2, raw=False)["last_resolved"]
+        assert lr1 == lr2
+
+    def test_save_no_cycles_no_hash(self):
+        """CyclicDecayField with empty cycles removes stale cycle data."""
+        item = CyclicItem.create(name="no_cycles")
+        field = CyclicItem._meta.fields["relevance"]
+        cycles_key = field._get_cycles_hash_key(item, "relevance")
+        raw = popoto.POPOTO_REDIS_DB.hget(cycles_key, item.db_key.redis_key)
+        assert raw is None
+
+
+# --- Delete behavior tests ---
+
+
+class TestCyclicDecayFieldDelete:
+    """Test that on_delete() cleans up companion hashes."""
+
+    def setup_method(self):
+        CyclicFull.delete_all()
+
+    def teardown_method(self):
+        CyclicFull.delete_all()
+
+    def test_delete_cleans_cycles_hash(self):
+        item = CyclicFull.create(name="del_cycles")
+        field = CyclicFull._meta.fields["relevance"]
+        cycles_key = field._get_cycles_hash_key(item, "relevance")
+        member_key = item.db_key.redis_key
+
+        # Verify data exists
+        assert popoto.POPOTO_REDIS_DB.hget(cycles_key, member_key) is not None
+
+        item.delete()
+        assert popoto.POPOTO_REDIS_DB.hget(cycles_key, member_key) is None
+
+    def test_delete_cleans_pressure_hash(self):
+        item = CyclicFull.create(name="del_pressure")
+        field = CyclicFull._meta.fields["relevance"]
+        pressure_key = field._get_pressure_hash_key(item, "relevance")
+        member_key = item.db_key.redis_key
+
+        assert popoto.POPOTO_REDIS_DB.hget(pressure_key, member_key) is not None
+
+        item.delete()
+        assert popoto.POPOTO_REDIS_DB.hget(pressure_key, member_key) is None
+
+
+# --- top_by_decay() with cyclic resonance ---
+
+
+class TestTopByDecayCyclic:
+    """Test cyclic resonance ranking."""
+
+    def setup_method(self):
+        CyclicWithCycles.delete_all()
+
+    def teardown_method(self):
+        CyclicWithCycles.delete_all()
+
+    def test_yearly_cycle_peak(self):
+        """A yearly cycle should peak at the phase time and trough 6 months later."""
+        now = time.time()
+        field = CyclicWithCycles._meta.fields["relevance"]
+
+        # Create two items at the same decay age
+        peak_item = CyclicWithCycles.create(name="peak")
+        trough_item = CyclicWithCycles.create(name="trough")
+
+        # Set both to same timestamp (1 day ago)
+        ss_key = CyclicDecayField.get_sortedset_db_key(CyclicWithCycles, "relevance")
+        one_day_ago = now - 86400
+        popoto.POPOTO_REDIS_DB.zadd(
+            ss_key.redis_key,
+            {
+                peak_item.db_key.redis_key: one_day_ago,
+                trough_item.db_key.redis_key: one_day_ago,
+            },
+        )
+
+        # Set peak_item cycles with phase = now (peak now)
+        # Set trough_item cycles with phase = now - half_year (trough now)
+        cycles_key = field._get_cycles_hash_key(peak_item, "relevance")
+        half_year = TemporalPeriod.YEARLY / 2
+
+        # Peak cycle: phase aligns so cos(2*pi*(now-phase)/period) = 1
+        peak_cycles = [[TemporalPeriod.YEARLY, 5.0, now]]
+        # Trough cycle: phase shifted so cos = -1
+        trough_cycles = [[TemporalPeriod.YEARLY, 5.0, now - half_year]]
+
+        popoto.POPOTO_REDIS_DB.hset(
+            cycles_key, peak_item.db_key.redis_key, msgpack.packb(peak_cycles)
+        )
+        popoto.POPOTO_REDIS_DB.hset(
+            cycles_key, trough_item.db_key.redis_key, msgpack.packb(trough_cycles)
+        )
+
+        results = CyclicWithCycles.query.top_by_decay("relevance", n=10)
+        assert len(results) == 2
+        assert results[0].name == "peak"
+
+    def test_empty_set_returns_empty(self):
+        results = CyclicWithCycles.query.top_by_decay("relevance", n=10)
+        assert results == []
+
+
+# --- top_by_decay() with pressure ---
+
+
+class TestTopByDecayPressure:
+    """Test homeostatic pressure ranking."""
+
+    def setup_method(self):
+        CyclicWithPressure.delete_all()
+
+    def teardown_method(self):
+        CyclicWithPressure.delete_all()
+
+    def test_pressure_increases_over_time(self):
+        """Item with longer unresolved time ranks higher due to pressure."""
+        now = time.time()
+        field = CyclicWithPressure._meta.fields["relevance"]
+
+        old_item = CyclicWithPressure.create(name="old_pressure")
+        new_item = CyclicWithPressure.create(name="new_pressure")
+
+        # Set both to same decay timestamp (1 day ago)
+        ss_key = CyclicDecayField.get_sortedset_db_key(
+            CyclicWithPressure, "relevance"
+        )
+        one_day_ago = now - 86400
+        popoto.POPOTO_REDIS_DB.zadd(
+            ss_key.redis_key,
+            {
+                old_item.db_key.redis_key: one_day_ago,
+                new_item.db_key.redis_key: one_day_ago,
+            },
+        )
+
+        # Set old_item pressure to have been unresolved for 30 days
+        pressure_key = field._get_pressure_hash_key(old_item, "relevance")
+        old_pressure = {"rate": 0.1, "last_resolved": now - 86400 * 30}
+        new_pressure = {"rate": 0.1, "last_resolved": now}
+
+        popoto.POPOTO_REDIS_DB.hset(
+            pressure_key,
+            old_item.db_key.redis_key,
+            msgpack.packb(old_pressure),
+        )
+        popoto.POPOTO_REDIS_DB.hset(
+            pressure_key,
+            new_item.db_key.redis_key,
+            msgpack.packb(new_pressure),
+        )
+
+        results = CyclicWithPressure.query.top_by_decay("relevance", n=10)
+        assert len(results) == 2
+        # old_item has 30 days * 0.1 = 3.0 pressure boost
+        assert results[0].name == "old_pressure"
+
+    def test_pressure_resets_after_resolve(self):
+        """resolve_pressure() discharges accumulated urgency."""
+        now = time.time()
+        field = CyclicWithPressure._meta.fields["relevance"]
+
+        item = CyclicWithPressure.create(name="resolve_test")
+        pressure_key = field._get_pressure_hash_key(item, "relevance")
+
+        # Set old last_resolved
+        old_pressure = {"rate": 0.1, "last_resolved": now - 86400 * 30}
+        popoto.POPOTO_REDIS_DB.hset(
+            pressure_key,
+            item.db_key.redis_key,
+            msgpack.packb(old_pressure),
+        )
+
+        # Resolve pressure
+        item.resolve_pressure("relevance")
+
+        # Verify last_resolved was updated
+        raw = popoto.POPOTO_REDIS_DB.hget(pressure_key, item.db_key.redis_key)
+        decoded = msgpack.unpackb(raw, raw=False)
+        assert abs(decoded["last_resolved"] - time.time()) < 2.0
+
+
+# --- Three-force superposition ---
+
+
+class TestThreeForcesSuperposition:
+    """Verify three-force computation against hand-computed values."""
+
+    def setup_method(self):
+        CyclicFull.delete_all()
+
+    def teardown_method(self):
+        CyclicFull.delete_all()
+
+    def test_known_values(self):
+        """Verify effective_score = decay + cyclic + pressure.
+
+        Setup:
+        - decay_rate=0.5, 1 day old -> decay = 1.0 * 1^(-0.5) = 1.0
+        - yearly cycle, amplitude=5.0, phase=now -> cos(0) = 1 -> cyclic = 5.0
+        - pressure_rate=0.1, 10 days unresolved -> pressure = 0.1 * 10 = 1.0
+        - Expected effective_score = 1.0 + 5.0 + 1.0 = 7.0
+        """
+        now = time.time()
+        field = CyclicFull._meta.fields["relevance"]
+
+        item = CyclicFull.create(name="three_force")
+
+        # Set decay timestamp to 1 day ago
+        ss_key = CyclicDecayField.get_sortedset_db_key(CyclicFull, "relevance")
+        popoto.POPOTO_REDIS_DB.zadd(
+            ss_key.redis_key,
+            {item.db_key.redis_key: now - 86400},
+        )
+
+        # Set cycles: yearly, amplitude 5.0, phase=now (cos(0)=1)
+        cycles_key = field._get_cycles_hash_key(item, "relevance")
+        popoto.POPOTO_REDIS_DB.hset(
+            cycles_key,
+            item.db_key.redis_key,
+            msgpack.packb([[TemporalPeriod.YEARLY, 5.0, now]]),
+        )
+
+        # Set pressure: rate=0.1, 10 days unresolved
+        pressure_key = field._get_pressure_hash_key(item, "relevance")
+        popoto.POPOTO_REDIS_DB.hset(
+            pressure_key,
+            item.db_key.redis_key,
+            msgpack.packb({"rate": 0.1, "last_resolved": now - 86400 * 10}),
+        )
+
+        # Run the Lua script directly to get the raw score
+        cycles_hash_key = CyclicDecayField._get_cycles_hash_key_from_parts(
+            CyclicFull, "relevance"
+        )
+        pressure_hash_key = CyclicDecayField._get_pressure_hash_key_from_parts(
+            CyclicFull, "relevance"
+        )
+
+        result = popoto.POPOTO_REDIS_DB.eval(
+            CYCLIC_DECAY_LUA,
+            3,
+            ss_key.redis_key,
+            cycles_hash_key,
+            pressure_hash_key,
+            str(now),
+            "0.5",
+            "10",
+            "",
+        )
+
+        assert len(result) == 2
+        score = float(result[1])
+        # Expected: 1.0 (decay) + 5.0 (cyclic) + 1.0 (pressure) = 7.0
+        assert abs(score - 7.0) < 0.1, f"Expected ~7.0, got {score}"
+
+
+# --- Equivalence with DecayingSortedField ---
+
+
+class TestEquivalenceWithDecaySortedField:
+    """CyclicDecayField with no cycles and pressure=0 matches DecayingSortedField."""
+
+    def setup_method(self):
+        CyclicItem.delete_all()
+        PlainDecayItem.delete_all()
+
+    def teardown_method(self):
+        CyclicItem.delete_all()
+        PlainDecayItem.delete_all()
+
+    def test_same_ranking(self):
+        """Both fields produce the same ranking for identical data."""
+        now = time.time()
+
+        # Create items in both models
+        cyclic_a = CyclicItem.create(name="a")
+        cyclic_b = CyclicItem.create(name="b")
+        plain_a = PlainDecayItem.create(name="a")
+        plain_b = PlainDecayItem.create(name="b")
+
+        # Backdate identically — use actual field class for correct key prefix
+        cyclic_ss = CyclicDecayField.get_sortedset_db_key(CyclicItem, "relevance")
+        plain_ss = DecayingSortedField.get_sortedset_db_key(PlainDecayItem, "relevance")
+
+        popoto.POPOTO_REDIS_DB.zadd(
+            cyclic_ss.redis_key,
+            {
+                cyclic_a.db_key.redis_key: now - 86400 * 10,
+                cyclic_b.db_key.redis_key: now - 86400 * 1,
+            },
+        )
+        popoto.POPOTO_REDIS_DB.zadd(
+            plain_ss.redis_key,
+            {
+                plain_a.db_key.redis_key: now - 86400 * 10,
+                plain_b.db_key.redis_key: now - 86400 * 1,
+            },
+        )
+
+        cyclic_results = CyclicItem.query.top_by_decay("relevance", n=10)
+        plain_results = PlainDecayItem.query.top_by_decay("relevance", n=10)
+
+        assert len(cyclic_results) == 2
+        assert len(plain_results) == 2
+        assert cyclic_results[0].name == plain_results[0].name
+        assert cyclic_results[1].name == plain_results[1].name
+
+
+# --- Partitioned CyclicDecayField ---
+
+
+class TestPartitionedCyclic:
+    """Test partition_by with CyclicDecayField."""
+
+    def setup_method(self):
+        PartitionedCyclic.delete_all()
+
+    def teardown_method(self):
+        PartitionedCyclic.delete_all()
+
+    def test_partitioned_query(self):
+        PartitionedCyclic.create(name="a1", category="A")
+        PartitionedCyclic.create(name="b1", category="B")
+
+        results = PartitionedCyclic.query.filter(category="A").top_by_decay(
+            "relevance", n=10
+        )
+        assert len(results) == 1
+        assert results[0].name == "a1"
+
+    def test_partitioned_missing_filter_raises(self):
+        PartitionedCyclic.create(name="x1", category="X")
+        with pytest.raises(QueryException):
+            PartitionedCyclic.query.top_by_decay("relevance", n=10)
+
+
+# --- resolve_pressure() tests ---
+
+
+class TestResolvePressure:
+    """Test Model.resolve_pressure() method."""
+
+    def setup_method(self):
+        CyclicWithPressure.delete_all()
+        CyclicItem.delete_all()
+
+    def teardown_method(self):
+        CyclicWithPressure.delete_all()
+        CyclicItem.delete_all()
+
+    def test_resolve_updates_last_resolved(self):
+        item = CyclicWithPressure.create(name="resolve_1")
+        result = item.resolve_pressure("relevance")
+        assert abs(result - time.time()) < 2.0
+
+    def test_resolve_wrong_field_type_raises(self):
+        item = PlainDecayItem.create(name="bad_resolve")
+        with pytest.raises(TypeError):
+            item.resolve_pressure("relevance")
+        item.delete()
+
+    def test_resolve_no_pressure_raises(self):
+        """resolve_pressure on CyclicDecayField with pressure_rate=0 raises TypeError."""
+        item = CyclicItem.create(name="no_pressure")
+        with pytest.raises(TypeError):
+            item.resolve_pressure("relevance")
+
+    def test_resolve_unsaved_raises(self):
+        item = CyclicWithPressure(name="unsaved_resolve")
+        with pytest.raises(TypeError):
+            item.resolve_pressure("relevance")
+
+    def test_resolve_nonexistent_field_raises(self):
+        item = CyclicWithPressure.create(name="no_field_resolve")
+        with pytest.raises(AttributeError):
+            item.resolve_pressure("nonexistent")
+
+    def test_resolve_with_pipeline(self):
+        item = CyclicWithPressure.create(name="pipeline_resolve")
+        pipe = popoto.POPOTO_REDIS_DB.pipeline()
+        result = item.resolve_pressure("relevance", pipeline=pipe)
+        assert result is pipe
+        pipe.execute()
+
+        field = CyclicWithPressure._meta.fields["relevance"]
+        pressure_key = field._get_pressure_hash_key(item, "relevance")
+        raw = popoto.POPOTO_REDIS_DB.hget(pressure_key, item.db_key.redis_key)
+        decoded = msgpack.unpackb(raw, raw=False)
+        assert abs(decoded["last_resolved"] - time.time()) < 2.0
+
+
+# --- Nil companion hash handling ---
+
+
+class TestNilCompanionHash:
+    """Test that Lua handles missing companion hashes gracefully."""
+
+    def setup_method(self):
+        CyclicWithCycles.delete_all()
+
+    def teardown_method(self):
+        CyclicWithCycles.delete_all()
+
+    def test_members_without_companion_data(self):
+        """Members saved before CyclicDecayField migration rank by pure decay."""
+        now = time.time()
+        field = CyclicWithCycles._meta.fields["relevance"]
+
+        # Create item normally (which stores companion data)
+        item = CyclicWithCycles.create(name="has_data")
+
+        # Manually add a member to sorted set without companion hashes
+        ss_key = CyclicDecayField.get_sortedset_db_key(
+            CyclicWithCycles, "relevance"
+        )
+        fake_key = "CyclicWithCycles:orphan_member"
+        popoto.POPOTO_REDIS_DB.zadd(
+            ss_key.redis_key, {fake_key: now - 86400}
+        )
+
+        # Should not crash — orphan member gets pure decay score
+        cycles_hash_key = CyclicDecayField._get_cycles_hash_key_from_parts(
+            CyclicWithCycles, "relevance"
+        )
+        pressure_hash_key = CyclicDecayField._get_pressure_hash_key_from_parts(
+            CyclicWithCycles, "relevance"
+        )
+
+        result = popoto.POPOTO_REDIS_DB.eval(
+            CYCLIC_DECAY_LUA,
+            3,
+            ss_key.redis_key,
+            cycles_hash_key,
+            pressure_hash_key,
+            str(now),
+            "0.5",
+            "10",
+            "",
+        )
+        # Should return both members without error
+        assert len(result) == 4  # 2 members * 2 (key + score)
+
+        # Cleanup fake key
+        popoto.POPOTO_REDIS_DB.zrem(ss_key.redis_key, fake_key)
+
+
+# --- Performance benchmarks ---
+
+
+class TestCyclicBenchmarks:
+    """Benchmark top_by_decay on larger sorted sets with cyclic+pressure."""
+
+    def setup_method(self):
+        CyclicFull.delete_all()
+
+    def teardown_method(self):
+        CyclicFull.delete_all()
+
+    def test_1k_members(self):
+        """Extended Lua handles 1K members with cycle+pressure data."""
+        ss_key = CyclicDecayField.get_sortedset_db_key(CyclicFull, "relevance")
+        cycles_hash_key = CyclicDecayField._get_cycles_hash_key_from_parts(
+            CyclicFull, "relevance"
+        )
+        pressure_hash_key = CyclicDecayField._get_pressure_hash_key_from_parts(
+            CyclicFull, "relevance"
+        )
+        now = time.time()
+
+        pipe = popoto.POPOTO_REDIS_DB.pipeline()
+        members = {}
+        for i in range(1000):
+            redis_key = f"CyclicFull:bench1k_{i}"
+            members[redis_key] = now - (i * 3600)
+            pipe.hset(
+                cycles_hash_key,
+                redis_key,
+                msgpack.packb([[TemporalPeriod.YEARLY, 5.0, 0]]),
+            )
+            pipe.hset(
+                pressure_hash_key,
+                redis_key,
+                msgpack.packb({"rate": 0.1, "last_resolved": now - 86400 * i}),
+            )
+        pipe.zadd(ss_key.redis_key, members)
+        pipe.execute()
+
+        start = time.time()
+        result = popoto.POPOTO_REDIS_DB.eval(
+            CYCLIC_DECAY_LUA,
+            3,
+            ss_key.redis_key,
+            cycles_hash_key,
+            pressure_hash_key,
+            str(now),
+            "0.5",
+            "10",
+            "",
+        )
+        elapsed = time.time() - start
+
+        assert len(result) == 20  # 10 items * 2
+        assert elapsed < 2.0, f"1K members took {elapsed:.3f}s (expected < 2s)"
+
+        # Cleanup
+        popoto.POPOTO_REDIS_DB.delete(ss_key.redis_key)
+        popoto.POPOTO_REDIS_DB.delete(cycles_hash_key)
+        popoto.POPOTO_REDIS_DB.delete(pressure_hash_key)
+
+    def test_10k_members(self):
+        """Extended Lua handles 10K members with cycle+pressure data."""
+        ss_key = CyclicDecayField.get_sortedset_db_key(CyclicFull, "relevance")
+        cycles_hash_key = CyclicDecayField._get_cycles_hash_key_from_parts(
+            CyclicFull, "relevance"
+        )
+        pressure_hash_key = CyclicDecayField._get_pressure_hash_key_from_parts(
+            CyclicFull, "relevance"
+        )
+        now = time.time()
+
+        pipe = popoto.POPOTO_REDIS_DB.pipeline()
+        members = {}
+        for i in range(10000):
+            redis_key = f"CyclicFull:bench10k_{i}"
+            members[redis_key] = now - (i * 360)
+            pipe.hset(
+                cycles_hash_key,
+                redis_key,
+                msgpack.packb([[TemporalPeriod.YEARLY, 5.0, 0]]),
+            )
+            pipe.hset(
+                pressure_hash_key,
+                redis_key,
+                msgpack.packb({"rate": 0.1, "last_resolved": now - 86400}),
+            )
+        pipe.zadd(ss_key.redis_key, members)
+        pipe.execute()
+
+        start = time.time()
+        result = popoto.POPOTO_REDIS_DB.eval(
+            CYCLIC_DECAY_LUA,
+            3,
+            ss_key.redis_key,
+            cycles_hash_key,
+            pressure_hash_key,
+            str(now),
+            "0.5",
+            "10",
+            "",
+        )
+        elapsed = time.time() - start
+
+        assert len(result) == 20
+        assert elapsed < 10.0, f"10K members took {elapsed:.3f}s (expected < 10s)"
+
+        # Cleanup
+        popoto.POPOTO_REDIS_DB.delete(ss_key.redis_key)
+        popoto.POPOTO_REDIS_DB.delete(cycles_hash_key)
+        popoto.POPOTO_REDIS_DB.delete(pressure_hash_key)
+
+
+# --- Export tests ---
+
+
+class TestExports:
+    """Test package exports."""
+
+    def test_cyclic_decay_field_in_all(self):
+        assert "CyclicDecayField" in popoto.__all__
+
+    def test_temporal_period_in_all(self):
+        assert "TemporalPeriod" in popoto.__all__


### PR DESCRIPTION
## Summary

Adds `CyclicDecayField`, a `DecayingSortedField` subclass that extends time-weighted scoring with two additional temporal forces:

1. **Cyclical resonance** — cosine-based periodic boosts (e.g., quarterly renewals resurface every Q1)
2. **Homeostatic pressure** — linear urgency that builds when items go unresolved, discharged via `resolve_pressure()`

The effective score is computed atomically in a single Lua script: `decay + cyclic + pressure`

## Changes

- **`src/popoto/fields/constants.py`** — `TemporalPeriod` constants (DAILY, WEEKLY, MONTHLY, QUARTERLY, YEARLY)
- **`src/popoto/fields/cyclic_decay_field.py`** — `CyclicDecayField` class with extended Lua script, companion hash management
- **`src/popoto/models/query.py`** — `top_by_decay()` dispatches to extended Lua script for CyclicDecayField; fixed sorted set key prefix to use actual field class
- **`src/popoto/models/base.py`** — Added `resolve_pressure()` method to Model
- **`src/popoto/__init__.py`** — Exports `CyclicDecayField` and `TemporalPeriod`
- **`tests/test_cyclic_decay_field.py`** — 44 comprehensive tests
- **`docs/features/cyclic-decay-field.md`** — Feature documentation

## Testing

- [x] 44 new tests covering init, save, delete, cyclic resonance, pressure, three-force superposition, equivalence, partitions, error cases, benchmarks
- [x] All 30 existing DecayingSortedField tests still pass
- [x] Full test suite passes (435 passed, 10 skipped)
- [x] Ruff lint clean on new files
- [x] Benchmarks: 1K members < 2s, 10K members < 10s with full cycle+pressure data

## Key Design Decisions

- Companion hashes store per-member cycle/pressure data (enables future per-member entrainment)
- `on_save()` preserves existing `last_resolved` on re-save (prevents undoing `resolve_pressure()`)
- Nil HGET lookups short-circuit cleanly — members without companion data rank by pure decay
- CyclicDecayField gets its own `$CyclicDecayF` key prefix via metaclass

Closes #196