### PR TITLE
Fix KeyField index stale reads (#283)

### DIFF
--- a/docs/plans/keyfield_index_stale_reads.md
+++ b/docs/plans/keyfield_index_stale_reads.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: Done
 type: bug
 appetite: Small
 owner: Agent

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -613,6 +613,7 @@ class Model(metaclass=ModelBase):
         self._saved_field_values = (
             dict()
         )  # stores field values at last save for proper on_delete cleanup
+        self._is_persisted = False  # True after pipeline.execute() confirms write
 
         # todo: create set of possible custom field keys
 
@@ -1026,15 +1027,22 @@ class Model(metaclass=ModelBase):
             key is automatically deleted. This enables "rename" operations
             while maintaining data integrity.
 
+            When no pipeline is provided, save() uses an internal pipeline
+            and calls execute() before returning. This guarantees that all
+            index writes are visible to subsequent filter() calls. When an
+            external pipeline is provided, index writes are queued but NOT
+            flushed -- the caller must call pipeline.execute() before
+            querying, or filter() may miss the saved record.
+
         Example:
-            # Single save
+            # Single save (immediately queryable after return)
             user.save()
 
-            # Batched saves
+            # Batched saves (NOT queryable until execute)
             pipe = redis.pipeline()
             user1.save(pipeline=pipe)
             user2.save(pipeline=pipe)
-            pipe.execute()
+            pipe.execute()  # indexes now visible to filter()
 
             # Partial save (only update specific fields)
             user.name = "new_name"
@@ -1198,6 +1206,7 @@ class Model(metaclass=ModelBase):
                     )
                 results = internal_pipeline.execute()
                 db_response = results[0]  # HSET result
+                self._is_persisted = True
                 self._redis_key = new_db_key.redis_key
                 # Merge into saved_field_values (preserve existing, update listed)
                 for field_name in update_fields:
@@ -1370,9 +1379,12 @@ class Model(metaclass=ModelBase):
                 if new_hash:
                     internal_pipeline.hset(index_key, new_hash, new_db_key.redis_key)
 
+            # pipeline.execute() is synchronous in redis-py: it blocks until
+            # all responses are received, guaranteeing write visibility after return
             results = internal_pipeline.execute()
             db_response = results[0]  # HSET result (backward compat)
 
