### PR TITLE
Fix embedding cache filenames exceeding 255-byte limit

### DIFF
--- a/src/popoto/fields/embedding_field.py
+++ b/src/popoto/fields/embedding_field.py
@@ -23,6 +23,8 @@ Example:
     m.save()  # embedding generated automatically via provider
 """
 
+import hashlib
+import json
 import logging
 import os
 import tempfile
@@ -63,6 +65,48 @@ def _get_embeddings_dir():
         os.path.join(os.path.expanduser("~"), ".popoto", "content"),
     )
     return os.path.join(base, ".embeddings")
+
+
+def _index_path(model_class_name: str) -> str:
+    """Return the path to the _index.json sidecar for a model class."""
+    base = _get_embeddings_dir()
+    return os.path.join(base, model_class_name, "_index.json")
+
+
+def _read_index(model_class_name: str) -> dict:
+    """Read the _index.json sidecar, returning a dict mapping filenames to Redis keys.
+
+    Returns an empty dict if the file is missing or corrupt.
+    """
+    path = _index_path(model_class_name)
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+        return {}
+    except (json.JSONDecodeError, OSError):
+        logger.warning(f"Could not read index file {path}, returning empty index")
+        return {}
+
+
+def _write_index(model_class_name: str, index_dict: dict) -> None:
+    """Atomically write the _index.json sidecar (temp file + rename)."""
+    path = _index_path(model_class_name)
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(dir=directory, suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(index_dict, f, ensure_ascii=False)
+        os.rename(tmp_path, path)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
 
 
 def invalidate_cache(model_class_name: str = None):
@@ -133,9 +177,21 @@ class EmbeddingField(Field):
     def _embedding_path(cls, model_class_name: str, redis_key: str) -> str:
         """Return the .npy file path for a model instance's embedding.
 
