### PR TITLE
Fix Query.get() to accept plain redis_key string positionally

### DIFF
--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -1517,6 +1517,10 @@ class Query:
             # Fallback to filter when using non-key fields
             user = User.query.get(email="alice@example.com")  # May be slower
         """
+        if isinstance(db_key, str) and not redis_key:
+            redis_key = db_key
+            db_key = None
+
         if (
             not db_key
             and not redis_key

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -1514,6 +1514,9 @@ class Query:
             # Direct lookup when all keys are known (single Redis command)
             user = User.query.get(username="alice", tenant_id="acme")
 
+            # Positional redis_key string (e.g. from a previous query or external source)
+            user = User.query.get("User:alice:acme")
+
             # Fallback to filter when using non-key fields
             user = User.query.get(email="alice@example.com")  # May be slower
         """

--- a/tests/test_query_get_positional_string.py
+++ b/tests/test_query_get_positional_string.py
@@ -1,0 +1,99 @@
+"""Tests for Query.get() accepting a plain redis_key string positionally.
+
+Covers the fix for issue #317: passing a string positionally to get() should
+be interpreted as redis_key, not db_key.
+"""
+
+import pytest
+
+from popoto import Model, KeyField, Field
+
+
+class PositionalGetModel(Model):
+    key = KeyField(type=str)
+    value = Field(type=str, null=True)
+
+
+class MultiKeyPositionalModel(Model):
+    key1 = KeyField(type=str)
+    key2 = KeyField(type=str)
+    value = Field(type=str, null=True)
+
+
+class TestQueryGetPositionalString:
+    """Test that Query.get() handles a positional string as redis_key."""
+
+    def setup_method(self):
+        PositionalGetModel.delete_all()
+        MultiKeyPositionalModel.delete_all()
+
+    def teardown_method(self):
+        PositionalGetModel.delete_all()
+        MultiKeyPositionalModel.delete_all()
+
+    def test_positional_string_retrieves_instance(self):
+        """A plain string passed positionally should be treated as redis_key."""
+        instance = PositionalGetModel.create(key="alpha", value="hello")
+        redis_key = instance.db_key.redis_key
+
+        result = PositionalGetModel.query.get(redis_key)
+        assert result is not None
+        assert result.key == "alpha"
+        assert result.value == "hello"
+
+    def test_positional_db_key_still_works(self):
+        """Passing an actual DB_key positionally must continue to work."""
+        instance = PositionalGetModel.create(key="beta", value="world")
+        db_key = instance.db_key
+
+        result = PositionalGetModel.query.get(db_key)
+        assert result is not None
+        assert result.key == "beta"
+        assert result.value == "world"
+
+    def test_keyword_redis_key_still_works(self):
+        """Explicit redis_key= keyword argument must still work."""
+        instance = PositionalGetModel.create(key="gamma", value="test")
+        redis_key = instance.db_key.redis_key
+
+        result = PositionalGetModel.query.get(redis_key=redis_key)
+        assert result is not None
+        assert result.key == "gamma"
+
+    def test_nonexistent_key_returns_none(self):
+        """A positional string for a nonexistent key should return None."""
+        result = PositionalGetModel.query.get("PositionalGetModel:nonexistent")
+        assert result is None
+
+    def test_kwargs_lookup_unchanged(self):
+        """Keyword-based field lookup must still work as before."""
+        instance = PositionalGetModel.create(key="delta", value="unchanged")
+
+        result = PositionalGetModel.query.get(key="delta")
+        assert result is not None
+        assert result.value == "unchanged"
+
+    def test_both_positional_string_and_keyword_redis_key(self):
+        """When both positional string and redis_key= are given, keyword wins."""
+        inst_a = PositionalGetModel.create(key="aaa", value="first")
+        inst_b = PositionalGetModel.create(key="bbb", value="second")
+        key_a = inst_a.db_key.redis_key
+        key_b = inst_b.db_key.redis_key
+
+        # Positional string is discarded when redis_key= is explicit
+        result = PositionalGetModel.query.get(key_a, redis_key=key_b)
+        assert result is not None
+        assert result.key == "bbb"
+
+    def test_multi_key_model_positional_string(self):
+        """Positional string lookup should work with multi-key models too."""
+        instance = MultiKeyPositionalModel.create(
+            key1="x", key2="y", value="multi"
+        )
+        redis_key = instance.db_key.redis_key
+
+        result = MultiKeyPositionalModel.query.get(redis_key)
+        assert result is not None
+        assert result.key1 == "x"
+        assert result.key2 == "y"
+        assert result.value == "multi"


### PR DESCRIPTION
## Summary
- Fixes #317: `Query.get("some_redis_key")` raised `AttributeError` because the positional string bound to `db_key` instead of `redis_key`
- Adds a 3-line guard clause at the top of `get()` that detects when `db_key` is a plain `str` (safe because `DB_key` extends `list`) and reinterprets it as `redis_key`
- No signature changes, no new dependencies

## Changes
- `src/popoto/models/query.py`: 3-line type-check guard before existing logic
- `tests/test_query_get_positional_string.py`: 7 tests covering positional string, positional DB_key, keyword redis_key, nonexistent key, kwargs lookup, both-args precedence, and multi-key models

## Test plan
- [x] All 7 new tests pass
- [x] Existing query tests (`test_get_or_create.py`, `test_queries.py`, `test_key_fields.py`) pass with no regressions