### PR TITLE
Bump version to 1.4.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "popoto"
-version = "1.4.3"
+version = "1.4.4"
 description = "A Python Redis ORM"
 readme = "README.md"
 authors = [{ name = "Tom Counsell", email = "other@tomcounsell.com" }]


### PR DESCRIPTION
## Summary
- Bump version from 1.4.3 to 1.4.4 in `pyproject.toml` for the next patch release

## Changes since v1.4.3
- **Fix embedding cache filenames exceeding 255-byte filesystem limit** (#315) — Uses SHA-256 hashing for cache filenames instead of hex-encoded field names that could exceed filesystem limits. Includes backward-compatible sidecar index for existing caches.
- **Family-aware parametric scenarios for constant sensitivity coverage** (#296) — Expanded test coverage for constant sensitivity code paths with parametric scenarios.

## Release process
After merging this PR:
1. Create and push tag `v1.4.4` on main
2. The `release.yml` workflow will publish to PyPI via trusted publishing
3. Create GitHub release with release notes