-        Uses hex encoding of the Redis key to ensure lossless round-trip:
-        any bytes in the key are preserved exactly when decoded back.
+        Uses SHA-256 hash of the Redis key to produce a fixed-length
+        filename (64 hex chars + '.npy' = 68 bytes), avoiding the
+        255-byte filesystem limit that hex encoding could exceed with
+        long Redis keys.
+
+        Since SHA-256 is one-way, a sidecar ``_index.json`` file maps
+        hash filenames back to Redis keys for reverse lookup.
         """
+        base = _get_embeddings_dir()
+        hash_key = hashlib.sha256(redis_key.encode("utf-8")).hexdigest()
+        return os.path.join(base, model_class_name, f"{hash_key}.npy")
+
+    @classmethod
+    def _legacy_embedding_path(cls, model_class_name: str, redis_key: str) -> str:
+        """Return the legacy hex-encoded .npy file path for migration."""
         base = _get_embeddings_dir()
         hex_key = redis_key.encode("utf-8").hex()
         return os.path.join(base, model_class_name, f"{hex_key}.npy")
@@ -238,6 +294,26 @@ class EmbeddingField(Field):
                 os.unlink(tmp_path)
             raise
 
+        # Update the _index.json sidecar with the hash-to-key mapping
+        model_class_name = model_instance.__class__.__name__
+        npy_filename = os.path.basename(npy_path)
+        index = _read_index(model_class_name)
+        index[npy_filename] = redis_key
+        _write_index(model_class_name, index)
+
+        # Migrate legacy hex-encoded file if it exists
+        legacy_path = cls._legacy_embedding_path(model_class_name, redis_key)
+        if legacy_path != npy_path and os.path.exists(legacy_path):
+            try:
+                os.unlink(legacy_path)
+                # Remove legacy filename from index if present
+                legacy_filename = os.path.basename(legacy_path)
+                if legacy_filename in index:
+                    del index[legacy_filename]
+                    _write_index(model_class_name, index)
+            except OSError:
+                logger.warning(f"Failed to remove legacy embedding file {legacy_path}")
+
         # Store dimension count in Redis field
         dim_count = len(embedding)
         setattr(model_instance, field_name, dim_count)
@@ -280,6 +356,13 @@ class EmbeddingField(Field):
         if os.path.exists(npy_path):
             os.unlink(npy_path)
 
+        # Remove entry from _index.json sidecar
+        npy_filename = os.path.basename(npy_path)
+        index = _read_index(model_class_name)
+        if npy_filename in index:
+            del index[npy_filename]
+            _write_index(model_class_name, index)
+
         invalidate_cache(model_class_name)
         return pipeline if pipeline else None
 
@@ -316,20 +399,47 @@ class EmbeddingField(Field):
         vectors = []
         keys = []
 
+        # Read the index for hash-to-key mapping
+        index = _read_index(model_name)
+        index_updated = False
+
         for filename in os.listdir(emb_dir):
             if not filename.endswith(".npy"):
                 continue
             filepath = os.path.join(emb_dir, filename)
             try:
                 vec = np.load(filepath)
-                # Reconstruct Redis key from hex-encoded filename
-                hex_key = filename[:-4]  # strip .npy
-                redis_key = bytes.fromhex(hex_key).decode("utf-8")
+
+                # Look up Redis key from the index first
+                if filename in index:
+                    redis_key = index[filename]
+                else:
+                    # Fallback: try legacy hex-decode for backward compatibility
+                    hex_key = filename[:-4]  # strip .npy
+                    try:
+                        redis_key = bytes.fromhex(hex_key).decode("utf-8")
+                        # Add to index for future lookups
+                        index[filename] = redis_key
+                        index_updated = True
+                    except (ValueError, UnicodeDecodeError):
+                        logger.warning(
+                            f"Skipping unrecognized embedding file {filename}: "
+                            "not in index and not a valid hex-encoded key"
+                        )
+                        continue
+
                 vectors.append(vec.astype(np.float32))
                 keys.append(redis_key)
             except Exception as e:
                 logger.warning(f"Failed to load embedding {filepath}: {e}")
                 continue
+
+        # Persist any index updates from legacy fallback
+        if index_updated:
+            try:
+                _write_index(model_name, index)
+            except Exception:
+                logger.warning(f"Failed to update index for {model_name}")
 
         if not vectors:
             return None, []

--- a/tests/test_embedding_field.py
+++ b/tests/test_embedding_field.py
@@ -26,11 +26,12 @@ from src.popoto.fields.embedding_field import (
     EmbeddingField,
     set_default_provider,
     invalidate_cache,
+    _read_index,
+    _index_path,
 )
 from src.popoto.stores.filesystem import FilesystemStore
 from src.popoto.embeddings import AbstractEmbeddingProvider
 from src.popoto.redis_db import POPOTO_REDIS_DB
-
 
 # --- Mock Provider ---
 
@@ -155,6 +156,13 @@ class TestEmbeddingFieldSave:
         npy_path = EmbeddingField._embedding_path("EmbDoc", redis_key)
         assert os.path.exists(npy_path)
 
+        # Verify SHA-256 filename format: 64 hex chars + .npy
+        filename = os.path.basename(npy_path)
+        assert len(filename) == 68  # 64 hex chars + '.npy'
+        assert filename.endswith(".npy")
+        hex_part = filename[:-4]
+        assert all(c in "0123456789abcdef" for c in hex_part)
+
         vec = np.load(npy_path)
         assert vec.shape == (4,)
         assert vec.dtype == np.float32
@@ -203,8 +211,17 @@ class TestEmbeddingFieldDelete:
         npy_path = EmbeddingField._embedding_path("EmbDoc", redis_key)
         assert os.path.exists(npy_path)
 
+        # Verify index entry exists before delete
+        index = _read_index("EmbDoc")
+        npy_filename = os.path.basename(npy_path)
+        assert npy_filename in index
+
         doc.delete()
         assert not os.path.exists(npy_path)
+
+        # Verify index entry removed after delete
+        index = _read_index("EmbDoc")
+        assert npy_filename not in index
 
 
 class TestEmbeddingCache:
@@ -276,3 +293,158 @@ class TestEmbeddingFieldErrors:
         # Should not raise -- just skip embedding
         doc.save()
         set_default_provider(MockProvider(dim=4))
+
+
+class TestEmbeddingFilenameLimit:
+    """Test SHA-256 hashing prevents filename length errors."""
+
+    def test_long_redis_key_filename(self):
+        """A Redis key >125 chars should produce a valid filename via SHA-256."""
+        # Use a name long enough that hex encoding would exceed 255 bytes
+        long_name = "x" * 200
+        doc = EmbDocPlainSource(name=long_name, text="Long key content")
+        # This would raise OSError with hex encoding; SHA-256 keeps it under 255
+        doc.save()
+
+        redis_key = doc._redis_key or doc.db_key.redis_key
+        npy_path = EmbeddingField._embedding_path("EmbDocPlainSource", redis_key)
+        assert os.path.exists(npy_path)
+
+        # Filename is always 68 bytes regardless of key length
+        filename = os.path.basename(npy_path)
+        assert len(filename) == 68
+
+
+class TestEmbeddingIndex:
+    """Test _index.json sidecar operations."""
+
+    def test_index_json_written_on_save(self):
+        """Saving a doc should create _index.json with the correct mapping."""
+        doc = EmbDoc(name="idx1", content="Index test")
+        doc.save()
+
+        redis_key = doc._redis_key or doc.db_key.redis_key
+        npy_path = EmbeddingField._embedding_path("EmbDoc", redis_key)
+        npy_filename = os.path.basename(npy_path)
+
+        index = _read_index("EmbDoc")
+        assert npy_filename in index
+        assert index[npy_filename] == redis_key
+
+    def test_index_entry_removed_on_delete(self):
+        """Deleting a doc should remove its entry from _index.json."""
+        doc = EmbDoc(name="idx2", content="Delete index test")
+        doc.save()
+
+        redis_key = doc._redis_key or doc.db_key.redis_key
+        npy_path = EmbeddingField._embedding_path("EmbDoc", redis_key)
+        npy_filename = os.path.basename(npy_path)
+
+        # Verify entry exists
+        index = _read_index("EmbDoc")
+        assert npy_filename in index
+
+        doc.delete()
+
+        # Verify entry removed
+        index = _read_index("EmbDoc")
+        assert npy_filename not in index
+
+    def test_legacy_migration_on_save(self, tmp_path):
+        """Saving a key that has a legacy hex-encoded file should migrate it."""
+        import hashlib
+
+        doc = EmbDoc(name="legacy1", content="Legacy migration test")
+        # Manually figure out what the redis key will be
+        doc.save()
+        redis_key = doc._redis_key or doc.db_key.redis_key
+
+        # Get the new SHA-256 path and the legacy hex path
+        new_path = EmbeddingField._embedding_path("EmbDoc", redis_key)
+        legacy_path = EmbeddingField._legacy_embedding_path("EmbDoc", redis_key)
+
+        # If they happen to be the same (very short key), skip this test
+        if new_path == legacy_path:
+            pytest.skip("Key too short for hex and sha256 paths to differ")
+
+        # Delete the new file and create a legacy hex-encoded file instead
+        vec = np.load(new_path)
+        os.unlink(new_path)
+        os.makedirs(os.path.dirname(legacy_path), exist_ok=True)
+        np.save(legacy_path, vec)
+        assert os.path.exists(legacy_path)
+        assert not os.path.exists(new_path)
+
+        # Clear the index entry
+        index = _read_index("EmbDoc")
+        new_filename = os.path.basename(new_path)
+        index.pop(new_filename, None)
+        from src.popoto.fields.embedding_field import _write_index
+
+        _write_index("EmbDoc", index)
+
+        # Re-save -- should migrate the legacy file
+        invalidate_cache("EmbDoc")
+        doc2 = EmbDoc(name="legacy1", content="Legacy migration test updated")
+        doc2.save()
+
+        # Legacy file should be gone, new file should exist
+        assert not os.path.exists(legacy_path)
+        assert os.path.exists(new_path)
+
+        # Index should have the new entry
+        index = _read_index("EmbDoc")
+        assert new_filename in index
+
+    def test_load_without_index_falls_back(self, tmp_path):
+        """Loading embeddings with hex-encoded files but no index should work."""
+        from src.popoto.fields.embedding_field import _get_embeddings_dir
+
+        # Save a doc normally (creates SHA-256 file + index)
+        doc = EmbDoc(name="fallback1", content="Fallback test")
+        doc.save()
+        redis_key = doc._redis_key or doc.db_key.redis_key
+
+        # Get the embedding directory
+        emb_dir = os.path.join(_get_embeddings_dir(), "EmbDoc")
+
+        # Remove the index file
+        idx_path = _index_path("EmbDoc")
+        if os.path.exists(idx_path):
+            os.unlink(idx_path)
+
+        # Rename the SHA-256 file to a legacy hex-encoded filename
+        new_path = EmbeddingField._embedding_path("EmbDoc", redis_key)
+        legacy_path = EmbeddingField._legacy_embedding_path("EmbDoc", redis_key)
+
+        if new_path != legacy_path:
+            os.rename(new_path, legacy_path)
+
+        # Clear cache so load_embeddings reads from disk
+        invalidate_cache("EmbDoc")
+
+        # load_embeddings should still work via hex-decode fallback
+        matrix, keys = EmbeddingField.load_embeddings(EmbDoc)
+        assert matrix is not None
+        assert len(keys) == 1
+        assert keys[0] == redis_key
+
+    def test_unrecognized_npy_skipped(self, tmp_path):
+        """A .npy file with a non-hex, non-indexed name should be skipped."""
+        from src.popoto.fields.embedding_field import _get_embeddings_dir
+
+        # Create model embedding directory
+        emb_dir = os.path.join(_get_embeddings_dir(), "EmbDoc")
+        os.makedirs(emb_dir, exist_ok=True)
+
+        # Create a .npy file with a name that is NOT valid hex and NOT in index
+        bogus_path = os.path.join(emb_dir, "not_a_valid_hex_name.npy")
+        np.save(bogus_path, np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))
+
+        invalidate_cache("EmbDoc")
+
+        # load_embeddings should skip the bogus file without crashing
+        matrix, keys = EmbeddingField.load_embeddings(EmbDoc)
+        # The bogus file should not appear in the results
+        for key in keys:
+            assert key != "not_a_valid_hex_name"


### PR DESCRIPTION
## Summary
- Replace hex encoding with SHA-256 hashing in `EmbeddingField._embedding_path()` to produce fixed 68-byte filenames, preventing `OSError` when Redis keys exceed ~125 characters
- Add `_index.json` sidecar file per model class for reverse-lookup (SHA-256 is one-way), with atomic writes via temp+rename
- Backward-compatible: `load_embeddings()` falls back to hex-decode for legacy files not yet in the index; `on_save()` lazily migrates legacy hex-encoded files

## Changes
- `src/popoto/fields/embedding_field.py`: SHA-256 hashing, `_read_index()`/`_write_index()` helpers, index updates in `on_save()`/`on_delete()`/`load_embeddings()`, legacy migration
- `tests/test_embedding_field.py`: Updated existing tests for new filename format + 6 new tests (long key, index CRUD, legacy migration, fallback loading, unrecognized file skipping)

## Test plan
- [x] All 20 tests pass (14 existing updated + 6 new)
- [x] `test_long_redis_key_filename` — 200-char key saves without OSError
- [x] `test_legacy_migration_on_save` — hex file renamed to SHA-256 on save
- [x] `test_load_without_index_falls_back` — hex-decode fallback works
- [x] `test_index_json_written_on_save` — index contains correct mapping
- [x] `test_index_entry_removed_on_delete` — index cleaned up on delete
- [x] `test_unrecognized_npy_skipped` — bogus files skipped with warning

Closes #313