### PR TITLE
Add SubconsciousMemory integration tests for 8 behavioral gaps

### DIFF
--- a/tests/test_subconscious_memory.py
+++ b/tests/test_subconscious_memory.py
@@ -8,6 +8,10 @@ Tests cover:
 - report_outcomes dispatching
 - report_outcomes with empty assembly result
 - Full round-trip with mocked LLM
+
+See also: tests/test_subconscious_memory_integration.py for live-Redis
+integration tests covering multi-memory ranking, token budgets, TTL expiry,
+concurrent agent isolation, and feedback-driven confidence changes.
 """
 
 import os

--- a/tests/test_subconscious_memory_integration.py
+++ b/tests/test_subconscious_memory_integration.py
@@ -494,8 +494,8 @@ class TestObservationFeedback:
         _, assembly = sm.inject_context(messages)
 
         # Apply acted to good, contradicted to bad
-        if assembly.records:
-            for record in assembly.records:
+        assert assembly.records, "inject_context should return at least one memory record"
+        for record in assembly.records:
                 content = getattr(record, "content", "")
                 if "Verified correct" in content:
                     ConfidenceField.update_confidence(record, "confidence", signal=0.9)
@@ -507,19 +507,22 @@ class TestObservationFeedback:
             [{"role": "user", "content": "Tell me about deployment steps."}]
         )
 
-        if len(assembly2.records) >= 2:
-            contents = [getattr(r, "content", "") for r in assembly2.records]
-            good_idx = next(
-                (i for i, c in enumerate(contents) if "Verified correct" in c), None
-            )
-            bad_idx = next(
-                (i for i, c in enumerate(contents) if "Possibly wrong" in c), None
-            )
-            if good_idx is not None and bad_idx is not None:
-                assert good_idx < bad_idx, (
-                    f"High-confidence memory (idx {good_idx}) should rank before "
-                    f"low-confidence (idx {bad_idx})"
-                )
+        assert len(assembly2.records) >= 2, (
+            f"Expected at least 2 records for ranking comparison, got {len(assembly2.records)}"
+        )
+        contents = [getattr(r, "content", "") for r in assembly2.records]
+        good_idx = next(
+            (i for i, c in enumerate(contents) if "Verified correct" in c), None
+        )
+        bad_idx = next(
+            (i for i, c in enumerate(contents) if "Possibly wrong" in c), None
+        )
+        assert good_idx is not None, "Good memory ('Verified correct') not found in results"
+        assert bad_idx is not None, "Bad memory ('Possibly wrong') not found in results"
+        assert good_idx < bad_idx, (
+            f"High-confidence memory (idx {good_idx}) should rank before "
+            f"low-confidence (idx {bad_idx})"
+        )
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Adds `tests/test_subconscious_memory_integration.py` with 8 test classes (27 tests) covering all behavioral gaps from #267
- All tests hit real Redis with no mocking of Popoto internals
- Existing tests in `tests/test_subconscious_memory.py` remain unchanged and passing (15/15)

## Test Classes
1. **TestRetrievalRelevance** -- topical queries surface topically relevant memories
2. **TestAgentIsolation** -- memories partitioned by agent_id, cross-agent invisibility
3. **TestMultiTurnAccumulation** -- inject-extract cycles grow memory, decay ranks older lower
4. **TestObservationFeedback** -- acted boosts confidence, contradicted penalizes, ranking changes
5. **TestTokenBudgetEnforcement** -- injected context respects max_tokens budget
6. **TestExtractionEdgeCases** -- _split_sentences handles URLs, decimals, code blocks, bullets
7. **TestConfigurableFieldNames** -- non-default field names work for extract and inject
8. **TestWriteFilterBoundary** -- exact threshold, below threshold, priority threshold semantics

## Test plan
- [x] `pytest tests/test_subconscious_memory_integration.py -v` -- 27/27 pass
- [x] `pytest tests/test_subconscious_memory.py -v` -- 15/15 pass (unchanged)
- [x] `ruff check` and `ruff format` clean

Closes #267