### PR TITLE
Index policy-cache-recipe guide for discoverability

### DIFF
--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -1089,6 +1089,8 @@ This is generic infrastructure — the processing logic is application code. One
 
 A reference recipe (not core ORM) composing all shipped primitives into a reinforcement-learning-style action selection cache. When a StreamConsumer detects repeated successful patterns, it crystallizes them into reusable `PolicyEntry` records. Agents query policies by state fingerprint and select actions based on Q-value, confidence, and co-occurrence.
 
+For the full guide with architecture diagrams, tuning advice, and design rationale, see [PolicyCache Recipe](../guides/policy-cache-recipe.md).
+
 Shipped in [PR #239](https://github.com/tomcounsell/popoto/pull/239).
 
 ### Basic usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,7 @@ Popoto provides a fast, familiar interface for working with Redis and Valkey.
  - compatible with Pandas, Xarray for N-dimensional matrix search
  - [PubSub](pubsub.md) for message queues, streaming data processing
  - [Agent Memory](features/agent-memory.md) — programmable memory primitives for AI agents (decay, confidence, associations)
+ - [PolicyCache Recipe](guides/policy-cache-recipe.md) — reference recipe composing all memory primitives into an RL-style action selection cache
 
 **Popoto** is ideal for streaming data. The pub/sub module allows you to trigger state updates in real time.
 Currently being used in production for:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ nav:
     - CyclicDecayField: 'features/cyclic-decay-field.md'
     - ConfidenceField: 'features/confidence-field.md'
     - API Reference: 'api-reference.md'
+    - Guides:
+        - PolicyCache Recipe: 'guides/policy-cache-recipe.md'
     - Contributing:
         - Style Guide: 'style-guide.md'
 

--- a/src/popoto/recipes/policy_cache.py
+++ b/src/popoto/recipes/policy_cache.py
@@ -21,6 +21,10 @@ Dependencies:
     All 12 shipped Popoto primitives (Steps 1-10 of the memory roadmap).
     No external dependencies beyond Popoto itself.
 
+See Also:
+    docs/guides/policy-cache-recipe.md — full guide with architecture,
+    tuning constants, and design decisions.
+
 Example:
     from popoto.recipes.policy_cache import (
         PolicyEntry, compute_fingerprint, update_q_value,


### PR DESCRIPTION
## Summary
- Added `guides/policy-cache-recipe.md` to mkdocs.yml nav under a new **Guides** section so it appears on readthedocs
- Added recipe to `docs/index.md` feature list for homepage discovery
- Cross-linked from the PolicyCache section in `docs/features/agent-memory.md` to the full guide
- Added `See Also` reference in `policy_cache.py` module docstring so developers find the guide from code

## Test plan
- [ ] Verify `mkdocs serve` renders the guide in the nav sidebar
- [ ] Confirm cross-links resolve correctly between agent-memory and the guide