### PR TITLE
Add AccessTrackerMixin with staged vs confirmed read tracking

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -5,7 +5,7 @@ Complete reference for all public classes, methods, and functions in the Popoto 
 ```python
 from popoto import Model, Field, KeyField, AutoKeyField, UniqueKeyField
 from popoto import SortedField, SortedKeyField, GeoField, DatetimeField, Relationship
-from popoto import DecayingSortedField, CyclicDecayField, TemporalPeriod
+from popoto import DecayingSortedField, CyclicDecayField, TemporalPeriod, AccessTrackerMixin
 from popoto import Publisher, Subscriber
 from popoto import ModelException, QueryException, PublisherException, SubscriberException
 ```
@@ -889,6 +889,39 @@ See [CyclicDecayField](features/cyclic-decay-field.md) for usage examples and
 | `cycles` | `list` | `[]` | List of `(period, amplitude, phase)` tuples. Use `TemporalPeriod` constants. |
 | `pressure_rate` | `float` | `0.0` | Rate of urgency buildup per unresolved day. Must be >= 0. |
 | `partition_by` | `str` or `tuple` | `()` | Partition the sorted set by key field values (inherited). |
+
+### AccessTrackerMixin
+
+```python
+from popoto import AccessTrackerMixin
+
+class MyModel(AccessTrackerMixin, Model):
+    _max_access_log = 100  # max confirmed timestamps kept (default)
+    _track_reads = True    # auto-fire on_read from queries (default)
+```
+
+A model mixin that tracks read access patterns with a two-stage pipeline (staged → confirmed).
+See [Agent Memory — AccessTracker](features/agent-memory.md#accesstracker) for full usage guide.
+
+#### AccessTrackerMixin.on\_read(pipeline=None)
+
+Stage a read by appending the current timestamp to the staging list. Called automatically by query hooks.
+
+#### AccessTrackerMixin.confirm\_access(pipeline=None) -> int
+
+Atomically promote all staged timestamps to the confirmed access log via Lua script. Returns the number of staged reads promoted. Raises `TypeError` if the instance has not been saved.
+
+#### AccessTrackerMixin.discard\_staged\_access(pipeline=None)
+
+Clear the staging list without affecting confirmed data.
+
+#### AccessTrackerMixin.access\_count -> int
+
+Total number of confirmed read accesses. Returns `0` if never confirmed.
+
+#### AccessTrackerMixin.last\_accessed -> float | None
+
+Timestamp of the most recent confirmed read. Returns `None` if never confirmed.
 
 ### GeoField
 

--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -24,7 +24,7 @@ The primitives ship incrementally. Each builds on the ones before it.
 |-----------|-------------|--------|
 | [DecayingSortedField](#decayingsortedfield) | Time-weighted scoring — records lose relevance over time unless refreshed | Shipped ([PR #199](https://github.com/tomcounsell/popoto/pull/199)) |
 | [CyclicDecayField](#cyclicdecayfield) | Temporal rhythms + homeostatic pressure on top of decay | Shipped ([PR #201](https://github.com/tomcounsell/popoto/pull/201)) |
-| [AccessTracker](#accesstracker) | Tracks read patterns — access count, timestamps, spacing effects | [#197](https://github.com/tomcounsell/popoto/issues/197) |
+| [AccessTracker](#accesstracker) | Tracks read patterns — access count, timestamps, spacing effects | Shipped ([PR #203](https://github.com/tomcounsell/popoto/pull/203)) |
 | [ObservationProtocol](#accesstracker) | Outcome-driven memory effects — acted/dismissed/deferred/contradicted | [#198](https://github.com/tomcounsell/popoto/issues/198) |
 | [WriteFilter](#writefilter) | Gates persistence — low-value records silently discarded at write time | Planned |
 | [ConfidenceField](#confidencefield) | Bayesian certainty — corroboration strengthens, contradiction weakens | Planned |
@@ -253,17 +253,68 @@ See [CyclicDecayField feature docs](cyclic-decay-field.md) for the full referenc
 
 ## AccessTracker
 
-Tracks read access patterns on any model: access count, last-accessed timestamp, and a capped list of access timestamps. Combined with `DecayingSortedField`, this enables spacing-effect-aware scoring — records accessed repeatedly over time rank higher than records accessed many times in a burst.
+Tracks read access patterns on any model using a two-stage pipeline: reads are first staged (cheap), then atomically promoted to a confirmed access log. This prevents naive "every read strengthens" behavior — only meaningful reads count.
+
+Shipped in [PR #203](https://github.com/tomcounsell/popoto/pull/203).
+
+### Basic usage
 
 ```python
+from popoto import Model, KeyField, Field, AccessTrackerMixin, DecayingSortedField
+
 class Memory(Model, AccessTrackerMixin):
     agent_id = KeyField()
     content = Field(type=str)
     relevance = DecayingSortedField()
+
+# Reading triggers on_read() automatically via query hooks
+memories = Memory.query.filter(agent_id="agent-1").top_by_decay("relevance", 5)
+
+# After the agent acts on a memory, confirm the read
+memories[0].confirm_access()       # promotes staged → confirmed
+memories[1].discard_staged_access() # clears staging without promoting
+
+# Inspect access patterns
+print(memories[0].access_count)    # 42
+print(memories[0].last_accessed)   # 1741872000.0
 ```
 
-!!! note
-    AccessTracker introduces an `on_read()` hook to the field protocol. Details TBD during implementation.
+### How staging works
+
+`on_read()` fires automatically when instances are hydrated via `Query.get()`, `Query.filter()`, `top_by_decay()`, and their async variants. Each call appends a timestamp to a per-instance staging list (`RPUSH` — single Redis command, batched via pipeline).
+
+Staged reads are not yet "real" — they represent candidate accesses. Your application decides which reads were meaningful:
+
+- `confirm_access()` — atomically promotes all staged timestamps to the confirmed access log using a Lua script. Updates `access_count` and `last_accessed`.
+- `discard_staged_access()` — clears staging without affecting confirmed data.
+
+### Configuration
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `_max_access_log` | `int` | `100` | Maximum timestamps kept in the confirmed access log. Older entries trimmed on confirm. |
+| `_track_reads` | `bool` | `True` | Set to `False` to disable automatic `on_read()` from queries. |
+
+### Suppressing tracking for bulk operations
+
+Use `no_track()` on the query builder to prevent `on_read()` from firing during internal operations like reindexing or migration:
+
+```python
+# These reads won't be tracked
+Memory.query.filter(agent_id="agent-1").no_track().all()
+```
+
+### Delete cleanup
+
+When a tracked model instance is deleted, all three AccessTracker Redis keys (staged, access_log, meta) are automatically removed.
+
+### Redis key patterns
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `$AT:{ClassName}:staged:{pk}` | List | Pending read timestamps |
+| `$AT:{ClassName}:access_log:{pk}` | List | Confirmed access timestamps (capped) |
+| `$AT:{ClassName}:meta:{pk}` | Hash | `access_count` (int) and `last_accessed` (float) |
 
 ## WriteFilter
 

--- a/docs/plans/access_tracker_mixin.md
+++ b/docs/plans/access_tracker_mixin.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: Shipped
 type: feature
 appetite: Medium
 owner: Solo dev

--- a/docs/query.md
+++ b/docs/query.md
@@ -195,6 +195,7 @@ The `QueryBuilder` returned by `filter()` supports these chainable methods:
 | `limit(n)` | Set maximum number of results |
 | `values(*fields)` | Return dicts with specified fields instead of model instances |
 | `computed_sort(fn, reverse)` | Sort by a Python key function (applied after fetch, before limit) |
+| `no_track()` | Suppress `on_read()` tracking for `AccessTrackerMixin` models |
 | `all()` | Execute query and return all results as a list |
 | `first()` | Execute query and return first result or None |
 | `count()` | Count matching results without loading objects |

--- a/examples/popoto_kitchen/screens/restaurants.py
+++ b/examples/popoto_kitchen/screens/restaurants.py
@@ -241,7 +241,6 @@ class RestaurantsScreen(Container):
         Uses programmatic name generation (no modal dialog) to keep demo simple
         while still exercising the KeyField rename code path.
         """
-        import random
         from ..seed import restaurant_name
 
         table = self.query_one("#restaurants-table", DataTable)

--- a/src/popoto/__init__.py
+++ b/src/popoto/__init__.py
@@ -25,6 +25,7 @@ from .fields.shortcuts import (
     SortedKeyField,
 )
 from .fields.decaying_sorted_field import DecayingSortedField
+from .fields.access_tracker import AccessTrackerMixin
 from .fields.geo_field import GeoField
 
 try:
@@ -82,6 +83,7 @@ __all__ = [
     "SortedField",
     "SortedKeyField",
     "DecayingSortedField",
+    "AccessTrackerMixin",
     "GeoField",
     "DataFrameField",
     "Relationship",

--- a/src/popoto/fields/access_tracker.py
+++ b/src/popoto/fields/access_tracker.py
@@ -1,0 +1,204 @@
+"""AccessTrackerMixin — read pattern tracking with staged vs confirmed reads.
+
+This module provides a mixin class that adds read access tracking to any Model.
+It uses a staging pattern: reads are first recorded to a staging list, then
+atomically promoted to the confirmed access log via a Lua script.
+
+Design:
+    - on_read() appends a timestamp to a staging list (cheap, fire-and-forget)
+    - confirm_access() atomically promotes staged timestamps to the confirmed log
+    - discard_staged_access() discards staged reads without affecting confirmed data
+    - Access log is capped at max_access_log entries (default 100)
+
+Redis Key Patterns:
+    - $AT:{ClassName}:staged:{redis_key} — staging list (RPUSH timestamps)
+    - $AT:{ClassName}:access_log:{redis_key} — confirmed access timestamps
+    - $AT:{ClassName}:meta:{redis_key} — hash with access_count and last_accessed
+
+Example:
+    class Memory(AccessTrackerMixin, Model):
+        key = UniqueKeyField()
+        content = StringField()
+
+    memory = Memory.query.get(key="important")  # auto-stages on_read
+    memory.confirm_access()  # promote staged reads to confirmed log
+    print(memory.access_count)  # total confirmed read count
+    print(memory.last_accessed)  # timestamp of most recent confirmed read
+"""
+
+import logging
+import time
+
+from ..redis_db import POPOTO_REDIS_DB
+
+logger = logging.getLogger("POPOTO.AccessTracker")
+
+# Lua script: atomically promote staged reads to confirmed access log.
+# KEYS[1] = staged list key
+# KEYS[2] = access log key
+# KEYS[3] = meta hash key
+# ARGV[1] = max_access_log (cap)
+CONFIRM_ACCESS_LUA = """
+local staged = redis.call('LRANGE', KEYS[1], 0, -1)
+if #staged == 0 then return 0 end
+for _, ts in ipairs(staged) do
+    redis.call('RPUSH', KEYS[2], ts)
+end
+redis.call('LTRIM', KEYS[2], -tonumber(ARGV[1]), -1)
+redis.call('HINCRBY', KEYS[3], 'access_count', #staged)
+redis.call('HSET', KEYS[3], 'last_accessed', staged[#staged])
+redis.call('DEL', KEYS[1])
+return #staged
+"""
+
+
+class AccessTrackerMixin:
+    """Mixin that adds read access tracking to any Model.
+
+    Add this as a base class alongside Model to enable read tracking:
+
+        class MyModel(AccessTrackerMixin, Model):
+            ...
+
+    Class Attributes:
+        _max_access_log: Maximum number of timestamps to keep in the access log.
+            Older entries are trimmed on confirm. Default 100.
+        _track_reads: Whether to automatically track reads from queries.
+            Default True.
+
+    Note: Attributes are prefixed with underscore to avoid conflict with
+    Popoto's ModelBase metaclass, which requires public attributes to be Fields.
+    """
+
+    _max_access_log = 100
+    _track_reads = True
+
+    def _at_key(self, kind):
+        """Build an access tracker Redis key.
+
+        Args:
+            kind: One of 'staged', 'access_log', 'meta'
+
+        Returns:
+            str: Redis key like '$AT:ClassName:kind:redis_key'
+        """
+        class_name = type(self).__name__
+        redis_key = self._redis_key or self.db_key.redis_key
+        return f"$AT:{class_name}:{kind}:{redis_key}"
+
+    def on_read(self, pipeline=None):
+        """Record a read access by staging a timestamp.
+
+        Appends the current timestamp to the staging list. This is a cheap
+        operation suitable for fire-and-forget use from query hooks.
+
+        Args:
+            pipeline: Optional Redis pipeline for batch operations.
+        """
+        ts = str(time.time())
+        staged_key = self._at_key("staged")
+        if pipeline:
+            pipeline.rpush(staged_key, ts)
+        else:
+            POPOTO_REDIS_DB.rpush(staged_key, ts)
+
+    def confirm_access(self, pipeline=None):
+        """Atomically promote staged reads to the confirmed access log.
+
+        Uses a Lua script to:
+        1. Move all staged timestamps to the access log
+        2. Trim the log to max_access_log entries
+        3. Update access_count and last_accessed in the meta hash
+        4. Delete the staging list
+
+        Args:
+            pipeline: Optional Redis pipeline (not used for Lua eval,
+                reserved for future use).
+
+        Returns:
+            int: Number of staged reads that were promoted.
+
+        Raises:
+            TypeError: If the model instance has not been saved to Redis.
+        """
+        if not hasattr(self, "_redis_key") and not hasattr(self, "db_key"):
+            raise TypeError("confirm_access() requires a saved model instance")
+        try:
+            redis_key = self._redis_key or self.db_key.redis_key
+        except Exception:
+            raise TypeError("confirm_access() requires a saved model instance")
+
+        # Check if the model has been saved (has a valid redis key in the DB)
+        if not POPOTO_REDIS_DB.exists(redis_key):
+            raise TypeError("confirm_access() requires a saved model instance")
+
+        staged_key = self._at_key("staged")
+        log_key = self._at_key("access_log")
+        meta_key = self._at_key("meta")
+
+        count = POPOTO_REDIS_DB.eval(
+            CONFIRM_ACCESS_LUA,
+            3,  # number of KEYS
+            staged_key,
+            log_key,
+            meta_key,
+            str(self._max_access_log),
+        )
+        return int(count)
+
+    def discard_staged_access(self, pipeline=None):
+        """Discard all staged reads without affecting confirmed data.
+
+        Args:
+            pipeline: Optional Redis pipeline for batch operations.
+        """
+        staged_key = self._at_key("staged")
+        if pipeline:
+            pipeline.delete(staged_key)
+        else:
+            POPOTO_REDIS_DB.delete(staged_key)
+
+    @property
+    def access_count(self):
+        """Total number of confirmed read accesses.
+
+        Returns:
+            int: The cumulative access count, or 0 if never confirmed.
+        """
+        meta_key = self._at_key("meta")
+        raw = POPOTO_REDIS_DB.hget(meta_key, "access_count")
+        if raw is None:
+            return 0
+        return int(raw)
+
+    @property
+    def last_accessed(self):
+        """Timestamp of the most recent confirmed read access.
+
+        Returns:
+            float or None: Unix timestamp, or None if never confirmed.
+        """
+        meta_key = self._at_key("meta")
+        raw = POPOTO_REDIS_DB.hget(meta_key, "last_accessed")
+        if raw is None:
+            return None
+        return float(raw)
+
+    def _delete_access_tracker_keys(self, pipeline=None):
+        """Remove all access tracker Redis keys for this instance.
+
+        Called during model deletion to clean up tracking data.
+
+        Args:
+            pipeline: Optional Redis pipeline for batch operations.
+        """
+        keys = [
+            self._at_key("staged"),
+            self._at_key("access_log"),
+            self._at_key("meta"),
+        ]
+        if pipeline:
+            for key in keys:
+                pipeline.delete(key)
+        else:
+            POPOTO_REDIS_DB.delete(*keys)

--- a/src/popoto/fields/shortcuts.py
+++ b/src/popoto/fields/shortcuts.py
@@ -481,7 +481,7 @@ class ListField(Field):
         # Encode each element individually
         encoded_values = [_encode_list_element(v) for v in data]
 
-        if hasattr(pipeline, 'execute'):
+        if hasattr(pipeline, "execute"):
             pipeline.delete(list_key)
             if encoded_values:
                 pipeline.rpush(list_key, *encoded_values)

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -1560,7 +1560,7 @@ class Model(metaclass=ModelBase):
             if index_hash:
                 pipeline = pipeline.hdel(index_key, index_hash)
 
-        # Clean up AccessTrackerMixin keys if applicable  # 5
+        # Clean up AccessTrackerMixin keys if applicable
         from ..fields.access_tracker import AccessTrackerMixin
 
         if isinstance(self, AccessTrackerMixin):

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -323,7 +323,6 @@ class ModelBase(type):
     """
 
     def __new__(cls, name, bases, attrs, **kwargs):
-
         # Initialization is only performed for a Model and its subclasses
         parents = [b for b in bases if isinstance(b, ModelBase)]
         if not parents:
@@ -1561,8 +1560,14 @@ class Model(metaclass=ModelBase):
             if index_hash:
                 pipeline = pipeline.hdel(index_key, index_hash)
 
-        self._db_content = dict()  # 5
-        self._saved_field_values = dict()  # 5
+        # Clean up AccessTrackerMixin keys if applicable  # 5
+        from ..fields.access_tracker import AccessTrackerMixin
+
+        if isinstance(self, AccessTrackerMixin):
+            self._delete_access_tracker_keys(pipeline=pipeline)
+
+        self._db_content = dict()  # 6
+        self._saved_field_values = dict()  # 6
 
         if db_response is not False:
             pipeline.execute()

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -76,6 +76,36 @@ class QueryException(Exception):
     pass
 
 
+def _fire_on_read(model_class, instances):
+    """Fire on_read() for AccessTrackerMixin models after hydration.
+
+    Batches all RPUSH commands into a single pipeline for efficiency.
+    Only fires when the model class uses AccessTrackerMixin and
+    _track_reads is True.
+
+    Args:
+        model_class: The Model class being queried
+        instances: List of hydrated model instances
+    """
+    from ..fields.access_tracker import AccessTrackerMixin
+
+    if not issubclass(model_class, AccessTrackerMixin):
+        return
+    if not getattr(model_class, "_track_reads", True):
+        return
+    valid = [
+        inst
+        for inst in instances
+        if hasattr(inst, "_redis_key") or hasattr(inst, "db_key")
+    ]
+    if not valid:
+        return
+    pipe = POPOTO_REDIS_DB.pipeline()
+    for inst in valid:
+        inst.on_read(pipeline=pipe)
+    pipe.execute()
+
+
 class QueryBuilder:
     """Chainable query builder that accumulates query state.
 
@@ -113,6 +143,7 @@ class QueryBuilder:
         self._values_tuple = None
         self._computed_sort_fn = None
         self._computed_sort_reverse = False
+        self._no_track = False
 
     def filter(self, *args, **kwargs) -> "QueryBuilder":
         """Add filter criteria and return a new QueryBuilder.
@@ -153,6 +184,7 @@ class QueryBuilder:
         new_builder._values_tuple = self._values_tuple
         new_builder._computed_sort_fn = self._computed_sort_fn
         new_builder._computed_sort_reverse = self._computed_sort_reverse
+        new_builder._no_track = self._no_track
         return new_builder
 
     def limit(self, n: int) -> "QueryBuilder":
@@ -239,6 +271,21 @@ class QueryBuilder:
             raise TypeError("computed_sort() requires a callable, got None")
         self._computed_sort_fn = fn
         self._computed_sort_reverse = reverse
+        return self
+
+    def no_track(self) -> "QueryBuilder":
+        """Suppress on_read() tracking for this query.
+
+        Use for internal operations (reindex, migration) that shouldn't
+        count as reads for AccessTrackerMixin models.
+
+        Returns:
+            Self for method chaining
+
+        Example:
+            results = Model.query.filter(status="active").no_track().all()
+        """
+        self._no_track = True
         return self
 
     def top_by_decay(self, field_name, n=10, decay_rate=None, base_score_field=None):
@@ -343,6 +390,9 @@ class QueryBuilder:
                 instance = decode_popoto_model_hashmap(model_class, data)
                 instances.append(instance)
 
+        if not self._no_track:
+            _fire_on_read(model_class, instances)
+
         return instances
 
     def all(self) -> list:
@@ -368,7 +418,9 @@ class QueryBuilder:
                 )
             if self._values_tuple is not None:
                 kwargs["values"] = self._values_tuple
-            results = self._query._execute_filter(q_objects=self._q_objects, **kwargs)
+            results = self._query._execute_filter(
+                q_objects=self._q_objects, _no_track=self._no_track, **kwargs
+            )
             # Apply computed sort (O(N log N) on full result set)
             results = sorted(
                 results,
@@ -387,7 +439,9 @@ class QueryBuilder:
             kwargs["order_by"] = self._order_by_value
         if self._values_tuple is not None:
             kwargs["values"] = self._values_tuple
-        return self._query._execute_filter(q_objects=self._q_objects, **kwargs)
+        return self._query._execute_filter(
+            q_objects=self._q_objects, _no_track=self._no_track, **kwargs
+        )
 
     def count(self) -> int:
         """Count matching results without loading objects.
@@ -595,6 +649,7 @@ class Query:
             if not hashmap:
                 return None
             instance = decode_popoto_model_hashmap(self.model_class, hashmap)
+            _fire_on_read(self.model_class, [instance])
 
         else:
             instances = self.filter(**kwargs)
@@ -1071,7 +1126,9 @@ class Query:
             field_name, n=n, decay_rate=decay_rate, base_score_field=base_score_field
         )
 
-    def _execute_filter(self, q_objects: list = None, **kwargs) -> list:
+    def _execute_filter(
+        self, q_objects: list = None, _no_track: bool = False, **kwargs
+    ) -> list:
         """Internal method to execute filter logic and return results.
 
         This is the actual filter execution, called by QueryBuilder.all() and
@@ -1079,6 +1136,7 @@ class Query:
 
         Args:
             q_objects: List of Q objects for complex query expressions
+            _no_track: If True, suppress on_read() for AccessTrackerMixin models
             **kwargs: Filter parameters and result modifiers
 
         Returns:
@@ -1171,7 +1229,15 @@ class Query:
             model_objects.sort(key=lambda o: getattr(o, "_geo_distance", float("inf")))
             objects = model_objects + dict_objects
 
-        return self.prepare_results(objects, **kwargs)
+        results = self.prepare_results(objects, **kwargs)
+
+        # Fire on_read for AccessTrackerMixin models (skip for value projections)
+        if not _no_track and not kwargs.get("values"):
+            model_results = [r for r in results if not isinstance(r, dict)]
+            if model_results:
+                _fire_on_read(self.model_class, model_results)
+
+        return results
 
     def prepare_results(
         self,
@@ -1467,6 +1533,7 @@ class Query:
             if not hashmap:
                 return None
             instance = decode_popoto_model_hashmap(self.model_class, hashmap)
+            await to_thread(_fire_on_read, self.model_class, [instance])
         else:
             instances = await self.async_filter(**kwargs)
             if len(instances) > 1:
@@ -1765,10 +1832,13 @@ class Query:
                 "one or more redis keys points to missing objects. Debug with Model.query.keys(clean=True)"
             )
 
-        return [
+        objects = [
             decode_popoto_model_hashmap(
                 model, redis_hash, fields_only=bool(values), lazy=lazy and not values
             )
             for redis_hash in hashes_list
             if redis_hash
         ]
+        if not values:
+            await to_thread(_fire_on_read, model, objects)
+        return objects

--- a/tests/test_access_tracker.py
+++ b/tests/test_access_tracker.py
@@ -1,0 +1,558 @@
+"""Tests for AccessTrackerMixin — read pattern tracking with staged vs confirmed reads.
+
+Tests cover:
+- on_read() stages timestamps (single and batch)
+- confirm_access() promotes staged reads, increments count, updates last_accessed
+- discard_staged_access() clears staging without affecting confirmed
+- access_log capping (stage 150 reads, confirm, verify 100 in log)
+- access_count and last_accessed properties (zero-state and after confirm)
+- no_track() suppresses on_read
+- delete cleanup removes all 3 keys
+- models without AccessTrackerMixin are unaffected
+- concurrent on_read + confirm (threading-based)
+- confirm_access() on unsaved model raises TypeError
+- confirm_access() when staging is empty returns 0
+"""
+
+import sys
+import os
+import time
+import threading
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+import pytest
+from src import popoto
+from src.popoto.fields.access_tracker import AccessTrackerMixin
+
+
+# --- Test Models ---
+
+
+class TrackedItem(AccessTrackerMixin, popoto.Model):
+    name = popoto.UniqueKeyField()
+    content = popoto.StringField(default="")
+
+
+class TrackedItemSmallCap(AccessTrackerMixin, popoto.Model):
+    _max_access_log = 10
+    name = popoto.UniqueKeyField()
+
+
+class UntrackedItem(popoto.Model):
+    name = popoto.UniqueKeyField()
+    content = popoto.StringField(default="")
+
+
+# --- Setup / Teardown ---
+
+
+def setup_module():
+    """Clean up test data before running tests."""
+    for model in [TrackedItem, TrackedItemSmallCap, UntrackedItem]:
+        model.delete_all()
+
+
+def teardown_module():
+    """Clean up test data after running tests."""
+    for model in [TrackedItem, TrackedItemSmallCap, UntrackedItem]:
+        model.delete_all()
+    # Clean up any leftover access tracker keys
+    redis = popoto.get_redis()
+    for key in redis.keys("$AT:*"):
+        redis.delete(key)
+
+
+# --- on_read() tests ---
+
+
+class TestOnRead:
+    """Test that on_read() stages timestamps."""
+
+    def setup_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def teardown_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def test_on_read_stages_timestamp(self):
+        """on_read() pushes a timestamp to the staging list."""
+        item = TrackedItem.create(name="read_test")
+        before = time.time()
+        item.on_read()
+        after = time.time()
+
+        redis = popoto.get_redis()
+        staged_key = f"$AT:TrackedItem:staged:{item.db_key.redis_key}"
+        staged = redis.lrange(staged_key, 0, -1)
+        assert len(staged) == 1
+        ts = float(staged[0])
+        assert before <= ts <= after
+
+    def test_on_read_multiple_stages(self):
+        """Multiple on_read() calls accumulate in staging."""
+        item = TrackedItem.create(name="multi_read")
+        for _ in range(5):
+            item.on_read()
+
+        redis = popoto.get_redis()
+        staged_key = f"$AT:TrackedItem:staged:{item.db_key.redis_key}"
+        staged = redis.lrange(staged_key, 0, -1)
+        assert len(staged) == 5
+
+    def test_on_read_with_pipeline(self):
+        """on_read() works with an existing pipeline."""
+        item = TrackedItem.create(name="pipe_read")
+        pipe = popoto.get_redis().pipeline()
+        item.on_read(pipeline=pipe)
+        pipe.execute()
+
+        redis = popoto.get_redis()
+        staged_key = f"$AT:TrackedItem:staged:{item.db_key.redis_key}"
+        staged = redis.lrange(staged_key, 0, -1)
+        assert len(staged) == 1
+
+
+# --- confirm_access() tests ---
+
+
+class TestConfirmAccess:
+    """Test that confirm_access() promotes staged reads."""
+
+    def setup_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def teardown_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def test_confirm_promotes_staged(self):
+        """confirm_access() moves staged timestamps to access_log."""
+        item = TrackedItem.create(name="confirm_test")
+        item.on_read()
+        item.on_read()
+        count = item.confirm_access()
+
+        assert count == 2
+
+        redis = popoto.get_redis()
+        staged_key = f"$AT:TrackedItem:staged:{item.db_key.redis_key}"
+        log_key = f"$AT:TrackedItem:access_log:{item.db_key.redis_key}"
+
+        # Staging should be empty after confirm
+        assert redis.llen(staged_key) == 0
+        # Log should have the timestamps
+        assert redis.llen(log_key) == 2
+
+    def test_confirm_increments_access_count(self):
+        """confirm_access() increments access_count in meta hash."""
+        item = TrackedItem.create(name="count_test")
+        item.on_read()
+        item.on_read()
+        item.on_read()
+        item.confirm_access()
+
+        assert item.access_count == 3
+
+    def test_confirm_updates_last_accessed(self):
+        """confirm_access() updates last_accessed to latest timestamp."""
+        item = TrackedItem.create(name="last_test")
+        before = time.time()
+        item.on_read()
+        item.confirm_access()
+        after = time.time()
+
+        assert item.last_accessed is not None
+        assert before <= item.last_accessed <= after
+
+    def test_confirm_empty_staging_returns_zero(self):
+        """confirm_access() when staging is empty returns 0."""
+        item = TrackedItem.create(name="empty_confirm")
+        count = item.confirm_access()
+        assert count == 0
+
+    def test_confirm_on_unsaved_raises(self):
+        """confirm_access() on unsaved model raises TypeError."""
+        item = TrackedItem(name="unsaved")
+        with pytest.raises(TypeError):
+            item.confirm_access()
+
+    def test_confirm_multiple_rounds(self):
+        """Multiple confirm rounds accumulate access_count."""
+        item = TrackedItem.create(name="multi_confirm")
+        item.on_read()
+        item.on_read()
+        item.confirm_access()
+
+        item.on_read()
+        item.confirm_access()
+
+        assert item.access_count == 3
+
+
+# --- discard_staged_access() tests ---
+
+
+class TestDiscardStagedAccess:
+    """Test that discard_staged_access() clears staging without affecting confirmed."""
+
+    def setup_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def teardown_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def test_discard_clears_staging(self):
+        """discard_staged_access() removes staging list."""
+        item = TrackedItem.create(name="discard_test")
+        item.on_read()
+        item.on_read()
+        item.discard_staged_access()
+
+        redis = popoto.get_redis()
+        staged_key = f"$AT:TrackedItem:staged:{item.db_key.redis_key}"
+        assert redis.llen(staged_key) == 0
+
+    def test_discard_preserves_confirmed(self):
+        """discard_staged_access() does not affect already confirmed data."""
+        item = TrackedItem.create(name="discard_preserve")
+        item.on_read()
+        item.on_read()
+        item.confirm_access()
+
+        # Stage more, then discard
+        item.on_read()
+        item.on_read()
+        item.on_read()
+        item.discard_staged_access()
+
+        # Original confirmed data should remain
+        assert item.access_count == 2
+
+        redis = popoto.get_redis()
+        log_key = f"$AT:TrackedItem:access_log:{item.db_key.redis_key}"
+        assert redis.llen(log_key) == 2
+
+
+# --- Access log capping tests ---
+
+
+class TestAccessLogCapping:
+    """Test that access_log is capped at max_access_log."""
+
+    def setup_method(self):
+        TrackedItemSmallCap.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def teardown_method(self):
+        TrackedItemSmallCap.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def test_capping_at_max_access_log(self):
+        """Stage 20 reads with max_access_log=10, confirm, verify 10 in log."""
+        item = TrackedItemSmallCap.create(name="cap_test")
+        for _ in range(20):
+            item.on_read()
+        item.confirm_access()
+
+        redis = popoto.get_redis()
+        log_key = f"$AT:TrackedItemSmallCap:access_log:{item.db_key.redis_key}"
+        log_len = redis.llen(log_key)
+        assert log_len == 10
+
+        # But access_count should reflect all 20
+        assert item.access_count == 20
+
+    def test_default_cap_100(self):
+        """Default max_access_log is 100."""
+        item = TrackedItem.create(name="default_cap")
+        for _ in range(150):
+            item.on_read()
+        item.confirm_access()
+
+        redis = popoto.get_redis()
+        log_key = f"$AT:TrackedItem:access_log:{item.db_key.redis_key}"
+        log_len = redis.llen(log_key)
+        assert log_len == 100
+
+        assert item.access_count == 150
+
+
+# --- Properties tests ---
+
+
+class TestProperties:
+    """Test access_count and last_accessed properties."""
+
+    def setup_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def teardown_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def test_access_count_default_zero(self):
+        """access_count returns 0 for fresh model."""
+        item = TrackedItem.create(name="zero_count")
+        assert item.access_count == 0
+
+    def test_last_accessed_default_none(self):
+        """last_accessed returns None for fresh model."""
+        item = TrackedItem.create(name="no_access")
+        assert item.last_accessed is None
+
+
+# --- no_track() tests ---
+
+
+class TestNoTrack:
+    """Test that no_track() suppresses on_read firing from queries."""
+
+    def setup_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def teardown_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def test_no_track_suppresses_on_read(self):
+        """no_track() prevents on_read from being called during query."""
+        TrackedItem.create(name="no_track_test")
+
+        # Normal get should fire on_read
+        TrackedItem.query.get(name="no_track_test")
+        redis = popoto.get_redis()
+        staged_key = f"$AT:TrackedItem:staged:{TrackedItem(name='no_track_test').db_key.redis_key}"
+        normal_count = redis.llen(staged_key)
+
+        # no_track get should NOT fire on_read
+        TrackedItem.query.filter(name="no_track_test").no_track().all()
+        after_no_track_count = redis.llen(staged_key)
+
+        # Count should have increased from normal get but not from no_track
+        assert normal_count == 1
+        assert after_no_track_count == 1
+
+
+# --- Delete cleanup tests ---
+
+
+class TestDeleteCleanup:
+    """Test that delete() cleans up all 3 access tracker keys."""
+
+    def setup_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def teardown_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def test_delete_removes_all_keys(self):
+        """delete() removes staged, access_log, and meta keys."""
+        item = TrackedItem.create(name="delete_test")
+        item.on_read()
+        item.on_read()
+        item.confirm_access()
+        item.on_read()  # leave some in staging too
+
+        redis_key = item.db_key.redis_key
+        item.delete()
+
+        redis = popoto.get_redis()
+        assert redis.exists(f"$AT:TrackedItem:staged:{redis_key}") == 0
+        assert redis.exists(f"$AT:TrackedItem:access_log:{redis_key}") == 0
+        assert redis.exists(f"$AT:TrackedItem:meta:{redis_key}") == 0
+
+
+# --- Untracked model tests ---
+
+
+class TestUntrackedModel:
+    """Test that models without AccessTrackerMixin are unaffected."""
+
+    def setup_method(self):
+        UntrackedItem.delete_all()
+
+    def teardown_method(self):
+        UntrackedItem.delete_all()
+
+    def test_untracked_model_no_on_read(self):
+        """Models without AccessTrackerMixin have no on_read method."""
+        item = UntrackedItem.create(name="untracked")
+        assert not hasattr(item, "on_read")
+
+    def test_untracked_get_no_side_effects(self):
+        """Getting an untracked model creates no $AT keys."""
+        UntrackedItem.create(name="untracked_get")
+        UntrackedItem.query.get(name="untracked_get")
+
+        redis = popoto.get_redis()
+        at_keys = redis.keys("$AT:UntrackedItem:*")
+        assert len(at_keys) == 0
+
+
+# --- Concurrent access tests ---
+
+
+class TestConcurrentAccess:
+    """Test concurrent on_read + confirm scenarios."""
+
+    def setup_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def teardown_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def test_concurrent_on_read(self):
+        """Multiple threads calling on_read() concurrently."""
+        item = TrackedItem.create(name="concurrent_test")
+        errors = []
+
+        def do_reads():
+            try:
+                for _ in range(10):
+                    item.on_read()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=do_reads) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+        redis = popoto.get_redis()
+        staged_key = f"$AT:TrackedItem:staged:{item.db_key.redis_key}"
+        staged = redis.lrange(staged_key, 0, -1)
+        assert len(staged) == 50  # 5 threads * 10 reads
+
+    def test_concurrent_read_and_confirm(self):
+        """on_read and confirm_access can run concurrently safely."""
+        item = TrackedItem.create(name="concurrent_confirm")
+        errors = []
+
+        def do_reads():
+            try:
+                for _ in range(20):
+                    item.on_read()
+                    time.sleep(0.001)
+            except Exception as e:
+                errors.append(e)
+
+        def do_confirms():
+            try:
+                for _ in range(5):
+                    item.confirm_access()
+                    time.sleep(0.005)
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=do_reads)
+        t2 = threading.Thread(target=do_confirms)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert len(errors) == 0
+        # Final confirm to capture any remaining staged
+        item.confirm_access()
+        # All 20 reads should be accounted for
+        assert item.access_count == 20
+
+
+# --- Query integration tests ---
+
+
+class TestQueryIntegration:
+    """Test that queries fire on_read for AccessTrackerMixin models."""
+
+    def setup_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def teardown_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.keys("$AT:*"):
+            redis.delete(key)
+
+    def test_get_fires_on_read(self):
+        """Query.get() fires on_read for tracked models."""
+        TrackedItem.create(name="query_get")
+        TrackedItem.query.get(name="query_get")
+
+        redis = popoto.get_redis()
+        staged_key = (
+            f"$AT:TrackedItem:staged:{TrackedItem(name='query_get').db_key.redis_key}"
+        )
+        assert redis.llen(staged_key) == 1
+
+    def test_filter_fires_on_read(self):
+        """Query.filter().all() fires on_read for tracked models."""
+        TrackedItem.create(name="query_filter")
+        TrackedItem.query.filter(name="query_filter").all()
+
+        redis = popoto.get_redis()
+        staged_key = f"$AT:TrackedItem:staged:{TrackedItem(name='query_filter').db_key.redis_key}"
+        assert redis.llen(staged_key) == 1
+
+
+# --- Export tests ---
+
+
+class TestExport:
+    """Test that AccessTrackerMixin is accessible from popoto package."""
+
+    def test_importable(self):
+        """AccessTrackerMixin can be imported from popoto."""
+        from src.popoto import AccessTrackerMixin as ATM
+
+        assert ATM is AccessTrackerMixin

--- a/tests/test_access_tracker.py
+++ b/tests/test_access_tracker.py
@@ -60,7 +60,7 @@ def teardown_module():
         model.delete_all()
     # Clean up any leftover access tracker keys
     redis = popoto.get_redis()
-    for key in redis.keys("$AT:*"):
+    for key in redis.scan_iter("$AT:*"):
         redis.delete(key)
 
 
@@ -73,13 +73,13 @@ class TestOnRead:
     def setup_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def teardown_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def test_on_read_stages_timestamp(self):
@@ -129,13 +129,13 @@ class TestConfirmAccess:
     def setup_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def teardown_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def test_confirm_promotes_staged(self):
@@ -211,13 +211,13 @@ class TestDiscardStagedAccess:
     def setup_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def teardown_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def test_discard_clears_staging(self):
@@ -261,13 +261,13 @@ class TestAccessLogCapping:
     def setup_method(self):
         TrackedItemSmallCap.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def teardown_method(self):
         TrackedItemSmallCap.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def test_capping_at_max_access_log(self):
@@ -309,13 +309,13 @@ class TestProperties:
     def setup_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def teardown_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def test_access_count_default_zero(self):
@@ -338,13 +338,13 @@ class TestNoTrack:
     def setup_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def teardown_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def test_no_track_suppresses_on_read(self):
@@ -375,13 +375,13 @@ class TestDeleteCleanup:
     def setup_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def teardown_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def test_delete_removes_all_keys(self):
@@ -437,13 +437,13 @@ class TestConcurrentAccess:
     def setup_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def teardown_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def test_concurrent_on_read(self):
@@ -515,13 +515,13 @@ class TestQueryIntegration:
     def setup_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def teardown_method(self):
         TrackedItem.delete_all()
         redis = popoto.get_redis()
-        for key in redis.keys("$AT:*"):
+        for key in redis.scan_iter("$AT:*"):
             redis.delete(key)
 
     def test_get_fires_on_read(self):
@@ -543,6 +543,172 @@ class TestQueryIntegration:
         redis = popoto.get_redis()
         staged_key = f"$AT:TrackedItem:staged:{TrackedItem(name='query_filter').db_key.redis_key}"
         assert redis.llen(staged_key) == 1
+
+
+# --- Export tests ---
+
+
+class TestSpacingEffect:
+    """Test that spaced reads produce different access logs than massed reads."""
+
+    def setup_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.scan_iter("$AT:*"):
+            redis.delete(key)
+
+    def teardown_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.scan_iter("$AT:*"):
+            redis.delete(key)
+
+    def test_spaced_vs_massed_reads(self):
+        """Spaced reads over 3 days produce different timestamps than massed reads."""
+
+        spaced = TrackedItem.create(name="spaced")
+        massed = TrackedItem.create(name="massed")
+
+        redis = popoto.get_redis()
+
+        # Simulate spaced reads: 3 reads spread across 3 days
+        day_seconds = 86400
+        base_time = time.time() - 3 * day_seconds
+        for day in range(3):
+            ts = str(base_time + day * day_seconds)
+            redis.rpush(spaced._at_key("staged"), ts)
+
+        # Simulate massed reads: 3 reads all at once
+        now = str(time.time())
+        for _ in range(3):
+            redis.rpush(massed._at_key("staged"), now)
+
+        spaced.confirm_access()
+        massed.confirm_access()
+
+        # Both have same access_count
+        assert spaced.access_count == 3
+        assert massed.access_count == 3
+
+        # But their access logs tell different stories
+        spaced_log = redis.lrange(spaced._at_key("access_log"), 0, -1)
+        massed_log = redis.lrange(massed._at_key("access_log"), 0, -1)
+
+        spaced_ts = [float(t) for t in spaced_log]
+        massed_ts = [float(t) for t in massed_log]
+
+        # Spaced reads have significant time spread
+        spaced_spread = max(spaced_ts) - min(spaced_ts)
+        massed_spread = max(massed_ts) - min(massed_ts)
+
+        assert spaced_spread > day_seconds  # spread over days
+        assert massed_spread < 1.0  # all within 1 second
+
+
+# --- Synergy test: priority score from access log ---
+
+
+class TestSynergyWithDecay:
+    """Test that confirmed access log enables priority score computation."""
+
+    def setup_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.scan_iter("$AT:*"):
+            redis.delete(key)
+
+    def teardown_method(self):
+        TrackedItem.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.scan_iter("$AT:*"):
+            redis.delete(key)
+
+    def test_priority_score_from_access_log(self):
+        """Confirmed access log timestamps enable B = ln(sum(t_j^(-d))) scoring."""
+        import math
+
+        item = TrackedItem.create(name="synergy")
+        redis = popoto.get_redis()
+
+        # Stage timestamps at known intervals (1, 2, 3 days ago)
+        now = time.time()
+        for days_ago in [1, 2, 3]:
+            ts = str(now - days_ago * 86400)
+            redis.rpush(item._at_key("staged"), ts)
+
+        item.confirm_access()
+
+        # Read back access log and compute spacing-effect priority score
+        log = redis.lrange(item._at_key("access_log"), 0, -1)
+        timestamps = [float(t) for t in log]
+
+        # B = ln(sum(t_j^(-d))) where t_j = elapsed days, d = decay rate
+        d = 0.5
+        score_sum = 0.0
+        for ts_val in timestamps:
+            elapsed_days = max((now - ts_val) / 86400, 0.001)
+            score_sum += elapsed_days ** (-d)
+
+        B = math.log(score_sum)
+        # Score should be computable and finite
+        assert math.isfinite(B)
+        # With 3 recent accesses, score should be positive
+        assert B > 0
+
+
+# --- Partition interaction test ---
+
+
+class TrackedPartitioned(AccessTrackerMixin, popoto.Model):
+    name = popoto.UniqueKeyField()
+    category = popoto.KeyField(null=False)
+    relevance = popoto.DecayingSortedField(partition_by="category")
+
+
+class TestPartitionInteraction:
+    """Test AccessTracker works correctly with partition_by on DecayingSortedField."""
+
+    def setup_method(self):
+        TrackedPartitioned.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.scan_iter("$AT:*"):
+            redis.delete(key)
+
+    def teardown_method(self):
+        TrackedPartitioned.delete_all()
+        redis = popoto.get_redis()
+        for key in redis.scan_iter("$AT:*"):
+            redis.delete(key)
+
+    def test_partition_by_with_access_tracker(self):
+        """AccessTracker keys are per-instance, independent of partition_by."""
+        a1 = TrackedPartitioned.create(name="item_a1", category="A")
+        a2 = TrackedPartitioned.create(name="item_a2", category="A")
+        b1 = TrackedPartitioned.create(name="item_b1", category="B")
+
+        # Query within partition A — should fire on_read for a1, a2 only
+        results = TrackedPartitioned.query.filter(category="A").top_by_decay(
+            "relevance", n=10
+        )
+        assert len(results) == 2
+
+        redis = popoto.get_redis()
+
+        # a1 and a2 should have staged reads
+        assert redis.llen(a1._at_key("staged")) >= 1
+        assert redis.llen(a2._at_key("staged")) >= 1
+        # b1 should have no staged reads (not in partition A query)
+        assert redis.llen(b1._at_key("staged")) == 0
+
+        # Confirm a1 and verify its AT keys don't interfere with partition index
+        a1.confirm_access()
+        assert a1.access_count >= 1
+
+        # Partition query still works correctly after confirm
+        results_after = TrackedPartitioned.query.filter(category="A").top_by_decay(
+            "relevance", n=10
+        )
+        assert len(results_after) == 2
 
 
 # --- Export tests ---

--- a/tests/test_atomic_save.py
+++ b/tests/test_atomic_save.py
@@ -8,7 +8,6 @@ records exist but indexes haven't been updated yet.
 Related: https://github.com/tomcounsell/popoto/issues/147
 """
 
-import asyncio
 
 import pytest
 

--- a/tests/test_bulk_operations.py
+++ b/tests/test_bulk_operations.py
@@ -361,6 +361,7 @@ def reset_async_connection():
     """Reset async Redis connection for each test."""
     import src.popoto.redis_db as redis_db_module
     import asyncio
+
     redis_db_module._POPOTO_ASYNC_REDIS_DB = None
     redis_db_module._async_redis_lock = asyncio.Lock()
 
@@ -373,13 +374,22 @@ class TestAsyncBulkOperations:
         """Gap 1: async_bulk_create basic functionality."""
         restaurants = [
             Restaurant(
-                name="Async Restaurant A", rating=4.0, status="pending", cuisine="Italian"
+                name="Async Restaurant A",
+                rating=4.0,
+                status="pending",
+                cuisine="Italian",
             ),
             Restaurant(
-                name="Async Restaurant B", rating=4.5, status="pending", cuisine="Japanese"
+                name="Async Restaurant B",
+                rating=4.5,
+                status="pending",
+                cuisine="Japanese",
             ),
             Restaurant(
-                name="Async Restaurant C", rating=3.8, status="pending", cuisine="Mexican"
+                name="Async Restaurant C",
+                rating=3.8,
+                status="pending",
+                cuisine="Mexican",
             ),
         ]
 

--- a/tests/test_dx_polish.py
+++ b/tests/test_dx_polish.py
@@ -1,6 +1,5 @@
 """Tests for DX polish improvements."""
 
-import pytest
 import popoto
 from popoto import Model, KeyField, Field
 from popoto.testing import use_test_db, flush_test_db

--- a/tests/test_field_index_edge_cases.py
+++ b/tests/test_field_index_edge_cases.py
@@ -113,7 +113,6 @@ def _keyfield_set_key(model_class, field_name, value):
 
 def _relationship_set_key(model_class, field_name, related_instance):
     """Build the Redis Set key for a Relationship index entry."""
-    from popoto.models.db_key import DB_key
 
     prefix = model_class._meta.fields[field_name].get_special_use_field_db_key(
         model_class, field_name
@@ -125,7 +124,6 @@ def _relationship_set_key(model_class, field_name, related_instance):
 
 def _sorted_set_key(model_class, field_name, *partition_values):
     """Build the Redis Sorted Set key for a SortedField index."""
-    from popoto.fields.sorted_field_mixin import SortedFieldMixin
 
     key = model_class._meta.fields[field_name].get_sortedset_db_key(
         model_class, field_name, *partition_values

--- a/tests/test_list_field_capped.py
+++ b/tests/test_list_field_capped.py
@@ -29,6 +29,7 @@ class UncappedListModel(popoto.Model):
 @pytest.fixture(autouse=True)
 def cleanup():
     """Remove all test model instances before and after each test."""
+
     def _do_cleanup():
         for item in CappedListModel.query.all():
             item.delete()

--- a/tests/test_lua_decay_scoring.py
+++ b/tests/test_lua_decay_scoring.py
@@ -87,9 +87,7 @@ class TestLuaBasic:
 
     def test_lua_power_function(self):
         """Lua math.pow works (needed for decay formula)."""
-        result = POPOTO_REDIS_DB.eval(
-            "return tostring(math.pow(4.0, -0.5))", 0
-        )
+        result = POPOTO_REDIS_DB.eval("return tostring(math.pow(4.0, -0.5))", 0)
         assert abs(float(result) - 0.5) < 0.001
 
     def test_lua_table_sort(self):
@@ -124,9 +122,7 @@ class TestDecayScoring:
         POPOTO_REDIS_DB.hset(self.HASH_KEY, "item:1", "1.0")
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "10"
         )
 
         assert len(result) == 2
@@ -141,19 +137,23 @@ class TestDecayScoring:
         """Recently updated member should outscore older one with same base."""
         now = time.time()
 
-        POPOTO_REDIS_DB.zadd(self.ZSET_KEY, {
-            "recent": now - 3600,       # 1 hour ago
-            "old": now - 86400 * 30,    # 30 days ago
-        })
-        POPOTO_REDIS_DB.hset(self.HASH_KEY, mapping={
-            "recent": "1.0",
-            "old": "1.0",
-        })
+        POPOTO_REDIS_DB.zadd(
+            self.ZSET_KEY,
+            {
+                "recent": now - 3600,  # 1 hour ago
+                "old": now - 86400 * 30,  # 30 days ago
+            },
+        )
+        POPOTO_REDIS_DB.hset(
+            self.HASH_KEY,
+            mapping={
+                "recent": "1.0",
+                "old": "1.0",
+            },
+        )
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "10"
         )
 
         # First result should be "recent"
@@ -171,19 +171,23 @@ class TestDecayScoring:
         now = time.time()
         same_time = now - 86400  # both 1 day ago
 
-        POPOTO_REDIS_DB.zadd(self.ZSET_KEY, {
-            "high": same_time,
-            "low": same_time,
-        })
-        POPOTO_REDIS_DB.hset(self.HASH_KEY, mapping={
-            "high": "10.0",
-            "low": "1.0",
-        })
+        POPOTO_REDIS_DB.zadd(
+            self.ZSET_KEY,
+            {
+                "high": same_time,
+                "low": same_time,
+            },
+        )
+        POPOTO_REDIS_DB.hset(
+            self.HASH_KEY,
+            mapping={
+                "high": "10.0",
+                "low": "1.0",
+            },
+        )
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "10"
         )
 
         first = result[0].decode() if isinstance(result[0], bytes) else result[0]
@@ -194,31 +198,41 @@ class TestDecayScoring:
         """Higher decay rate penalizes old items more."""
         now = time.time()
 
-        POPOTO_REDIS_DB.zadd(self.ZSET_KEY, {
-            "recent": now - 3600,        # 1 hour ago
-            "old": now - 86400 * 10,     # 10 days ago
-        })
-        POPOTO_REDIS_DB.hset(self.HASH_KEY, mapping={
-            "recent": "1.0",
-            "old": "5.0",  # old has 5x base score
-        })
+        POPOTO_REDIS_DB.zadd(
+            self.ZSET_KEY,
+            {
+                "recent": now - 3600,  # 1 hour ago
+                "old": now - 86400 * 10,  # 10 days ago
+            },
+        )
+        POPOTO_REDIS_DB.hset(
+            self.HASH_KEY,
+            mapping={
+                "recent": "1.0",
+                "old": "5.0",  # old has 5x base score
+            },
+        )
 
         # With low decay (0.1), old item's high base score can win
         result_low = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.1", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.1", "10"
         )
 
         # With high decay (1.0), recency dominates
         result_high = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "1.0", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "1.0", "10"
         )
 
-        first_low = result_low[0].decode() if isinstance(result_low[0], bytes) else result_low[0]
-        first_high = result_high[0].decode() if isinstance(result_high[0], bytes) else result_high[0]
+        first_low = (
+            result_low[0].decode()
+            if isinstance(result_low[0], bytes)
+            else result_low[0]
+        )
+        first_high = (
+            result_high[0].decode()
+            if isinstance(result_high[0], bytes)
+            else result_high[0]
+        )
 
         # Low decay: base score matters more -> "old" (5.0 base) wins
         assert first_low == "old"
@@ -240,9 +254,7 @@ class TestDecayScoring:
         POPOTO_REDIS_DB.hset(self.HASH_KEY, mapping=base_scores)
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "5"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "5"
         )
 
         # 5 results * 2 (member + score) = 10 elements
@@ -251,9 +263,13 @@ class TestDecayScoring:
     def test_empty_sorted_set(self):
         """No members returns empty result."""
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(time.time()), "0.5", "10"
+            DECAY_SCORE_LUA,
+            2,
+            self.ZSET_KEY,
+            self.HASH_KEY,
+            str(time.time()),
+            "0.5",
+            "10",
         )
         assert result is None or result == []
 
@@ -265,9 +281,7 @@ class TestDecayScoring:
         # Don't set any base score in hash
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "10"
         )
 
         assert len(result) == 2
@@ -294,9 +308,12 @@ class TestDecayScoringFormula:
 
         # Set up items at known elapsed times
         cases = {
-            "1day": (now - 86400 * 1, 1.0),    # 1 day,  expect: 1.0 * 1^-0.5 = 1.0
-            "4day": (now - 86400 * 4, 1.0),     # 4 days, expect: 1.0 * 4^-0.5 = 0.5
-            "100day": (now - 86400 * 100, 1.0),  # 100 days, expect: 1.0 * 100^-0.5 = 0.1
+            "1day": (now - 86400 * 1, 1.0),  # 1 day,  expect: 1.0 * 1^-0.5 = 1.0
+            "4day": (now - 86400 * 4, 1.0),  # 4 days, expect: 1.0 * 4^-0.5 = 0.5
+            "100day": (
+                now - 86400 * 100,
+                1.0,
+            ),  # 100 days, expect: 1.0 * 100^-0.5 = 0.1
         }
 
         members = {}
@@ -309,9 +326,7 @@ class TestDecayScoringFormula:
         POPOTO_REDIS_DB.hset(self.HASH_KEY, mapping=base_scores)
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "10"
         )
 
         # Parse results into dict
@@ -332,9 +347,7 @@ class TestDecayScoringFormula:
         POPOTO_REDIS_DB.hset(self.HASH_KEY, "scaled", "5.0")
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "10"
         )
 
         score = float(result[1])


### PR DESCRIPTION
## Summary
- Adds `AccessTrackerMixin` — a model mixin that tracks read access patterns with a two-stage pipeline (staged → confirmed)
- Integrates `on_read()` hooks into all query paths: `Query.get()`, `_execute_filter()`, `QueryBuilder.top_by_decay()`, and async variants
- Adds `no_track()` on QueryBuilder to suppress tracking for bulk/internal operations
- Adds delete cleanup to remove all AccessTracker Redis keys when a model instance is deleted
- Exports `AccessTrackerMixin` from the `popoto` package

## Implementation Details
- **Staging**: `on_read()` fires a single `RPUSH` per instance, batched via Redis pipeline — one round trip regardless of instance count
- **Confirmation**: `confirm_access()` uses an atomic Lua script to promote staged timestamps, trim to cap, update access_count/last_accessed, and clear staging
- **Redis keys**: `$AT:{ClassName}:staged:{pk}`, `$AT:{ClassName}:access_log:{pk}`, `$AT:{ClassName}:meta:{pk}`
- **Zero overhead** for models without the mixin — `_fire_on_read()` checks `issubclass` and returns immediately

## Test plan
- [x] 24 dedicated tests covering all success criteria
- [x] Full regression suite passes (415 tests, 0 failures)
- [x] Staging, confirmation, discarding, capping, concurrent access
- [x] Query integration (get, filter, no_track)
- [x] Delete cleanup, untracked model isolation
- [x] Export verification

Resolves #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)