### PR TITLE
Fix ConfidenceField attribute access returning None (#281)

### DIFF
--- a/src/popoto/fields/confidence_field.py
+++ b/src/popoto/fields/confidence_field.py
@@ -122,8 +122,10 @@ class ConfidenceField(Field):
             )
 
         # ConfidenceField stores float confidence values
+        # Default to initial_confidence so instance.field returns
+        # the configured value rather than None (fixes #281)
         kwargs.setdefault("type", float)
-        kwargs.setdefault("default", None)
+        kwargs.setdefault("default", self.initial_confidence)
         kwargs.setdefault("null", True)
         super().__init__(**kwargs)
 
@@ -240,6 +242,10 @@ class ConfidenceField(Field):
         )
 
         new_confidence = float(result[0])
+
+        # Sync the instance attribute so instance.field returns
+        # the updated confidence (fixes #281)
+        setattr(model_instance, field_name, new_confidence)
 
         # EventStreamMixin: log confidence update event
         from .event_stream import EventStreamMixin

--- a/tests/test_confidence_field.py
+++ b/tests/test_confidence_field.py
@@ -272,6 +272,37 @@ class TestGetConfidence:
         assert data["contradictions"] == 0
 
 
+# --- Attribute Access Tests (issue #281) ---
+
+
+class TestAttributeAccess:
+    def test_attribute_returns_initial_confidence_after_create(self):
+        """instance.certainty returns initial_confidence, not None (issue #281)."""
+        item = ConfidenceItem.create(name="attr1")
+        assert item.certainty == 0.5
+
+    def test_attribute_returns_custom_initial_confidence(self):
+        """instance.certainty returns custom initial_confidence after create."""
+        item = ConfidenceCustom.create(name="attr2")
+        assert item.certainty == 0.8
+
+    def test_attribute_returns_initial_before_save(self):
+        """instance.certainty returns initial_confidence even before save."""
+        item = ConfidenceItem(name="attr3")
+        assert item.certainty == 0.5
+
+    def test_attribute_returns_updated_value_after_update(self):
+        """instance.certainty reflects updated confidence after update_confidence."""
+        item = ConfidenceItem.create(name="attr4")
+        ConfidenceField.update_confidence(item, "certainty", signal=0.9)
+        assert abs(item.certainty - 0.9) < 1e-6
+
+    def test_attribute_not_none(self):
+        """instance.certainty is never None with default config (issue #281)."""
+        item = ConfidenceItem.create(name="attr5")
+        assert item.certainty is not None
+
+
 # --- Error Cases ---
 
 


### PR DESCRIPTION
## Summary
- `instance.confidence` returned `None` instead of the configured `initial_confidence` value because the field default was hardcoded to `None`
- Changed field default to `self.initial_confidence` so attribute access returns the correct value from initialization onward
- Added `setattr` in `update_confidence()` to sync the instance attribute after Bayesian updates
- Added 5 new tests covering the reproduction case from #281

## Test plan
- [x] All 40 ConfidenceField tests pass (5 new + 35 existing)
- [x] Full suite: 1151 passed, 10 skipped, 0 failures
- [x] `instance.certainty` returns `0.5` after create (was `None`)
- [x] `instance.certainty` returns `0.8` with custom `initial_confidence=0.8`
- [x] `instance.certainty` reflects updated value after `update_confidence()`
- [x] Backward compatibility: `get_confidence()` classmethod still works

Closes #281