### PR TITLE
Add CompositeScoreQuery — multi-factor retrieval via ZUNIONSTORE

### DIFF
--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -30,7 +30,7 @@ The primitives ship incrementally. Each builds on the ones before it.
 | [ConfidenceField](#confidencefield) | Bayesian certainty — corroboration strengthens, contradiction weakens | Shipped ([PR #215](https://github.com/tomcounsell/popoto/pull/215)) |
 | [CoOccurrenceField](#cooccurrencefield) | Weighted associations — co-accessed records strengthen their link | Shipped ([PR #218](https://github.com/tomcounsell/popoto/pull/218)) |
 | [EventStreamMixin](#eventstreammixin) | Append-only mutation log via Redis Streams | Shipped |
-| [CompositeScoreQuery](#compositescorequery) | Multi-factor retrieval — combine N sorted indexes with weights | Planned |
+| [CompositeScoreQuery](#compositescorequery) | Multi-factor retrieval — combine N sorted indexes with weights | Shipped |
 | [ExistenceFilter](#existencefilter) | Bloom filter for O(1) "do I know anything about X?" checks | Planned |
 | [PredictionLedger](#predictionledger) | Outcome tracking — record predictions, observe results, compute error | Planned |
 | [StreamConsumer](#streamconsumer) | Background processing framework for Redis Streams | Planned |
@@ -653,19 +653,115 @@ When `WriteFilterMixin` discards a record (score below threshold), the `save()` 
 
 ## CompositeScoreQuery
 
-Combines multiple sorted set indexes via `ZUNIONSTORE` with configurable weights, returning top-K results by composite score. This is where all the scoring primitives converge.
+Combines multiple sorted set indexes via `ZUNIONSTORE` with configurable weights, returning top-K results ranked by composite score. This is where all the scoring primitives converge into a single retrieval call.
+
+Without `composite_score()`, retrieving by multiple factors requires application-level code: fetch by decay, fetch confidence data, fetch access counts, compute composite in Python, re-rank. This is slow (multiple round trips), error-prone, and not composable via the query API. `composite_score()` does it all server-side in a single call.
+
+### Basic usage
 
 ```python
-results = Memory.query.composite_score(
+from popoto import Model, KeyField, Field
+from popoto.fields import DecayingSortedField, ConfidenceField
+from popoto.fields.access_tracker import AccessTrackerMixin
+from popoto.fields.write_filter import WriteFilterMixin
+
+class Memory(AccessTrackerMixin, WriteFilterMixin, Model):
+    agent_id = KeyField()
+    content = Field(type=str)
+    importance = Field(type=float, default=1.0)
+    relevance = DecayingSortedField(
+        base_score_field="importance",
+        partition_by="agent_id",
+    )
+    certainty = ConfidenceField(initial_confidence=0.5)
+
+    def compute_filter_score(self):
+        return self.importance or 0.0
+```
+
+Retrieve the top-10 memories ranked by a weighted composite of decay, confidence, access frequency, and write filter priority:
+
+```python
+results = Memory.query.filter(agent_id="agent-1").composite_score(
     indexes={
-        "relevance": 0.4,      # DecayingSortedField
-        "confidence": 0.3,     # ConfidenceField
-        "access_score": 0.2,   # AccessTracker
+        "relevance": 0.4,      # DecayingSortedField (decay-computed scores)
+        "certainty": 0.3,      # ConfidenceField (Bayesian confidence)
+        "access_count": 0.2,   # AccessTracker (read frequency)
         "priority": 0.1,       # WriteFilter priority set
     },
-    limit=10
+    limit=10,
 )
 ```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `indexes` | `dict[str, float]` | *required* | Mapping of field names to weights. Weights are arbitrary positive floats; relative ratios matter, not absolute values. |
+| `limit` | `int` | `10` | Maximum number of results to return. |
+| `aggregate` | `str` | `"SUM"` | How ZUNIONSTORE combines scores: `"SUM"`, `"MIN"`, or `"MAX"`. |
+| `min_score` | `float` | `None` | Optional minimum composite score. Results below this threshold are excluded. |
+| `post_filter` | `callable` | `None` | Optional `(redis_key, score) -> bool` callback. Applied after scoring but before hydration. Return `True` to keep. |
+| `co_occurrence_boost` | `dict` | `None` | Optional `{redis_key: weight}` dict from `CoOccurrenceField.propagate()`. Injected as an additional scoring signal. |
+
+### Supported index types
+
+| Index name | Field type | Resolution strategy |
+|------------|-----------|-------------------|
+| Any `DecayingSortedField` | `DecayingSortedField` / `CyclicDecayField` | Materializes decay-computed scores into a temp ZSET via the existing Lua decay script |
+| Any `SortedField` | `SortedFieldMixin` | Uses the existing sorted set directly |
+| Any `ConfidenceField` | `ConfidenceField` | Materializes confidence values from the companion hash into a temp ZSET |
+| `"access_count"` or `"access_score"` | `AccessTrackerMixin` | Materializes `access_count` from meta hashes into a temp ZSET |
+| `"priority"` | `WriteFilterMixin` | Uses the `$WF:{Class}:priority` sorted set directly |
+
+### CoOccurrence boost
+
+Inject associative retrieval scores from `CoOccurrenceField.propagate()`:
+
+```python
+from popoto.fields.co_occurrence_field import CoOccurrenceField
+
+# Get propagated association scores from a seed memory
+assoc_field = Memory._meta.fields["associations"]
+co_scores = assoc_field.propagate(Memory, seed_pks=["memory_key_1"], depth=2)
+
+# Inject as a boost signal in composite scoring
+results = Memory.query.filter(agent_id="agent-1").composite_score(
+    indexes={"relevance": 0.3, "certainty": 0.3},
+    co_occurrence_boost=co_scores,
+    limit=10,
+)
+```
+
+A record with mediocre decay and confidence scores but a strong co-occurrence association to the seed will surface higher in results.
+
+### Post-filter callback
+
+Use `post_filter` to exclude specific records after scoring but before model hydration:
+
+```python
+# Exclude already-used memories
+used_keys = {"Memory:key1", "Memory:key2"}
+results = Memory.query.filter(agent_id="agent-1").composite_score(
+    indexes={"relevance": 0.5, "certainty": 0.5},
+    post_filter=lambda key, score: key not in used_keys,
+    limit=10,
+)
+```
+
+### Temp key management
+
+All temporary Redis keys use a `$CSQ:` prefix with a UUID suffix and a 5-second `EXPIRE` for cleanup safety. Keys are deleted immediately after the query completes. Even if the process crashes mid-query, keys auto-expire within 5 seconds.
+
+### Error handling
+
+- Empty `indexes` dict raises `QueryException`
+- Invalid field name raises `QueryException` with list of valid fields
+- Field without a sorted set index raises `QueryException`
+- `"priority"` on a non-`WriteFilterMixin` model raises `QueryException`
+- `"access_count"` on a non-`AccessTrackerMixin` model raises `QueryException`
+- Missing partition filters for partitioned fields raises `QueryException`
+- `limit=0` returns an empty list (no error)
 
 ## ExistenceFilter
 

--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -701,7 +701,7 @@ results = Memory.query.filter(agent_id="agent-1").composite_score(
 | `limit` | `int` | `10` | Maximum number of results to return. |
 | `aggregate` | `str` | `"SUM"` | How ZUNIONSTORE combines scores: `"SUM"`, `"MIN"`, or `"MAX"`. |
 | `min_score` | `float` | `None` | Optional minimum composite score. Results below this threshold are excluded. |
-| `post_filter` | `callable` | `None` | Optional `(redis_key, score) -> bool` callback. Applied after scoring but before hydration. Return `True` to keep. |
+| `post_filter` | `Callable[[str, float], bool]` | `None` | Optional `(redis_key, score) -> bool` callback. Applied after scoring but before hydration. Return `True` to keep. |
 | `co_occurrence_boost` | `dict` | `None` | Optional `{redis_key: weight}` dict from `CoOccurrenceField.propagate()`. Injected as an additional scoring signal. |
 
 ### Supported index types
@@ -711,8 +711,10 @@ results = Memory.query.filter(agent_id="agent-1").composite_score(
 | Any `DecayingSortedField` | `DecayingSortedField` / `CyclicDecayField` | Materializes decay-computed scores into a temp ZSET via the existing Lua decay script |
 | Any `SortedField` | `SortedFieldMixin` | Uses the existing sorted set directly |
 | Any `ConfidenceField` | `ConfidenceField` | Materializes confidence values from the companion hash into a temp ZSET |
-| `"access_count"` or `"access_score"` | `AccessTrackerMixin` | Materializes `access_count` from meta hashes into a temp ZSET |
+| `"access_count"` or `"access_score"` | `AccessTrackerMixin` | Materializes `access_count` from meta hashes into a temp ZSET (uses `SMEMBERS` — see scaling note below) |
 | `"priority"` | `WriteFilterMixin` | Uses the `$WF:{Class}:priority` sorted set directly |
+
+> **Scaling note:** The `access_count`/`access_score` index uses `SMEMBERS` to discover all model instances before materializing scores. For models with 100K+ instances, this scan can be expensive. Use `post_filter` or partitioned queries to narrow the result set at that scale.
 
 ### CoOccurrence boost
 

--- a/docs/features/composite-score-query.md
+++ b/docs/features/composite-score-query.md
@@ -1,0 +1,125 @@
+# CompositeScoreQuery
+
+Multi-factor retrieval for Popoto models. Combines N sorted set indexes with configurable weights via Redis `ZUNIONSTORE` and returns top-K results ranked by composite score.
+
+## Quick start
+
+```python
+from popoto import Model, KeyField, Field
+from popoto.fields import DecayingSortedField, ConfidenceField
+from popoto.fields.access_tracker import AccessTrackerMixin
+from popoto.fields.write_filter import WriteFilterMixin
+
+class Memory(AccessTrackerMixin, WriteFilterMixin, Model):
+    agent_id = KeyField()
+    content = Field(type=str)
+    importance = Field(type=float, default=1.0)
+    relevance = DecayingSortedField(
+        base_score_field="importance",
+        partition_by="agent_id",
+    )
+    certainty = ConfidenceField(initial_confidence=0.5)
+
+    def compute_filter_score(self):
+        return self.importance or 0.0
+
+# Retrieve top-10 by weighted composite
+results = Memory.query.filter(agent_id="agent-1").composite_score(
+    indexes={
+        "relevance": 0.4,
+        "certainty": 0.3,
+        "access_count": 0.2,
+        "priority": 0.1,
+    },
+    limit=10,
+)
+```
+
+## API reference
+
+### `QueryBuilder.composite_score()`
+
+```python
+def composite_score(
+    self,
+    indexes: dict[str, float],
+    limit: int = 10,
+    aggregate: str = "SUM",
+    min_score: float = None,
+    post_filter: callable = None,
+    co_occurrence_boost: dict = None,
+) -> list:
+```
+
+Also available as `Query.composite_score()` (convenience method that creates a QueryBuilder internally).
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `indexes` | `dict[str, float]` | *required* | Field names mapped to weights. Relative ratios matter, not absolute values. |
+| `limit` | `int` | `10` | Maximum results to return. |
+| `aggregate` | `str` | `"SUM"` | Score combination mode: `"SUM"`, `"MIN"`, or `"MAX"`. |
+| `min_score` | `float` | `None` | Minimum composite score threshold. |
+| `post_filter` | `callable` | `None` | `(redis_key, score) -> bool` filter applied after scoring. |
+| `co_occurrence_boost` | `dict` | `None` | `{redis_key: weight}` from `CoOccurrenceField.propagate()`. |
+
+### Supported index types
+
+| Index name | Source | How it resolves |
+|------------|--------|----------------|
+| `DecayingSortedField` name | Model field | Materializes decay-computed scores into temp ZSET via Lua |
+| `CyclicDecayField` name | Model field | Same as above, uses cyclic decay Lua script |
+| `SortedField` name | Model field | Uses existing sorted set directly |
+| `ConfidenceField` name | Model field | Materializes confidence from companion hash |
+| `"access_count"` | `AccessTrackerMixin` | Materializes access count from meta hashes |
+| `"access_score"` | `AccessTrackerMixin` | Same as `"access_count"` |
+| `"priority"` | `WriteFilterMixin` | Uses `$WF:{Class}:priority` sorted set directly |
+
+## How it works
+
+1. **Index resolution**: Each named index maps to a Redis sorted set key. Native ZSET fields resolve directly. Non-ZSET sources (ConfidenceField, AccessTracker) are materialized into temporary sorted sets.
+
+2. **ZUNIONSTORE**: Redis combines all resolved sorted set keys into a single temporary sorted set with the specified weights and aggregate mode.
+
+3. **ZREVRANGE**: Top-K members extracted from the composite sorted set. If `min_score` is set, uses `ZREVRANGEBYSCORE` instead.
+
+4. **Post-filter**: Optional callback filters results before hydration.
+
+5. **Cleanup**: All temporary keys deleted immediately. Keys also have a 5-second EXPIRE as a safety net.
+
+6. **Hydration**: Redis keys passed to existing Query infrastructure for model instance loading.
+
+## CoOccurrence boost
+
+Inject graph propagation scores as an additional scoring signal:
+
+```python
+from popoto.fields.co_occurrence_field import CoOccurrenceField
+
+assoc_field = Memory._meta.fields["associations"]
+co_scores = assoc_field.propagate(Memory, seed_pks=["key1"], depth=2)
+
+results = Memory.query.filter(agent_id="agent-1").composite_score(
+    indexes={"relevance": 0.3, "certainty": 0.3},
+    co_occurrence_boost=co_scores,
+    limit=10,
+)
+```
+
+## Error handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Empty `indexes` dict | `QueryException` |
+| Unknown field name | `QueryException` with valid field list |
+| Field without sorted set | `QueryException` |
+| `"priority"` without `WriteFilterMixin` | `QueryException` |
+| `"access_count"` without `AccessTrackerMixin` | `QueryException` |
+| Missing partition filter | `QueryException` |
+| `limit=0` | Returns `[]` |
+| No matching records | Returns `[]` |
+
+## Temp key conventions
+
+All temporary keys follow the pattern `$CSQ:{ModelName}:{type}:{uid}` where `uid` is a random 8-character hex string. Keys are deleted in a `finally` block and also set with `EXPIRE 5` as a safety net against process crashes.

--- a/docs/features/composite-score-query.md
+++ b/docs/features/composite-score-query.md
@@ -46,7 +46,7 @@ def composite_score(
     limit: int = 10,
     aggregate: str = "SUM",
     min_score: float = None,
-    post_filter: callable = None,
+    post_filter: Optional[Callable[[str, float], bool]] = None,
     co_occurrence_boost: dict = None,
 ) -> list:
 ```
@@ -61,7 +61,7 @@ Also available as `Query.composite_score()` (convenience method that creates a Q
 | `limit` | `int` | `10` | Maximum results to return. |
 | `aggregate` | `str` | `"SUM"` | Score combination mode: `"SUM"`, `"MIN"`, or `"MAX"`. |
 | `min_score` | `float` | `None` | Minimum composite score threshold. |
-| `post_filter` | `callable` | `None` | `(redis_key, score) -> bool` filter applied after scoring. |
+| `post_filter` | `Callable[[str, float], bool]` | `None` | `(redis_key, score) -> bool` filter applied after scoring. |
 | `co_occurrence_boost` | `dict` | `None` | `{redis_key: weight}` from `CoOccurrenceField.propagate()`. |
 
 ### Supported index types
@@ -87,6 +87,8 @@ Also available as `Query.composite_score()` (convenience method that creates a Q
 4. **Post-filter**: Optional callback filters results before hydration.
 
 5. **Cleanup**: All temporary keys deleted immediately. Keys also have a 5-second EXPIRE as a safety net.
+
+> **Scaling note:** The `access_count`/`access_score` index uses `SMEMBERS` to discover all model instances. For models with 100K+ instances, this scan can be expensive. Use `post_filter` or partitioned queries to narrow the result set at that scale.
 
 6. **Hydration**: Redis keys passed to existing Query infrastructure for model instance loading.
 

--- a/docs/plans/composite_score_query.md
+++ b/docs/plans/composite_score_query.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: Shipped
 type: feature
 appetite: Medium
 owner: Valor

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -536,10 +536,7 @@ class QueryBuilder:
             if co_occurrence_boost:
                 POPOTO_REDIS_DB.zadd(
                     co_key,
-                    {
-                        str(k): float(v)
-                        for k, v in co_occurrence_boost.items()
-                    },
+                    {str(k): float(v) for k, v in co_occurrence_boost.items()},
                 )
                 POPOTO_REDIS_DB.expire(co_key, 5)
                 temp_keys.append(co_key)
@@ -656,9 +653,7 @@ class QueryBuilder:
                     f"'{model_name}' does not use AccessTrackerMixin; "
                     f"cannot resolve '{field_name}' index"
                 )
-            return self._materialize_access_tracker(
-                model_class, uid, temp_keys
-            )
+            return self._materialize_access_tracker(model_class, uid, temp_keys)
 
         # --- Look up the field on the model ---
         if field_name not in model_class._meta.fields:
@@ -684,13 +679,9 @@ class QueryBuilder:
         # --- SortedFieldMixin: use existing sorted set directly ---
         if isinstance(field, SortedFieldMixin):
             try:
-                partition_values = [
-                    str(self._filters[pf]) for pf in field.partition_by
-                ]
+                partition_values = [str(self._filters[pf]) for pf in field.partition_by]
             except KeyError:
-                missing = [
-                    pf for pf in field.partition_by if pf not in self._filters
-                ]
+                missing = [pf for pf in field.partition_by if pf not in self._filters]
                 raise QueryException(
                     f"composite_score() on '{field_name}' requires "
                     f"partition filter(s): {', '.join(missing)}"
@@ -706,9 +697,7 @@ class QueryBuilder:
             f"a sorted set index and cannot be used in composite_score()"
         )
 
-    def _materialize_decay_field(
-        self, model_class, field, field_name, uid, temp_keys
-    ):
+    def _materialize_decay_field(self, model_class, field, field_name, uid, temp_keys):
         """Materialize a DecayingSortedField's decay-computed scores into a temp ZSET.
 
         Uses the existing Lua decay script to compute scores, then writes
@@ -732,13 +721,9 @@ class QueryBuilder:
         model_name = model_class.__name__
 
         try:
-            partition_values = [
-                str(self._filters[pf]) for pf in field.partition_by
-            ]
+            partition_values = [str(self._filters[pf]) for pf in field.partition_by]
         except KeyError:
-            missing = [
-                pf for pf in field.partition_by if pf not in self._filters
-            ]
+            missing = [pf for pf in field.partition_by if pf not in self._filters]
             raise QueryException(
                 f"composite_score() on '{field_name}' requires "
                 f"partition filter(s): {', '.join(missing)}"

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -442,6 +442,471 @@ class QueryBuilder:
 
         return instances
 
+    def composite_score(
+        self,
+        indexes: dict,
+        limit: int = 10,
+        aggregate: str = "SUM",
+        min_score: float = None,
+        post_filter: callable = None,
+        co_occurrence_boost: dict = None,
+    ) -> list:
+        """Return top-K instances ranked by a weighted composite of multiple indexes.
+
+        Combines N sorted set indexes with configurable weights via Redis
+        ZUNIONSTORE and returns model instances ranked by composite score.
+
+        Each index name maps to a field on the model. Supported field types:
+            - DecayingSortedField / CyclicDecayField: Materializes decay-computed
+              scores into a temp ZSET via the existing Lua decay script.
+            - SortedFieldMixin fields: Uses the sorted set directly.
+            - WriteFilter priority: Resolves ``$WF:{Class}:priority`` directly.
+            - ConfidenceField: Materializes confidence values from companion hash.
+            - AccessTracker: Materializes access_count from meta hashes.
+
+        Args:
+            indexes: Mapping of field names to weights, e.g.
+                ``{"relevance": 0.4, "confidence": 0.3}``. Weights are arbitrary
+                positive floats; relative ratios matter, not absolute values.
+            limit: Maximum results to return. Default 10.
+            aggregate: Aggregation mode for ZUNIONSTORE: "SUM", "MIN", or "MAX".
+                Default "SUM".
+            min_score: Optional minimum composite score threshold. Results below
+                this score are excluded.
+            post_filter: Optional callable ``(redis_key, score) -> bool``. Applied
+                after ZREVRANGE but before hydration. Return True to keep.
+            co_occurrence_boost: Optional dict ``{redis_key: weight}`` from
+                ``CoOccurrenceField.propagate()``. Injected as an additional
+                index in the composite.
+
+        Returns:
+            List of model instances ranked by composite score (descending).
+
+        Raises:
+            QueryException: If indexes is empty, contains invalid field names,
+                or references fields without sorted set indexes.
+
+        Example:
+            results = Memory.query.filter(agent_id="agent-1").composite_score(
+                indexes={"relevance": 0.4, "confidence": 0.3, "access_score": 0.2},
+                limit=10,
+            )
+        """
+        import time
+        import uuid
+
+        from ..fields.access_tracker import AccessTrackerMixin
+        from ..fields.confidence_field import ConfidenceField
+        from ..fields.decaying_sorted_field import DecayingSortedField, DECAY_SCORE_LUA
+        from ..fields.sorted_field_mixin import SortedFieldMixin
+        from ..fields.write_filter import WriteFilterMixin
+        from .encoding import decode_popoto_model_hashmap
+
+        model_class = self._query.model_class
+
+        # --- Validate inputs ---
+        if not indexes:
+            raise QueryException("composite_score() requires a non-empty indexes dict")
+
+        if limit <= 0:
+            return []
+
+        aggregate = aggregate.upper()
+        if aggregate not in ("SUM", "MIN", "MAX"):
+            raise QueryException(
+                f"aggregate must be 'SUM', 'MIN', or 'MAX' (got '{aggregate}')"
+            )
+
+        # --- Resolve each index to a Redis sorted set key ---
+        resolved_keys = {}  # {redis_zset_key: weight}
+        temp_keys = []  # keys to clean up after
+        uid = uuid.uuid4().hex[:8]
+        model_name = model_class.__name__
+
+        for field_name, weight in indexes.items():
+            resolved_key = self._resolve_index(
+                model_class, field_name, weight, uid, temp_keys
+            )
+            if resolved_key:
+                resolved_keys[resolved_key] = weight
+
+        # --- Handle co_occurrence_boost ---
+        if co_occurrence_boost:
+            co_key = f"$CSQ:{model_name}:co_occurrence:{uid}"
+            if co_occurrence_boost:
+                POPOTO_REDIS_DB.zadd(
+                    co_key,
+                    {
+                        str(k): float(v)
+                        for k, v in co_occurrence_boost.items()
+                    },
+                )
+                POPOTO_REDIS_DB.expire(co_key, 5)
+                temp_keys.append(co_key)
+                resolved_keys[co_key] = 1.0  # weight already in the scores
+
+        if not resolved_keys:
+            self._cleanup_temp_keys(temp_keys)
+            return []
+
+        # --- ZUNIONSTORE ---
+        composite_key = f"$CSQ:{model_name}:{uid}"
+        temp_keys.append(composite_key)
+
+        try:
+            POPOTO_REDIS_DB.zunionstore(
+                composite_key,
+                resolved_keys,
+                aggregate=aggregate,
+            )
+            POPOTO_REDIS_DB.expire(composite_key, 5)
+
+            # --- ZREVRANGE top-K ---
+            if min_score is not None:
+                raw_results = POPOTO_REDIS_DB.zrevrangebyscore(
+                    composite_key,
+                    "+inf",
+                    str(min_score),
+                    start=0,
+                    num=limit,
+                    withscores=True,
+                )
+            else:
+                raw_results = POPOTO_REDIS_DB.zrevrange(
+                    composite_key, 0, limit - 1, withscores=True
+                )
+
+            if not raw_results:
+                return []
+
+            # --- Post-filter ---
+            pks = []
+            for member, score in raw_results:
+                if isinstance(member, bytes):
+                    member = member.decode()
+                if post_filter is not None and not post_filter(member, score):
+                    continue
+                pks.append(member)
+
+            if not pks:
+                return []
+
+            # --- Hydrate models ---
+            pipe = POPOTO_REDIS_DB.pipeline()
+            for key in pks:
+                pipe.hgetall(key)
+            hashes = pipe.execute()
+
+            instances = []
+            for key, data in zip(pks, hashes):
+                if data:
+                    instance = decode_popoto_model_hashmap(model_class, data)
+                    instances.append(instance)
+
+            if not self._no_track:
+                _fire_on_read(model_class, instances)
+
+            return instances
+
+        finally:
+            self._cleanup_temp_keys(temp_keys)
+
+    def _resolve_index(self, model_class, field_name, weight, uid, temp_keys):
+        """Resolve a field name to a Redis sorted set key for composite scoring.
+
+        Handles different field types by either returning existing ZSET keys
+        directly or materializing data into temporary ZSETs.
+
+        Args:
+            model_class: The Model class.
+            field_name: Name of the field or special index.
+            weight: The weight for this index (used for naming temp keys).
+            uid: Unique identifier for temp key namespacing.
+            temp_keys: List to append any created temp keys to.
+
+        Returns:
+            str: Redis key of the sorted set to use, or None if unresolvable.
+
+        Raises:
+            QueryException: If field_name is invalid or unsupported.
+        """
+        import time
+
+        from ..fields.access_tracker import AccessTrackerMixin
+        from ..fields.confidence_field import ConfidenceField
+        from ..fields.decaying_sorted_field import DecayingSortedField, DECAY_SCORE_LUA
+        from ..fields.sorted_field_mixin import SortedFieldMixin
+        from ..fields.write_filter import WriteFilterMixin
+
+        model_name = model_class.__name__
+
+        # --- Special case: "priority" for WriteFilter ---
+        if field_name == "priority":
+            if not issubclass(model_class, WriteFilterMixin):
+                raise QueryException(
+                    f"'{model_name}' does not use WriteFilterMixin; "
+                    f"cannot resolve 'priority' index"
+                )
+            return f"$WF:{model_name}:priority"
+
+        # --- Special case: "access_count" / "access_score" for AccessTracker ---
+        if field_name in ("access_count", "access_score"):
+            if not issubclass(model_class, AccessTrackerMixin):
+                raise QueryException(
+                    f"'{model_name}' does not use AccessTrackerMixin; "
+                    f"cannot resolve '{field_name}' index"
+                )
+            return self._materialize_access_tracker(
+                model_class, uid, temp_keys
+            )
+
+        # --- Look up the field on the model ---
+        if field_name not in model_class._meta.fields:
+            raise QueryException(
+                f"'{model_name}' has no field '{field_name}'. "
+                f"Valid fields: {list(model_class._meta.fields.keys())}"
+            )
+
+        field = model_class._meta.fields[field_name]
+
+        # --- DecayingSortedField: materialize decay scores ---
+        if isinstance(field, DecayingSortedField):
+            return self._materialize_decay_field(
+                model_class, field, field_name, uid, temp_keys
+            )
+
+        # --- ConfidenceField: materialize from companion hash ---
+        if isinstance(field, ConfidenceField):
+            return self._materialize_confidence_field(
+                model_class, field, field_name, uid, temp_keys
+            )
+
+        # --- SortedFieldMixin: use existing sorted set directly ---
+        if isinstance(field, SortedFieldMixin):
+            try:
+                partition_values = [
+                    str(self._filters[pf]) for pf in field.partition_by
+                ]
+            except KeyError:
+                missing = [
+                    pf for pf in field.partition_by if pf not in self._filters
+                ]
+                raise QueryException(
+                    f"composite_score() on '{field_name}' requires "
+                    f"partition filter(s): {', '.join(missing)}"
+                )
+            sortedset_db_key = field.__class__.get_sortedset_db_key(
+                model_class, field_name, *partition_values
+            )
+            return sortedset_db_key.redis_key
+
+        # --- Unsupported field type ---
+        raise QueryException(
+            f"Field '{field_name}' ({type(field).__name__}) does not have "
+            f"a sorted set index and cannot be used in composite_score()"
+        )
+
+    def _materialize_decay_field(
+        self, model_class, field, field_name, uid, temp_keys
+    ):
+        """Materialize a DecayingSortedField's decay-computed scores into a temp ZSET.
+
+        Uses the existing Lua decay script to compute scores, then writes
+        them to a temporary sorted set.
+
+        Args:
+            model_class: The Model class.
+            field: The DecayingSortedField instance.
+            field_name: Name of the field.
+            uid: Unique identifier for temp key.
+            temp_keys: List to append temp key to.
+
+        Returns:
+            str: Redis key of the temp sorted set.
+        """
+        import time
+
+        from ..fields.decaying_sorted_field import DECAY_SCORE_LUA
+        from ..fields.cyclic_decay_field import CyclicDecayField, CYCLIC_DECAY_LUA
+
+        model_name = model_class.__name__
+
+        try:
+            partition_values = [
+                str(self._filters[pf]) for pf in field.partition_by
+            ]
+        except KeyError:
+            missing = [
+                pf for pf in field.partition_by if pf not in self._filters
+            ]
+            raise QueryException(
+                f"composite_score() on '{field_name}' requires "
+                f"partition filter(s): {', '.join(missing)}"
+            )
+
+        sortedset_db_key = field.__class__.get_sortedset_db_key(
+            model_class, field_name, *partition_values
+        )
+
+        now = time.time()
+        base_score_field = field.base_score_field or ""
+
+        # Get all decay scores via Lua
+        if isinstance(field, CyclicDecayField):
+            cycles_hash_key = CyclicDecayField._get_cycles_hash_key_from_parts(
+                model_class, field_name, *partition_values
+            )
+            pressure_hash_key = CyclicDecayField._get_pressure_hash_key_from_parts(
+                model_class, field_name, *partition_values
+            )
+            result = POPOTO_REDIS_DB.eval(
+                CYCLIC_DECAY_LUA,
+                3,
+                sortedset_db_key.redis_key,
+                cycles_hash_key,
+                pressure_hash_key,
+                str(now),
+                str(field.decay_rate),
+                str(999999),  # get all members
+                base_score_field,
+            )
+        else:
+            result = POPOTO_REDIS_DB.eval(
+                DECAY_SCORE_LUA,
+                1,
+                sortedset_db_key.redis_key,
+                str(now),
+                str(field.decay_rate),
+                str(999999),  # get all members
+                base_score_field,
+            )
+
+        temp_key = f"$CSQ:{model_name}:decay:{field_name}:{uid}"
+        temp_keys.append(temp_key)
+
+        if result:
+            # Parse [key1, score1, key2, score2, ...] and write to temp ZSET
+            zadd_mapping = {}
+            for i in range(0, len(result), 2):
+                member = result[i]
+                if isinstance(member, bytes):
+                    member = member.decode()
+                score = float(result[i + 1])
+                zadd_mapping[member] = score
+
+            if zadd_mapping:
+                POPOTO_REDIS_DB.zadd(temp_key, zadd_mapping)
+                POPOTO_REDIS_DB.expire(temp_key, 5)
+
+        return temp_key
+
+    def _materialize_confidence_field(
+        self, model_class, field, field_name, uid, temp_keys
+    ):
+        """Materialize a ConfidenceField's confidence values into a temp ZSET.
+
+        Reads the companion hash and extracts confidence values for each member.
+
+        Args:
+            model_class: The Model class.
+            field: The ConfidenceField instance.
+            field_name: Name of the field.
+            uid: Unique identifier for temp key.
+            temp_keys: List to append temp key to.
+
+        Returns:
+            str: Redis key of the temp sorted set.
+        """
+        import msgpack
+
+        model_name = model_class.__name__
+
+        # Build companion hash key
+        # Pattern: $ConfidencF:{Model}:{field}:data
+        base_key = field.get_special_use_field_db_key(model_class, field_name)
+        data_hash_key = base_key.redis_key + ":data"
+
+        # Read all entries from companion hash
+        all_data = POPOTO_REDIS_DB.hgetall(data_hash_key)
+
+        temp_key = f"$CSQ:{model_name}:confidence:{field_name}:{uid}"
+        temp_keys.append(temp_key)
+
+        if all_data:
+            zadd_mapping = {}
+            for member_key, raw_value in all_data.items():
+                if isinstance(member_key, bytes):
+                    member_key = member_key.decode()
+                try:
+                    data = msgpack.unpackb(raw_value, raw=False)
+                    confidence = data.get("confidence", field.initial_confidence)
+                except Exception:
+                    confidence = field.initial_confidence
+                zadd_mapping[member_key] = float(confidence)
+
+            if zadd_mapping:
+                POPOTO_REDIS_DB.zadd(temp_key, zadd_mapping)
+                POPOTO_REDIS_DB.expire(temp_key, 5)
+
+        return temp_key
+
+    def _materialize_access_tracker(self, model_class, uid, temp_keys):
+        """Materialize AccessTracker access_count values into a temp ZSET.
+
+        Iterates over all model instances and reads access_count from each
+        instance's meta hash.
+
+        Args:
+            model_class: The Model class.
+            uid: Unique identifier for temp key.
+            temp_keys: List to append temp key to.
+
+        Returns:
+            str: Redis key of the temp sorted set.
+        """
+        model_name = model_class.__name__
+        temp_key = f"$CSQ:{model_name}:access:{uid}"
+        temp_keys.append(temp_key)
+
+        # Get all instance keys
+        all_keys = POPOTO_REDIS_DB.smembers(
+            model_class._meta.db_class_set_key.redis_key
+        )
+
+        if all_keys:
+            zadd_mapping = {}
+            pipe = POPOTO_REDIS_DB.pipeline()
+            decoded_keys = []
+            for key in all_keys:
+                if isinstance(key, bytes):
+                    key = key.decode()
+                decoded_keys.append(key)
+                meta_key = f"$AT:{model_name}:meta:{key}"
+                pipe.hget(meta_key, "access_count")
+
+            results = pipe.execute()
+
+            for key, count_raw in zip(decoded_keys, results):
+                count = int(count_raw) if count_raw else 0
+                if count > 0:
+                    zadd_mapping[key] = float(count)
+
+            if zadd_mapping:
+                POPOTO_REDIS_DB.zadd(temp_key, zadd_mapping)
+                POPOTO_REDIS_DB.expire(temp_key, 5)
+
+        return temp_key
+
+    @staticmethod
+    def _cleanup_temp_keys(temp_keys):
+        """Delete temporary Redis keys created during composite scoring.
+
+        Args:
+            temp_keys: List of Redis key strings to delete.
+        """
+        if temp_keys:
+            POPOTO_REDIS_DB.delete(*temp_keys)
+
     def all(self) -> list:
         """Execute the query and return all matching results.
 
@@ -1174,6 +1639,42 @@ class Query:
         builder = QueryBuilder(self)
         return builder.top_by_decay(
             field_name, n=n, decay_rate=decay_rate, base_score_field=base_score_field
+        )
+
+    def composite_score(
+        self,
+        indexes: dict,
+        limit: int = 10,
+        aggregate: str = "SUM",
+        min_score: float = None,
+        post_filter: callable = None,
+        co_occurrence_boost: dict = None,
+    ) -> list:
+        """Return top-K instances ranked by weighted composite score.
+
+        Convenience method that creates a QueryBuilder and delegates.
+        For partitioned fields, use
+        ``query.filter(partition=value).composite_score(...)``.
+
+        Args:
+            indexes: Mapping of field names to weights.
+            limit: Maximum results to return. Default 10.
+            aggregate: Aggregation mode: "SUM", "MIN", or "MAX".
+            min_score: Optional minimum composite score threshold.
+            post_filter: Optional callable (redis_key, score) -> bool.
+            co_occurrence_boost: Optional {redis_key: weight} dict.
+
+        Returns:
+            List of model instances ranked by composite score.
+        """
+        builder = QueryBuilder(self)
+        return builder.composite_score(
+            indexes=indexes,
+            limit=limit,
+            aggregate=aggregate,
+            min_score=min_score,
+            post_filter=post_filter,
+            co_occurrence_boost=co_occurrence_boost,
         )
 
     def _execute_filter(

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -57,7 +57,8 @@ from typing import TYPE_CHECKING, Optional
 from .db_key import DB_key
 
 if TYPE_CHECKING:
-    from .base import Model
+    from .base import Model, ModelOptions
+
 from ..redis_db import POPOTO_REDIS_DB, get_async_redis_db
 
 logger = logging.getLogger("POPOTO.Query")
@@ -492,14 +493,8 @@ class QueryBuilder:
                 limit=10,
             )
         """
-        import time
         import uuid
 
-        from ..fields.access_tracker import AccessTrackerMixin
-        from ..fields.confidence_field import ConfidenceField
-        from ..fields.decaying_sorted_field import DecayingSortedField, DECAY_SCORE_LUA
-        from ..fields.sorted_field_mixin import SortedFieldMixin
-        from ..fields.write_filter import WriteFilterMixin
         from .encoding import decode_popoto_model_hashmap
 
         model_class = self._query.model_class
@@ -627,11 +622,9 @@ class QueryBuilder:
         Raises:
             QueryException: If field_name is invalid or unsupported.
         """
-        import time
-
         from ..fields.access_tracker import AccessTrackerMixin
         from ..fields.confidence_field import ConfidenceField
-        from ..fields.decaying_sorted_field import DecayingSortedField, DECAY_SCORE_LUA
+        from ..fields.decaying_sorted_field import DecayingSortedField
         from ..fields.sorted_field_mixin import SortedFieldMixin
         from ..fields.write_filter import WriteFilterMixin
 
@@ -826,6 +819,7 @@ class QueryBuilder:
                     data = msgpack.unpackb(raw_value, raw=False)
                     confidence = data.get("confidence", field.initial_confidence)
                 except Exception:
+                    logger.warning("Failed to unpack confidence data for %s", member_key)
                     confidence = field.initial_confidence
                 zadd_mapping[member_key] = float(confidence)
 

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -52,7 +52,7 @@ See Also:
 
 import logging
 from asyncio import to_thread
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 from .db_key import DB_key
 
@@ -449,7 +449,7 @@ class QueryBuilder:
         limit: int = 10,
         aggregate: str = "SUM",
         min_score: float = None,
-        post_filter: callable = None,
+        post_filter: Optional[Callable[[str, float], bool]] = None,
         co_occurrence_boost: dict = None,
     ) -> list:
         """Return top-K instances ranked by a weighted composite of multiple indexes.
@@ -528,14 +528,13 @@ class QueryBuilder:
         # --- Handle co_occurrence_boost ---
         if co_occurrence_boost:
             co_key = f"$CSQ:{model_name}:co_occurrence:{uid}"
-            if co_occurrence_boost:
-                POPOTO_REDIS_DB.zadd(
-                    co_key,
-                    {str(k): float(v) for k, v in co_occurrence_boost.items()},
-                )
-                POPOTO_REDIS_DB.expire(co_key, 5)
-                temp_keys.append(co_key)
-                resolved_keys[co_key] = 1.0  # weight already in the scores
+            POPOTO_REDIS_DB.zadd(
+                co_key,
+                {str(k): float(v) for k, v in co_occurrence_boost.items()},
+            )
+            POPOTO_REDIS_DB.expire(co_key, 5)
+            temp_keys.append(co_key)
+            resolved_keys[co_key] = 1.0  # weight already in the scores
 
         if not resolved_keys:
             self._cleanup_temp_keys(temp_keys)
@@ -819,7 +818,9 @@ class QueryBuilder:
                     data = msgpack.unpackb(raw_value, raw=False)
                     confidence = data.get("confidence", field.initial_confidence)
                 except Exception:
-                    logger.warning("Failed to unpack confidence data for %s", member_key)
+                    logger.warning(
+                        "Failed to unpack confidence data for %s", member_key
+                    )
                     confidence = field.initial_confidence
                 zadd_mapping[member_key] = float(confidence)
 
@@ -834,6 +835,13 @@ class QueryBuilder:
 
         Iterates over all model instances and reads access_count from each
         instance's meta hash.
+
+        .. note::
+            This method uses ``SMEMBERS`` on the class set to discover all
+            instances.  For models with very large instance counts (100K+),
+            this scan can be expensive.  Consider using ``post_filter`` or
+            partitioned queries to narrow the result set when working at
+            that scale.
 
         Args:
             model_class: The Model class.
@@ -1626,7 +1634,7 @@ class Query:
         limit: int = 10,
         aggregate: str = "SUM",
         min_score: float = None,
-        post_filter: callable = None,
+        post_filter: Optional[Callable[[str, float], bool]] = None,
         co_occurrence_boost: dict = None,
     ) -> list:
         """Return top-K instances ranked by weighted composite score.

--- a/tests/test_composite_score_query.py
+++ b/tests/test_composite_score_query.py
@@ -175,9 +175,9 @@ class TestCompositeScoreSingleIndex:
 
     def test_single_decay_index(self):
         """Single DecayingSortedField index returns ranked results."""
-        a = SimpleDecayModel.create(name="old")
+        _a = SimpleDecayModel.create(name="old")
         time.sleep(0.05)
-        b = SimpleDecayModel.create(name="new")
+        _b = SimpleDecayModel.create(name="new")
 
         results = SimpleDecayModel.query.composite_score(
             indexes={"score": 1.0}, limit=10

--- a/tests/test_composite_score_query.py
+++ b/tests/test_composite_score_query.py
@@ -34,7 +34,6 @@ from src.popoto.fields.co_occurrence_field import CoOccurrenceField
 from src.popoto.models.query import QueryException
 from src.popoto.redis_db import POPOTO_REDIS_DB
 
-
 # --- Test Models ---
 
 
@@ -121,30 +120,22 @@ class TestCompositeScoreErrors:
     def test_invalid_field_name_raises(self):
         """Field name not on model raises QueryException."""
         with pytest.raises(QueryException, match="has no field"):
-            CompositeMemory.query.composite_score(
-                indexes={"nonexistent_field": 1.0}
-            )
+            CompositeMemory.query.composite_score(indexes={"nonexistent_field": 1.0})
 
     def test_plain_field_raises(self):
         """Field without sorted set index raises QueryException."""
         with pytest.raises(QueryException, match="does not have a sorted set"):
-            CompositeMemory.query.composite_score(
-                indexes={"content": 1.0}
-            )
+            CompositeMemory.query.composite_score(indexes={"content": 1.0})
 
     def test_priority_without_write_filter_raises(self):
         """'priority' on non-WriteFilterMixin model raises QueryException."""
         with pytest.raises(QueryException, match="WriteFilterMixin"):
-            SimpleDecayModel.query.composite_score(
-                indexes={"priority": 1.0}
-            )
+            SimpleDecayModel.query.composite_score(indexes={"priority": 1.0})
 
     def test_access_count_without_tracker_raises(self):
         """'access_count' on non-AccessTrackerMixin model raises QueryException."""
         with pytest.raises(QueryException, match="AccessTrackerMixin"):
-            SimpleDecayModel.query.composite_score(
-                indexes={"access_count": 1.0}
-            )
+            SimpleDecayModel.query.composite_score(indexes={"access_count": 1.0})
 
     def test_invalid_aggregate_raises(self):
         """Invalid aggregate mode raises QueryException."""
@@ -167,16 +158,12 @@ class TestCompositeScoreEmpty:
 
     def test_no_instances_returns_empty(self):
         """Query on model with no instances returns empty list."""
-        result = CompositeMemory.query.composite_score(
-            indexes={"relevance": 1.0}
-        )
+        result = CompositeMemory.query.composite_score(indexes={"relevance": 1.0})
         assert result == []
 
     def test_empty_sorted_sets_returns_empty(self):
         """All indexes empty returns empty list."""
-        result = SimpleDecayModel.query.composite_score(
-            indexes={"score": 1.0}
-        )
+        result = SimpleDecayModel.query.composite_score(indexes={"score": 1.0})
         assert result == []
 
 
@@ -224,14 +211,10 @@ class TestCompositeScoreTwoIndex:
     def test_high_confidence_recent_beats_low_confidence_old(self):
         """High-confidence recent record outranks low-confidence old record."""
         # Create "old" record
-        old = CompositeMemory.create(
-            name="old_fact", content="old", importance=0.8
-        )
+        old = CompositeMemory.create(name="old_fact", content="old", importance=0.8)
         time.sleep(0.05)
         # Create "new" record
-        new = CompositeMemory.create(
-            name="new_fact", content="new", importance=0.8
-        )
+        new = CompositeMemory.create(name="new_fact", content="new", importance=0.8)
 
         # Make old have low confidence, new have high confidence
         ConfidenceField.update_confidence(old, "certainty", signal=0.2)
@@ -257,9 +240,7 @@ class TestCompositeScoreThreeIndex:
     def test_frequently_accessed_gets_boost(self):
         """Frequently accessed records get a boost from access_count."""
         # Create records
-        rarely = CompositeMemory.create(
-            name="rarely_used", content="r", importance=0.8
-        )
+        rarely = CompositeMemory.create(name="rarely_used", content="r", importance=0.8)
         frequently = CompositeMemory.create(
             name="frequently_used", content="f", importance=0.8
         )
@@ -284,9 +265,7 @@ class TestCompositeScoreThreeIndex:
         assert len(results) >= 2
         # The frequently accessed one should rank higher
         result_names = [r.name for r in results]
-        assert result_names.index("frequently_used") < result_names.index(
-            "rarely_used"
-        )
+        assert result_names.index("frequently_used") < result_names.index("rarely_used")
 
 
 # --- Four-index synergy tests ---
@@ -302,9 +281,7 @@ class TestCompositeScoreFourIndex:
             name="high_priority", content="hp", importance=0.9
         )
         # Create a low-priority record (importance=0.5 -> normal save, no priority)
-        low = CompositeMemory.create(
-            name="low_priority", content="lp", importance=0.5
-        )
+        low = CompositeMemory.create(name="low_priority", content="lp", importance=0.5)
 
         # Set similar confidence
         ConfidenceField.update_confidence(high, "certainty", signal=0.7)
@@ -338,12 +315,8 @@ class TestCompositeScoreCoOccurrence:
     def test_co_occurrence_boost_surfaces_mediocre_record(self):
         """Record with mediocre scores but strong association surfaces."""
         # Create records
-        mediocre = CompositeMemory.create(
-            name="mediocre", content="m", importance=0.5
-        )
-        strong = CompositeMemory.create(
-            name="strong", content="s", importance=0.9
-        )
+        mediocre = CompositeMemory.create(name="mediocre", content="m", importance=0.5)
+        strong = CompositeMemory.create(name="strong", content="s", importance=0.9)
 
         # Set similar recency (both just created)
         ConfidenceField.update_confidence(mediocre, "certainty", signal=0.5)
@@ -488,9 +461,7 @@ class TestCompositeScorePartitioned:
         PartitionedComposite.create(name="b", category="cat1")
         PartitionedComposite.create(name="c", category="cat2")
 
-        results = PartitionedComposite.query.filter(
-            category="cat1"
-        ).composite_score(
+        results = PartitionedComposite.query.filter(category="cat1").composite_score(
             indexes={"relevance": 1.0}, limit=10
         )
         assert len(results) == 2
@@ -509,9 +480,7 @@ class TestCompositeScoreLimit:
         for i in range(5):
             SortedOnlyModel.create(name=f"item_{i}", score=float(i * 10))
 
-        results = SortedOnlyModel.query.composite_score(
-            indexes={"score": 1.0}, limit=3
-        )
+        results = SortedOnlyModel.query.composite_score(indexes={"score": 1.0}, limit=3)
         assert len(results) == 3
 
     def test_limit_larger_than_results(self):
@@ -548,9 +517,7 @@ class TestCompositeScoreTempKeys:
 
     def test_temp_keys_cleaned_on_empty_result(self):
         """Temp keys are cleaned even when result is empty."""
-        SimpleDecayModel.query.composite_score(
-            indexes={"score": 1.0}, limit=10
-        )
+        SimpleDecayModel.query.composite_score(indexes={"score": 1.0}, limit=10)
 
         csq_keys = POPOTO_REDIS_DB.keys("$CSQ:*")
         assert len(csq_keys) == 0

--- a/tests/test_composite_score_query.py
+++ b/tests/test_composite_score_query.py
@@ -1,0 +1,574 @@
+"""Tests for composite_score() — multi-factor retrieval via ZUNIONSTORE.
+
+Tests cover:
+- Two-index synergy: decay + confidence
+- Three-index synergy: decay + confidence + access frequency
+- Four-index synergy: + write filter priority
+- CoOccurrence boost synergy test
+- Single-index degenerate case
+- Empty indexes dict -> QueryException
+- Invalid field name -> QueryException
+- Field without sorted set index -> QueryException
+- Empty result set -> empty list
+- Aggregate modes: SUM, MIN, MAX
+- min_score filtering
+- post_filter callback
+- Partition filter integration
+- limit=0 -> empty list
+"""
+
+import sys
+import os
+import time
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+import pytest
+from src import popoto
+from src.popoto.fields.confidence_field import ConfidenceField
+from src.popoto.fields.decaying_sorted_field import DecayingSortedField
+from src.popoto.fields.access_tracker import AccessTrackerMixin
+from src.popoto.fields.write_filter import WriteFilterMixin
+from src.popoto.fields.co_occurrence_field import CoOccurrenceField
+from src.popoto.models.query import QueryException
+from src.popoto.redis_db import POPOTO_REDIS_DB
+
+
+# --- Test Models ---
+
+
+class CompositeMemory(AccessTrackerMixin, WriteFilterMixin, popoto.Model):
+    """Model with all composite-scorable field types."""
+
+    name = popoto.UniqueKeyField()
+    content = popoto.StringField(default="")
+    importance = popoto.FloatField(default=0.5)
+    relevance = DecayingSortedField(base_score_field="importance")
+    certainty = ConfidenceField(initial_confidence=0.5)
+    associations = CoOccurrenceField(symmetric=True, max_edges=100)
+
+    def compute_filter_score(self):
+        return self.importance or 0.0
+
+
+class SimpleDecayModel(popoto.Model):
+    """Model with just a DecayingSortedField for simple tests."""
+
+    name = popoto.UniqueKeyField()
+    score = DecayingSortedField()
+
+
+class PartitionedComposite(popoto.Model):
+    """Model with partitioned DecayingSortedField."""
+
+    name = popoto.UniqueKeyField()
+    category = popoto.KeyField(null=False)
+    relevance = DecayingSortedField(partition_by="category")
+
+
+class PlainModel(popoto.Model):
+    """Model with no sorted set fields."""
+
+    name = popoto.UniqueKeyField()
+    content = popoto.StringField(default="")
+
+
+class SortedOnlyModel(popoto.Model):
+    """Model with a plain SortedField."""
+
+    name = popoto.UniqueKeyField()
+    score = popoto.SortedField(type=float, default=0.0)
+
+
+ALL_MODELS = [
+    CompositeMemory,
+    SimpleDecayModel,
+    PartitionedComposite,
+    PlainModel,
+    SortedOnlyModel,
+]
+
+
+# --- Setup / Teardown ---
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    """Clean up Redis keys after each test."""
+    yield
+    for model_class in ALL_MODELS:
+        try:
+            model_class.delete_all()
+        except Exception:
+            pass
+    # Clean up any leftover temp keys
+    for key in POPOTO_REDIS_DB.keys("$CSQ:*"):
+        POPOTO_REDIS_DB.delete(key)
+
+
+# --- Error case tests ---
+
+
+class TestCompositeScoreErrors:
+    """Test error handling for invalid inputs."""
+
+    def test_empty_indexes_raises(self):
+        """Empty indexes dict raises QueryException."""
+        with pytest.raises(QueryException, match="non-empty indexes"):
+            CompositeMemory.query.composite_score(indexes={})
+
+    def test_invalid_field_name_raises(self):
+        """Field name not on model raises QueryException."""
+        with pytest.raises(QueryException, match="has no field"):
+            CompositeMemory.query.composite_score(
+                indexes={"nonexistent_field": 1.0}
+            )
+
+    def test_plain_field_raises(self):
+        """Field without sorted set index raises QueryException."""
+        with pytest.raises(QueryException, match="does not have a sorted set"):
+            CompositeMemory.query.composite_score(
+                indexes={"content": 1.0}
+            )
+
+    def test_priority_without_write_filter_raises(self):
+        """'priority' on non-WriteFilterMixin model raises QueryException."""
+        with pytest.raises(QueryException, match="WriteFilterMixin"):
+            SimpleDecayModel.query.composite_score(
+                indexes={"priority": 1.0}
+            )
+
+    def test_access_count_without_tracker_raises(self):
+        """'access_count' on non-AccessTrackerMixin model raises QueryException."""
+        with pytest.raises(QueryException, match="AccessTrackerMixin"):
+            SimpleDecayModel.query.composite_score(
+                indexes={"access_count": 1.0}
+            )
+
+    def test_invalid_aggregate_raises(self):
+        """Invalid aggregate mode raises QueryException."""
+        with pytest.raises(QueryException, match="aggregate must be"):
+            CompositeMemory.query.composite_score(
+                indexes={"relevance": 1.0},
+                aggregate="INVALID",
+            )
+
+    def test_limit_zero_returns_empty(self):
+        """limit=0 returns empty list."""
+        result = CompositeMemory.query.composite_score(
+            indexes={"relevance": 1.0}, limit=0
+        )
+        assert result == []
+
+
+class TestCompositeScoreEmpty:
+    """Test empty result handling."""
+
+    def test_no_instances_returns_empty(self):
+        """Query on model with no instances returns empty list."""
+        result = CompositeMemory.query.composite_score(
+            indexes={"relevance": 1.0}
+        )
+        assert result == []
+
+    def test_empty_sorted_sets_returns_empty(self):
+        """All indexes empty returns empty list."""
+        result = SimpleDecayModel.query.composite_score(
+            indexes={"score": 1.0}
+        )
+        assert result == []
+
+
+# --- Single-index tests ---
+
+
+class TestCompositeScoreSingleIndex:
+    """Test degenerate case: single index works correctly."""
+
+    def test_single_decay_index(self):
+        """Single DecayingSortedField index returns ranked results."""
+        a = SimpleDecayModel.create(name="old")
+        time.sleep(0.05)
+        b = SimpleDecayModel.create(name="new")
+
+        results = SimpleDecayModel.query.composite_score(
+            indexes={"score": 1.0}, limit=10
+        )
+        assert len(results) == 2
+        # Both records should be present
+        names = {r.name for r in results}
+        assert names == {"old", "new"}
+
+    def test_single_sorted_field(self):
+        """Single plain SortedField index returns ranked results."""
+        SortedOnlyModel.create(name="low", score=10.0)
+        SortedOnlyModel.create(name="high", score=90.0)
+        SortedOnlyModel.create(name="mid", score=50.0)
+
+        results = SortedOnlyModel.query.composite_score(
+            indexes={"score": 1.0}, limit=10
+        )
+        assert len(results) == 3
+        assert results[0].name == "high"
+        assert results[1].name == "mid"
+        assert results[2].name == "low"
+
+
+# --- Two-index synergy tests ---
+
+
+class TestCompositeScoreTwoIndex:
+    """Test decay + confidence synergy."""
+
+    def test_high_confidence_recent_beats_low_confidence_old(self):
+        """High-confidence recent record outranks low-confidence old record."""
+        # Create "old" record
+        old = CompositeMemory.create(
+            name="old_fact", content="old", importance=0.8
+        )
+        time.sleep(0.05)
+        # Create "new" record
+        new = CompositeMemory.create(
+            name="new_fact", content="new", importance=0.8
+        )
+
+        # Make old have low confidence, new have high confidence
+        ConfidenceField.update_confidence(old, "certainty", signal=0.2)
+        ConfidenceField.update_confidence(old, "certainty", signal=0.2)
+        ConfidenceField.update_confidence(new, "certainty", signal=0.95)
+        ConfidenceField.update_confidence(new, "certainty", signal=0.95)
+
+        results = CompositeMemory.query.composite_score(
+            indexes={"relevance": 0.5, "certainty": 0.5},
+            limit=10,
+        )
+        assert len(results) >= 2
+        # New + high confidence should beat old + low confidence
+        assert results[0].name == "new_fact"
+
+
+# --- Three-index synergy tests ---
+
+
+class TestCompositeScoreThreeIndex:
+    """Test decay + confidence + access frequency synergy."""
+
+    def test_frequently_accessed_gets_boost(self):
+        """Frequently accessed records get a boost from access_count."""
+        # Create records
+        rarely = CompositeMemory.create(
+            name="rarely_used", content="r", importance=0.8
+        )
+        frequently = CompositeMemory.create(
+            name="frequently_used", content="f", importance=0.8
+        )
+
+        # Set similar confidence
+        ConfidenceField.update_confidence(rarely, "certainty", signal=0.7)
+        ConfidenceField.update_confidence(frequently, "certainty", signal=0.7)
+
+        # Give frequently_used many accesses
+        for _ in range(10):
+            frequently.on_read()
+        frequently.confirm_access()
+
+        results = CompositeMemory.query.composite_score(
+            indexes={
+                "relevance": 0.3,
+                "certainty": 0.3,
+                "access_count": 0.4,
+            },
+            limit=10,
+        )
+        assert len(results) >= 2
+        # The frequently accessed one should rank higher
+        result_names = [r.name for r in results]
+        assert result_names.index("frequently_used") < result_names.index(
+            "rarely_used"
+        )
+
+
+# --- Four-index synergy tests ---
+
+
+class TestCompositeScoreFourIndex:
+    """Test decay + confidence + access + write filter priority."""
+
+    def test_priority_tagged_ranks_higher(self):
+        """Priority-tagged records rank higher with priority weight."""
+        # Create a high-priority record (importance=0.9 -> above priority threshold)
+        high = CompositeMemory.create(
+            name="high_priority", content="hp", importance=0.9
+        )
+        # Create a low-priority record (importance=0.5 -> normal save, no priority)
+        low = CompositeMemory.create(
+            name="low_priority", content="lp", importance=0.5
+        )
+
+        # Set similar confidence
+        ConfidenceField.update_confidence(high, "certainty", signal=0.7)
+        ConfidenceField.update_confidence(low, "certainty", signal=0.7)
+
+        results = CompositeMemory.query.composite_score(
+            indexes={
+                "relevance": 0.25,
+                "certainty": 0.25,
+                "access_count": 0.1,
+                "priority": 0.4,
+            },
+            limit=10,
+        )
+        # Both should be in results
+        result_names = [r.name for r in results]
+        assert "high_priority" in result_names
+        # High priority should rank higher due to priority weight
+        if "low_priority" in result_names:
+            assert result_names.index("high_priority") < result_names.index(
+                "low_priority"
+            )
+
+
+# --- CoOccurrence boost tests ---
+
+
+class TestCompositeScoreCoOccurrence:
+    """Test CoOccurrence boost injection."""
+
+    def test_co_occurrence_boost_surfaces_mediocre_record(self):
+        """Record with mediocre scores but strong association surfaces."""
+        # Create records
+        mediocre = CompositeMemory.create(
+            name="mediocre", content="m", importance=0.5
+        )
+        strong = CompositeMemory.create(
+            name="strong", content="s", importance=0.9
+        )
+
+        # Set similar recency (both just created)
+        ConfidenceField.update_confidence(mediocre, "certainty", signal=0.5)
+        ConfidenceField.update_confidence(strong, "certainty", signal=0.8)
+
+        # Give mediocre a strong co-occurrence boost
+        mediocre_key = mediocre.db_key.redis_key
+        strong_key = strong.db_key.redis_key
+        co_boost = {mediocre_key: 5.0, strong_key: 0.1}
+
+        results = CompositeMemory.query.composite_score(
+            indexes={"relevance": 0.2, "certainty": 0.2},
+            co_occurrence_boost=co_boost,
+            limit=10,
+        )
+        assert len(results) >= 2
+        # Mediocre should now rank first due to strong co-occurrence boost
+        assert results[0].name == "mediocre"
+
+
+# --- Aggregate mode tests ---
+
+
+class TestCompositeScoreAggregate:
+    """Test SUM, MIN, MAX aggregate modes."""
+
+    def test_sum_aggregate(self):
+        """SUM (default) adds scores across indexes."""
+        SortedOnlyModel.create(name="a", score=50.0)
+        SortedOnlyModel.create(name="b", score=100.0)
+
+        results = SortedOnlyModel.query.composite_score(
+            indexes={"score": 1.0}, aggregate="SUM", limit=10
+        )
+        assert len(results) == 2
+        assert results[0].name == "b"
+
+    def test_min_aggregate(self):
+        """MIN aggregate takes minimum score across indexes."""
+        SortedOnlyModel.create(name="a", score=50.0)
+        SortedOnlyModel.create(name="b", score=100.0)
+
+        results = SortedOnlyModel.query.composite_score(
+            indexes={"score": 1.0}, aggregate="MIN", limit=10
+        )
+        assert len(results) == 2
+        assert results[0].name == "b"
+
+    def test_max_aggregate(self):
+        """MAX aggregate takes maximum score across indexes."""
+        SortedOnlyModel.create(name="a", score=50.0)
+        SortedOnlyModel.create(name="b", score=100.0)
+
+        results = SortedOnlyModel.query.composite_score(
+            indexes={"score": 1.0}, aggregate="MAX", limit=10
+        )
+        assert len(results) == 2
+        assert results[0].name == "b"
+
+
+# --- min_score tests ---
+
+
+class TestCompositeScoreMinScore:
+    """Test min_score filtering."""
+
+    def test_min_score_filters_low_scores(self):
+        """Records below min_score are excluded."""
+        SortedOnlyModel.create(name="low", score=5.0)
+        SortedOnlyModel.create(name="high", score=100.0)
+
+        results = SortedOnlyModel.query.composite_score(
+            indexes={"score": 1.0}, min_score=50.0, limit=10
+        )
+        assert len(results) == 1
+        assert results[0].name == "high"
+
+    def test_min_score_all_below_returns_empty(self):
+        """All records below min_score returns empty list."""
+        SortedOnlyModel.create(name="a", score=5.0)
+        SortedOnlyModel.create(name="b", score=10.0)
+
+        results = SortedOnlyModel.query.composite_score(
+            indexes={"score": 1.0}, min_score=999.0, limit=10
+        )
+        assert results == []
+
+
+# --- post_filter tests ---
+
+
+class TestCompositeScorePostFilter:
+    """Test post_filter callback."""
+
+    def test_post_filter_excludes_records(self):
+        """post_filter callback can exclude specific records."""
+        SortedOnlyModel.create(name="keep", score=50.0)
+        excluded = SortedOnlyModel.create(name="exclude", score=100.0)
+        excluded_key = excluded.db_key.redis_key
+
+        def filter_fn(redis_key, score):
+            return redis_key != excluded_key
+
+        results = SortedOnlyModel.query.composite_score(
+            indexes={"score": 1.0},
+            post_filter=filter_fn,
+            limit=10,
+        )
+        assert len(results) == 1
+        assert results[0].name == "keep"
+
+    def test_post_filter_all_excluded_returns_empty(self):
+        """Excluding all records returns empty list."""
+        SortedOnlyModel.create(name="a", score=50.0)
+
+        results = SortedOnlyModel.query.composite_score(
+            indexes={"score": 1.0},
+            post_filter=lambda k, s: False,
+            limit=10,
+        )
+        assert results == []
+
+
+# --- Partition filter tests ---
+
+
+class TestCompositeScorePartitioned:
+    """Test partition filter integration."""
+
+    def test_partitioned_field_requires_partition_filter(self):
+        """Partitioned field without partition filter raises QueryException."""
+        PartitionedComposite.create(name="a", category="cat1")
+
+        with pytest.raises(QueryException, match="partition filter"):
+            PartitionedComposite.query.composite_score(
+                indexes={"relevance": 1.0}, limit=10
+            )
+
+    def test_partitioned_field_with_filter(self):
+        """Partitioned field with correct partition filter works."""
+        PartitionedComposite.create(name="a", category="cat1")
+        PartitionedComposite.create(name="b", category="cat1")
+        PartitionedComposite.create(name="c", category="cat2")
+
+        results = PartitionedComposite.query.filter(
+            category="cat1"
+        ).composite_score(
+            indexes={"relevance": 1.0}, limit=10
+        )
+        assert len(results) == 2
+        names = {r.name for r in results}
+        assert names == {"a", "b"}
+
+
+# --- Limit tests ---
+
+
+class TestCompositeScoreLimit:
+    """Test limit parameter."""
+
+    def test_limit_constrains_results(self):
+        """limit parameter constrains number of returned results."""
+        for i in range(5):
+            SortedOnlyModel.create(name=f"item_{i}", score=float(i * 10))
+
+        results = SortedOnlyModel.query.composite_score(
+            indexes={"score": 1.0}, limit=3
+        )
+        assert len(results) == 3
+
+    def test_limit_larger_than_results(self):
+        """limit larger than result set returns all results."""
+        SortedOnlyModel.create(name="only_one", score=50.0)
+
+        results = SortedOnlyModel.query.composite_score(
+            indexes={"score": 1.0}, limit=100
+        )
+        assert len(results) == 1
+
+
+# --- Temp key cleanup tests ---
+
+
+class TestCompositeScoreTempKeys:
+    """Test temp key cleanup."""
+
+    def test_no_leaked_temp_keys(self):
+        """No $CSQ: keys remain after query completes."""
+        CompositeMemory.create(name="item", content="test", importance=0.8)
+        ConfidenceField.update_confidence(
+            CompositeMemory.query.get(name="item"), "certainty", signal=0.9
+        )
+
+        CompositeMemory.query.composite_score(
+            indexes={"relevance": 0.5, "certainty": 0.5},
+            limit=10,
+        )
+
+        # Check for any leftover $CSQ: keys
+        csq_keys = POPOTO_REDIS_DB.keys("$CSQ:*")
+        assert len(csq_keys) == 0, f"Leaked temp keys: {csq_keys}"
+
+    def test_temp_keys_cleaned_on_empty_result(self):
+        """Temp keys are cleaned even when result is empty."""
+        SimpleDecayModel.query.composite_score(
+            indexes={"score": 1.0}, limit=10
+        )
+
+        csq_keys = POPOTO_REDIS_DB.keys("$CSQ:*")
+        assert len(csq_keys) == 0
+
+
+# --- Convenience method on Query class tests ---
+
+
+class TestQueryConvenienceMethod:
+    """Test the convenience composite_score() method on Query."""
+
+    def test_query_class_has_composite_score(self):
+        """Query class exposes composite_score() convenience method."""
+        SortedOnlyModel.create(name="item", score=50.0)
+
+        # This uses Query.composite_score (not QueryBuilder.composite_score)
+        results = SortedOnlyModel.query.composite_score(
+            indexes={"score": 1.0}, limit=10
+        )
+        assert len(results) == 1
+        assert results[0].name == "item"


### PR DESCRIPTION
## Summary

Adds `composite_score()` method to `QueryBuilder` and `Query` classes, enabling multi-factor retrieval that combines N sorted set indexes with configurable weights via Redis ZUNIONSTORE.

This is where all the agent memory scoring primitives converge: decay, confidence, access frequency, write filter priority, and co-occurrence associations — combined into a single query call that returns top-K results ranked by composite score.

## Changes

- **`src/popoto/models/query.py`**: Added `composite_score()` to QueryBuilder with index resolver, materialization helpers for DecayingSortedField, ConfidenceField, AccessTracker, and temp key management. Added convenience method on Query class.
- **`tests/test_composite_score_query.py`**: 29 tests covering error handling, empty results, single-index degenerate case, 2/3/4-index synergy tests, CoOccurrence boost, aggregate modes (SUM/MIN/MAX), min_score, post_filter, partition integration, limit constraints, and temp key cleanup.
- **`docs/features/agent-memory.md`**: Updated CompositeScoreQuery from Planned to Shipped with full API documentation.
- **`docs/features/composite-score-query.md`**: New standalone feature doc with quick start, API reference, and data flow explanation.
- **`docs/plans/composite_score_query.md`**: Status updated to Shipped.

## Testing

- [x] 29 composite_score tests passing
- [x] Full test suite: 677 passed, 10 skipped (pre-existing)
- [x] Black formatting clean

## Supported Index Types

| Index | Field Type | Strategy |
|-------|-----------|----------|
| DecayingSortedField | Decay-computed | Materialized via Lua |
| CyclicDecayField | Cyclic decay | Materialized via Lua |
| SortedField | Plain sorted | Direct ZSET |
| ConfidenceField | Bayesian | Materialized from hash |
| AccessTracker | Read frequency | Materialized from meta |
| WriteFilter priority | Priority set | Direct ZSET |
| CoOccurrence boost | Graph propagation | Injected temp ZSET |

## API

```python
results = Memory.query.filter(agent_id="agent-1").composite_score(
    indexes={"relevance": 0.4, "certainty": 0.3, "access_count": 0.2, "priority": 0.1},
    limit=10,
    aggregate="SUM",
    min_score=0.1,
    post_filter=lambda key, score: key not in used_keys,
    co_occurrence_boost=propagated_scores,
)
```