+            self._is_persisted = True
             self._redis_key = new_db_key.redis_key  # 7
             # Store field values for proper cleanup on delete  # 8
             self._saved_field_values = {

--- a/src/popoto/models/encoding.py
+++ b/src/popoto/models/encoding.py
@@ -344,6 +344,7 @@ def decode_popoto_model_hashmap(
             field_name: getattr(model_instance, field_name)
             for field_name in model_instance._meta.fields.keys()
         }
+        model_instance._is_persisted = True
 
         return model_instance
 
@@ -409,6 +410,7 @@ def _create_lazy_model(model_class: "Model", redis_hash: dict) -> "Model":
     instance.obsolete_redis_key = None
     instance._ttl = model_class._meta.ttl
     instance._expire_at = None
+    instance._is_persisted = True
 
     return instance
 

--- a/tests/test_keyfield_stale_reads.py
+++ b/tests/test_keyfield_stale_reads.py
@@ -1,0 +1,149 @@
+"""Regression tests for KeyField index stale reads (issue #283).
+
+Verifies that Model.create() and save() produce immediately-queryable
+index entries -- filter() must find records right after create/save
+returns, with no timing gap.
+"""
+
+import sys
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+from src.popoto.redis_db import POPOTO_REDIS_DB
+from src import popoto
+
+
+class Job(popoto.Model):
+    chat_id = popoto.KeyField()
+    status = popoto.KeyField()
+    payload = popoto.Field(null=True)
+
+
+# Cleanup before tests
+for item in Job.query.all():
+    item.delete()
+
+
+def test_create_then_filter_single_keyfield():
+    """filter() finds a record immediately after create() by one KeyField."""
+    job = Job.create(chat_id="c1", status="pending", payload="data")
+    try:
+        results = Job.query.filter(status="pending").all()
+        keys = [r.chat_id for r in results]
+        assert "c1" in keys, f"Expected c1 in {keys}"
+    finally:
+        job.delete()
+
+
+def test_create_then_filter_multi_keyfield_intersection():
+    """filter() finds a record immediately after create() by multiple KeyFields."""
+    job = Job.create(chat_id="c2", status="pending", payload="data")
+    try:
+        results = Job.query.filter(chat_id="c2", status="pending").all()
+        assert len(results) == 1, f"Expected 1 result, got {len(results)}"
+        assert results[0].payload == "data"
+    finally:
+        job.delete()
+
+
+def test_create_multiple_then_filter():
+    """filter() finds all records immediately after multiple create() calls."""
+    jobs = []
+    for i in range(5):
+        jobs.append(Job.create(chat_id=f"batch_{i}", status="queued"))
+    try:
+        results = Job.query.filter(status="queued").all()
+        found_ids = {r.chat_id for r in results}
+        expected_ids = {f"batch_{i}" for i in range(5)}
+        assert expected_ids <= found_ids, f"Missing: {expected_ids - found_ids}"
+    finally:
+        for j in jobs:
+            j.delete()
+
+
+def test_save_then_filter():
+    """filter() finds a record immediately after save() (no pipeline)."""
+    job = Job(chat_id="c3", status="active")
+    job.save()
+    try:
+        results = Job.query.filter(chat_id="c3", status="active").all()
+        assert len(results) == 1, f"Expected 1 result, got {len(results)}"
+    finally:
+        job.delete()
+
+
+def test_external_pipeline_not_visible_until_execute():
+    """Records saved via external pipeline are NOT visible before execute()."""
+    pipe = POPOTO_REDIS_DB.pipeline()
+    job = Job(chat_id="c4", status="deferred")
+    job.save(pipeline=pipe)
+
+    # Before execute: filter should NOT find it
+    results = Job.query.filter(chat_id="c4", status="deferred").all()
+    assert len(results) == 0, f"Expected 0 before execute, got {len(results)}"
+
+    # After execute: filter should find it
+    pipe.execute()
+    results = Job.query.filter(chat_id="c4", status="deferred").all()
+    assert len(results) == 1, f"Expected 1 after execute, got {len(results)}"
+
+    # Cleanup
+    for r in results:
+        r.delete()
+
+
+def test_is_persisted_flag_internal_pipeline():
+    """_is_persisted is True after save() with internal pipeline."""
+    job = Job(chat_id="c5", status="new")
+    assert job._is_persisted is False
+    job.save()
+    assert job._is_persisted is True
+    job.delete()
+
+
+def test_is_persisted_flag_create():
+    """_is_persisted is True after create()."""
+    job = Job.create(chat_id="c6", status="new")
+    assert job._is_persisted is True
+    job.delete()
+
+
+def test_is_persisted_flag_external_pipeline():
+    """_is_persisted remains False when using external pipeline."""
+    pipe = POPOTO_REDIS_DB.pipeline()
+    job = Job(chat_id="c7", status="new")
+    job.save(pipeline=pipe)
+    assert job._is_persisted is False
+    pipe.execute()
+    # Even after external execute, _is_persisted stays False
+    # (Popoto can't observe external pipeline execution)
+    assert job._is_persisted is False
+
+    # Cleanup
+    loaded = Job.query.filter(chat_id="c7").all()
+    for r in loaded:
+        r.delete()
+
+
+def test_is_persisted_flag_loaded_from_redis():
+    """_is_persisted is True for instances loaded from Redis."""
+    job = Job.create(chat_id="c8", status="loaded")
+    loaded = Job.query.filter(chat_id="c8").all()
+    assert len(loaded) == 1
+    assert loaded[0]._is_persisted is True
+    job.delete()
+
+
+if __name__ == "__main__":
+    test_create_then_filter_single_keyfield()
+    test_create_then_filter_multi_keyfield_intersection()
+    test_create_multiple_then_filter()
+    test_save_then_filter()
+    test_external_pipeline_not_visible_until_execute()
+    test_is_persisted_flag_internal_pipeline()
+    test_is_persisted_flag_create()
+    test_is_persisted_flag_external_pipeline()
+    test_is_persisted_flag_loaded_from_redis()
+    print("All tests passed!")


### PR DESCRIPTION
## Summary

- Confirms that the internal pipeline path in `save()` already provides atomic read-after-write consistency — `filter()` immediately finds records after `create()` or `save()` returns
- Adds `_is_persisted` flag to Model instances: `True` after successful internal pipeline save or when loaded from Redis, `False` for new/external-pipeline instances
- Updates `save()` docstring documenting that external pipeline callers must call `execute()` before querying

## Test plan

- [x] 9 new regression tests in `test_keyfield_stale_reads.py` covering:
  - Single KeyField filter after create
  - Multi-KeyField intersection filter after create
  - Batch create then filter
  - Save (no pipeline) then filter
  - External pipeline NOT visible before execute, visible after
  - `_is_persisted` flag correctness for all paths
- [x] Full test suite passes (1157 passed, 14 skipped)

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)