### PR TITLE
Remove duplicate Guides nav section

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,8 +29,6 @@ nav:
         - Memory Systems Research: 'guides/research-prompt-memory-systems.md'
         - Launch Announcements: 'guides/launch-announcements.md'
     - API Reference: 'api-reference.md'
-    - Guides:
-        - PolicyCache Recipe: 'guides/policy-cache-recipe.md'
     - Contributing:
         - Style Guide: 'style-guide.md'
 


### PR DESCRIPTION
Merge artifact from squash-merging PRs #241 and #242 left a duplicate Guides entry in mkdocs.yml. This removes it.