### PR TITLE
Docs: AccessTrackerMixin documentation cascade

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -5,7 +5,7 @@ Complete reference for all public classes, methods, and functions in the Popoto 
 ```python
 from popoto import Model, Field, KeyField, AutoKeyField, UniqueKeyField
 from popoto import SortedField, SortedKeyField, GeoField, DatetimeField, Relationship
-from popoto import DecayingSortedField, CyclicDecayField, TemporalPeriod
+from popoto import DecayingSortedField, CyclicDecayField, TemporalPeriod, AccessTrackerMixin
 from popoto import Publisher, Subscriber
 from popoto import ModelException, QueryException, PublisherException, SubscriberException
 ```
@@ -889,6 +889,39 @@ See [CyclicDecayField](features/cyclic-decay-field.md) for usage examples and
 | `cycles` | `list` | `[]` | List of `(period, amplitude, phase)` tuples. Use `TemporalPeriod` constants. |
 | `pressure_rate` | `float` | `0.0` | Rate of urgency buildup per unresolved day. Must be >= 0. |
 | `partition_by` | `str` or `tuple` | `()` | Partition the sorted set by key field values (inherited). |
+
+### AccessTrackerMixin
+
+```python
+from popoto import AccessTrackerMixin
+
+class MyModel(AccessTrackerMixin, Model):
+    _max_access_log = 100  # max confirmed timestamps kept (default)
+    _track_reads = True    # auto-fire on_read from queries (default)
+```
+
+A model mixin that tracks read access patterns with a two-stage pipeline (staged → confirmed).
+See [Agent Memory — AccessTracker](features/agent-memory.md#accesstracker) for full usage guide.
+
+#### AccessTrackerMixin.on\_read(pipeline=None)
+
+Stage a read by appending the current timestamp to the staging list. Called automatically by query hooks.
+
+#### AccessTrackerMixin.confirm\_access(pipeline=None) -> int
+
+Atomically promote all staged timestamps to the confirmed access log via Lua script. Returns the number of staged reads promoted. Raises `TypeError` if the instance has not been saved.
+
+#### AccessTrackerMixin.discard\_staged\_access(pipeline=None)
+
+Clear the staging list without affecting confirmed data.
+
+#### AccessTrackerMixin.access\_count -> int
+
+Total number of confirmed read accesses. Returns `0` if never confirmed.
+
+#### AccessTrackerMixin.last\_accessed -> float | None
+
+Timestamp of the most recent confirmed read. Returns `None` if never confirmed.
 
 ### GeoField
 

--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -24,7 +24,7 @@ The primitives ship incrementally. Each builds on the ones before it.
 |-----------|-------------|--------|
 | [DecayingSortedField](#decayingsortedfield) | Time-weighted scoring — records lose relevance over time unless refreshed | Shipped ([PR #199](https://github.com/tomcounsell/popoto/pull/199)) |
 | [CyclicDecayField](#cyclicdecayfield) | Temporal rhythms + homeostatic pressure on top of decay | Shipped ([PR #201](https://github.com/tomcounsell/popoto/pull/201)) |
-| [AccessTracker](#accesstracker) | Tracks read patterns — access count, timestamps, spacing effects | [#197](https://github.com/tomcounsell/popoto/issues/197) |
+| [AccessTracker](#accesstracker) | Tracks read patterns — access count, timestamps, spacing effects | Shipped ([PR #203](https://github.com/tomcounsell/popoto/pull/203)) |
 | [ObservationProtocol](#accesstracker) | Outcome-driven memory effects — acted/dismissed/deferred/contradicted | [#198](https://github.com/tomcounsell/popoto/issues/198) |
 | [WriteFilter](#writefilter) | Gates persistence — low-value records silently discarded at write time | Planned |
 | [ConfidenceField](#confidencefield) | Bayesian certainty — corroboration strengthens, contradiction weakens | Planned |
@@ -253,17 +253,68 @@ See [CyclicDecayField feature docs](cyclic-decay-field.md) for the full referenc
 
 ## AccessTracker
 
-Tracks read access patterns on any model: access count, last-accessed timestamp, and a capped list of access timestamps. Combined with `DecayingSortedField`, this enables spacing-effect-aware scoring — records accessed repeatedly over time rank higher than records accessed many times in a burst.
+Tracks read access patterns on any model using a two-stage pipeline: reads are first staged (cheap), then atomically promoted to a confirmed access log. This prevents naive "every read strengthens" behavior — only meaningful reads count.
+
+Shipped in [PR #203](https://github.com/tomcounsell/popoto/pull/203).
+
+### Basic usage
 
 ```python
+from popoto import Model, KeyField, Field, AccessTrackerMixin, DecayingSortedField
+
 class Memory(Model, AccessTrackerMixin):
     agent_id = KeyField()
     content = Field(type=str)
     relevance = DecayingSortedField()
+
+# Reading triggers on_read() automatically via query hooks
+memories = Memory.query.filter(agent_id="agent-1").top_by_decay("relevance", 5)
+
+# After the agent acts on a memory, confirm the read
+memories[0].confirm_access()       # promotes staged → confirmed
+memories[1].discard_staged_access() # clears staging without promoting
+
+# Inspect access patterns
+print(memories[0].access_count)    # 42
+print(memories[0].last_accessed)   # 1741872000.0
 ```
 
-!!! note
-    AccessTracker introduces an `on_read()` hook to the field protocol. Details TBD during implementation.
+### How staging works
+
+`on_read()` fires automatically when instances are hydrated via `Query.get()`, `Query.filter()`, `top_by_decay()`, and their async variants. Each call appends a timestamp to a per-instance staging list (`RPUSH` — single Redis command, batched via pipeline).
+
+Staged reads are not yet "real" — they represent candidate accesses. Your application decides which reads were meaningful:
+
+- `confirm_access()` — atomically promotes all staged timestamps to the confirmed access log using a Lua script. Updates `access_count` and `last_accessed`.
+- `discard_staged_access()` — clears staging without affecting confirmed data.
+
+### Configuration
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `_max_access_log` | `int` | `100` | Maximum timestamps kept in the confirmed access log. Older entries trimmed on confirm. |
+| `_track_reads` | `bool` | `True` | Set to `False` to disable automatic `on_read()` from queries. |
+
+### Suppressing tracking for bulk operations
+
+Use `no_track()` on the query builder to prevent `on_read()` from firing during internal operations like reindexing or migration:
+
+```python
+# These reads won't be tracked
+Memory.query.filter(agent_id="agent-1").no_track().all()
+```
+
+### Delete cleanup
+
+When a tracked model instance is deleted, all three AccessTracker Redis keys (staged, access_log, meta) are automatically removed.
+
+### Redis key patterns
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `$AT:{ClassName}:staged:{pk}` | List | Pending read timestamps |
+| `$AT:{ClassName}:access_log:{pk}` | List | Confirmed access timestamps (capped) |
+| `$AT:{ClassName}:meta:{pk}` | Hash | `access_count` (int) and `last_accessed` (float) |
 
 ## WriteFilter
 

--- a/docs/plans/access_tracker_mixin.md
+++ b/docs/plans/access_tracker_mixin.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: Shipped
 type: feature
 appetite: Medium
 owner: Solo dev

--- a/docs/query.md
+++ b/docs/query.md
@@ -195,6 +195,7 @@ The `QueryBuilder` returned by `filter()` supports these chainable methods:
 | `limit(n)` | Set maximum number of results |
 | `values(*fields)` | Return dicts with specified fields instead of model instances |
 | `computed_sort(fn, reverse)` | Sort by a Python key function (applied after fetch, before limit) |
+| `no_track()` | Suppress `on_read()` tracking for `AccessTrackerMixin` models |
 | `all()` | Execute query and return all results as a list |
 | `first()` | Execute query and return first result or None |
 | `count()` | Count matching results without loading objects |

--- a/examples/popoto_kitchen/screens/restaurants.py
+++ b/examples/popoto_kitchen/screens/restaurants.py
@@ -241,7 +241,6 @@ class RestaurantsScreen(Container):
         Uses programmatic name generation (no modal dialog) to keep demo simple
         while still exercising the KeyField rename code path.
         """
-        import random
         from ..seed import restaurant_name
 
         table = self.query_one("#restaurants-table", DataTable)

--- a/src/popoto/fields/shortcuts.py
+++ b/src/popoto/fields/shortcuts.py
@@ -481,7 +481,7 @@ class ListField(Field):
         # Encode each element individually
         encoded_values = [_encode_list_element(v) for v in data]
 
-        if hasattr(pipeline, 'execute'):
+        if hasattr(pipeline, "execute"):
             pipeline.delete(list_key)
             if encoded_values:
                 pipeline.rpush(list_key, *encoded_values)

--- a/tests/test_atomic_save.py
+++ b/tests/test_atomic_save.py
@@ -8,7 +8,6 @@ records exist but indexes haven't been updated yet.
 Related: https://github.com/tomcounsell/popoto/issues/147
 """
 
-import asyncio
 
 import pytest
 

--- a/tests/test_bulk_operations.py
+++ b/tests/test_bulk_operations.py
@@ -361,6 +361,7 @@ def reset_async_connection():
     """Reset async Redis connection for each test."""
     import src.popoto.redis_db as redis_db_module
     import asyncio
+
     redis_db_module._POPOTO_ASYNC_REDIS_DB = None
     redis_db_module._async_redis_lock = asyncio.Lock()
 
@@ -373,13 +374,22 @@ class TestAsyncBulkOperations:
         """Gap 1: async_bulk_create basic functionality."""
         restaurants = [
             Restaurant(
-                name="Async Restaurant A", rating=4.0, status="pending", cuisine="Italian"
+                name="Async Restaurant A",
+                rating=4.0,
+                status="pending",
+                cuisine="Italian",
             ),
             Restaurant(
-                name="Async Restaurant B", rating=4.5, status="pending", cuisine="Japanese"
+                name="Async Restaurant B",
+                rating=4.5,
+                status="pending",
+                cuisine="Japanese",
             ),
             Restaurant(
-                name="Async Restaurant C", rating=3.8, status="pending", cuisine="Mexican"
+                name="Async Restaurant C",
+                rating=3.8,
+                status="pending",
+                cuisine="Mexican",
             ),
         ]
 

--- a/tests/test_dx_polish.py
+++ b/tests/test_dx_polish.py
@@ -1,6 +1,5 @@
 """Tests for DX polish improvements."""
 
-import pytest
 import popoto
 from popoto import Model, KeyField, Field
 from popoto.testing import use_test_db, flush_test_db

--- a/tests/test_field_index_edge_cases.py
+++ b/tests/test_field_index_edge_cases.py
@@ -113,7 +113,6 @@ def _keyfield_set_key(model_class, field_name, value):
 
 def _relationship_set_key(model_class, field_name, related_instance):
     """Build the Redis Set key for a Relationship index entry."""
-    from popoto.models.db_key import DB_key
 
     prefix = model_class._meta.fields[field_name].get_special_use_field_db_key(
         model_class, field_name
@@ -125,7 +124,6 @@ def _relationship_set_key(model_class, field_name, related_instance):
 
 def _sorted_set_key(model_class, field_name, *partition_values):
     """Build the Redis Sorted Set key for a SortedField index."""
-    from popoto.fields.sorted_field_mixin import SortedFieldMixin
 
     key = model_class._meta.fields[field_name].get_sortedset_db_key(
         model_class, field_name, *partition_values

--- a/tests/test_list_field_capped.py
+++ b/tests/test_list_field_capped.py
@@ -29,6 +29,7 @@ class UncappedListModel(popoto.Model):
 @pytest.fixture(autouse=True)
 def cleanup():
     """Remove all test model instances before and after each test."""
+
     def _do_cleanup():
         for item in CappedListModel.query.all():
             item.delete()

--- a/tests/test_lua_decay_scoring.py
+++ b/tests/test_lua_decay_scoring.py
@@ -87,9 +87,7 @@ class TestLuaBasic:
 
     def test_lua_power_function(self):
         """Lua math.pow works (needed for decay formula)."""
-        result = POPOTO_REDIS_DB.eval(
-            "return tostring(math.pow(4.0, -0.5))", 0
-        )
+        result = POPOTO_REDIS_DB.eval("return tostring(math.pow(4.0, -0.5))", 0)
         assert abs(float(result) - 0.5) < 0.001
 
     def test_lua_table_sort(self):
@@ -124,9 +122,7 @@ class TestDecayScoring:
         POPOTO_REDIS_DB.hset(self.HASH_KEY, "item:1", "1.0")
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "10"
         )
 
         assert len(result) == 2
@@ -141,19 +137,23 @@ class TestDecayScoring:
         """Recently updated member should outscore older one with same base."""
         now = time.time()
 
-        POPOTO_REDIS_DB.zadd(self.ZSET_KEY, {
-            "recent": now - 3600,       # 1 hour ago
-            "old": now - 86400 * 30,    # 30 days ago
-        })
-        POPOTO_REDIS_DB.hset(self.HASH_KEY, mapping={
-            "recent": "1.0",
-            "old": "1.0",
-        })
+        POPOTO_REDIS_DB.zadd(
+            self.ZSET_KEY,
+            {
+                "recent": now - 3600,  # 1 hour ago
+                "old": now - 86400 * 30,  # 30 days ago
+            },
+        )
+        POPOTO_REDIS_DB.hset(
+            self.HASH_KEY,
+            mapping={
+                "recent": "1.0",
+                "old": "1.0",
+            },
+        )
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "10"
         )
 
         # First result should be "recent"
@@ -171,19 +171,23 @@ class TestDecayScoring:
         now = time.time()
         same_time = now - 86400  # both 1 day ago
 
-        POPOTO_REDIS_DB.zadd(self.ZSET_KEY, {
-            "high": same_time,
-            "low": same_time,
-        })
-        POPOTO_REDIS_DB.hset(self.HASH_KEY, mapping={
-            "high": "10.0",
-            "low": "1.0",
-        })
+        POPOTO_REDIS_DB.zadd(
+            self.ZSET_KEY,
+            {
+                "high": same_time,
+                "low": same_time,
+            },
+        )
+        POPOTO_REDIS_DB.hset(
+            self.HASH_KEY,
+            mapping={
+                "high": "10.0",
+                "low": "1.0",
+            },
+        )
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "10"
         )
 
         first = result[0].decode() if isinstance(result[0], bytes) else result[0]
@@ -194,31 +198,41 @@ class TestDecayScoring:
         """Higher decay rate penalizes old items more."""
         now = time.time()
 
-        POPOTO_REDIS_DB.zadd(self.ZSET_KEY, {
-            "recent": now - 3600,        # 1 hour ago
-            "old": now - 86400 * 10,     # 10 days ago
-        })
-        POPOTO_REDIS_DB.hset(self.HASH_KEY, mapping={
-            "recent": "1.0",
-            "old": "5.0",  # old has 5x base score
-        })
+        POPOTO_REDIS_DB.zadd(
+            self.ZSET_KEY,
+            {
+                "recent": now - 3600,  # 1 hour ago
+                "old": now - 86400 * 10,  # 10 days ago
+            },
+        )
+        POPOTO_REDIS_DB.hset(
+            self.HASH_KEY,
+            mapping={
+                "recent": "1.0",
+                "old": "5.0",  # old has 5x base score
+            },
+        )
 
         # With low decay (0.1), old item's high base score can win
         result_low = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.1", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.1", "10"
         )
 
         # With high decay (1.0), recency dominates
         result_high = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "1.0", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "1.0", "10"
         )
 
-        first_low = result_low[0].decode() if isinstance(result_low[0], bytes) else result_low[0]
-        first_high = result_high[0].decode() if isinstance(result_high[0], bytes) else result_high[0]
+        first_low = (
+            result_low[0].decode()
+            if isinstance(result_low[0], bytes)
+            else result_low[0]
+        )
+        first_high = (
+            result_high[0].decode()
+            if isinstance(result_high[0], bytes)
+            else result_high[0]
+        )
 
         # Low decay: base score matters more -> "old" (5.0 base) wins
         assert first_low == "old"
@@ -240,9 +254,7 @@ class TestDecayScoring:
         POPOTO_REDIS_DB.hset(self.HASH_KEY, mapping=base_scores)
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "5"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "5"
         )
 
         # 5 results * 2 (member + score) = 10 elements
@@ -251,9 +263,13 @@ class TestDecayScoring:
     def test_empty_sorted_set(self):
         """No members returns empty result."""
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(time.time()), "0.5", "10"
+            DECAY_SCORE_LUA,
+            2,
+            self.ZSET_KEY,
+            self.HASH_KEY,
+            str(time.time()),
+            "0.5",
+            "10",
         )
         assert result is None or result == []
 
@@ -265,9 +281,7 @@ class TestDecayScoring:
         # Don't set any base score in hash
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "10"
         )
 
         assert len(result) == 2
@@ -294,9 +308,12 @@ class TestDecayScoringFormula:
 
         # Set up items at known elapsed times
         cases = {
-            "1day": (now - 86400 * 1, 1.0),    # 1 day,  expect: 1.0 * 1^-0.5 = 1.0
-            "4day": (now - 86400 * 4, 1.0),     # 4 days, expect: 1.0 * 4^-0.5 = 0.5
-            "100day": (now - 86400 * 100, 1.0),  # 100 days, expect: 1.0 * 100^-0.5 = 0.1
+            "1day": (now - 86400 * 1, 1.0),  # 1 day,  expect: 1.0 * 1^-0.5 = 1.0
+            "4day": (now - 86400 * 4, 1.0),  # 4 days, expect: 1.0 * 4^-0.5 = 0.5
+            "100day": (
+                now - 86400 * 100,
+                1.0,
+            ),  # 100 days, expect: 1.0 * 100^-0.5 = 0.1
         }
 
         members = {}
@@ -309,9 +326,7 @@ class TestDecayScoringFormula:
         POPOTO_REDIS_DB.hset(self.HASH_KEY, mapping=base_scores)
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "10"
         )
 
         # Parse results into dict
@@ -332,9 +347,7 @@ class TestDecayScoringFormula:
         POPOTO_REDIS_DB.hset(self.HASH_KEY, "scaled", "5.0")
 
         result = POPOTO_REDIS_DB.eval(
-            DECAY_SCORE_LUA, 2,
-            self.ZSET_KEY, self.HASH_KEY,
-            str(now), "0.5", "10"
+            DECAY_SCORE_LUA, 2, self.ZSET_KEY, self.HASH_KEY, str(now), "0.5", "10"
         )
 
         score = float(result[1])


### PR DESCRIPTION
## Summary
- Replace placeholder AccessTracker section in `docs/features/agent-memory.md` with full API documentation
- Add `AccessTrackerMixin` section to `docs/api-reference.md` with all public methods/properties
- Add `no_track()` to QueryBuilder method table in `docs/query.md`
- Update plan status to Shipped in `docs/plans/access_tracker_mixin.md`
- Resolve merge conflicts with CyclicDecayField docs (both features now documented)

## Test plan
- [x] No conflict markers remain in any doc files
- [x] All doc changes are surgical updates to existing structure
- [x] Cross-references between agent-memory.md and api-reference.md are consistent

Follows up on #203 (AccessTrackerMixin implementation)