### PR TITLE
Add Query.get_many() for bulk key hydration

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -665,6 +665,30 @@ Retrieve a single model instance. Look up by `db_key`, `redis_key`, or keyword f
 restaurant = Restaurant.query.get(name="Taco Town")
 ```
 
+### Query.get\_many()
+
+```python
+Query.get_many(redis_keys: list[str], skip_none: bool = False) -> list
+```
+
+Retrieve multiple model instances by their Redis keys in a single pipelined round-trip.
+The returned list preserves the order of `redis_keys`; positions where no Redis hash exists
+contain `None` (or are omitted when `skip_none=True`).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `redis_keys` | `list[str]` | | List of Redis key strings to look up. |
+| `skip_none` | `bool` | `False` | When `True`, missing keys are dropped instead of appearing as `None`. |
+
+**Returns:** `list` of `Model` instances (and `None` placeholders unless `skip_none=True`).
+
+```python
+keys = ["Restaurant:Burger Palace", "Restaurant:Sushi Zen"]
+restaurants = Restaurant.query.get_many(redis_keys=keys)
+```
+
+The async counterpart is `await Model.query.async_get_many(redis_keys=keys)`.
+
 ### Query.filter()
 
 ```python

--- a/docs/async.md
+++ b/docs/async.md
@@ -184,6 +184,27 @@ async def audit_keys():
     print(f"Order keys in Redis: {len(keys)}")
 ```
 
+### async_get_many()
+
+Retrieve multiple instances by Redis key in a single async pipeline. This is the async
+counterpart of `query.get_many()` -- see [Making Queries](query.md#get-multiple-objects-by-key)
+for full details on ordering and `skip_none` behavior.
+
+```python
+async def bulk_lookup():
+    keys = ["Restaurant:Siam Garden", "Restaurant:Bella Napoli", "Restaurant:Gone"]
+    restaurants = await Restaurant.query.async_get_many(redis_keys=keys)
+    # => [<Restaurant>, <Restaurant>, None]
+
+    # Drop missing entries
+    restaurants = await Restaurant.query.async_get_many(redis_keys=keys, skip_none=True)
+    # => [<Restaurant>, <Restaurant>]
+```
+
+!!! tip
+    `async_get_many()` uses a native async Redis pipeline, so it does not block the event
+    loop even when hydrating hundreds of keys.
+
 ## Concurrent Operations
 
 The real power of async shows up when you need to perform independent operations at the
@@ -499,7 +520,7 @@ and edge cases. Each scenario listed below has at least one dedicated test.
 | Category | Tested Scenarios |
 |----------|-----------------|
 | **CRUD basics** | `async_create`, `async_save`, `async_delete`, `async_load`, `async_get` |
-| **Query methods** | `async_filter`, `async_all`, `async_count`, `async_keys` |
+| **Query methods** | `async_filter`, `async_all`, `async_count`, `async_keys`, `async_get_many` |
 | **SortedField queries** | `__lte`, `__lt`, `__gt`, `__gte`, range (between), `limit`, `order_by` |
 | **GeoField queries** | Radius search via `async_filter` with coordinates and distance units |
 | **Relationship fields** | Lazy-loading related objects through async queries |

--- a/docs/query.md
+++ b/docs/query.md
@@ -93,6 +93,43 @@ If no matching instance exists, `get()` returns `None`. If more than one instanc
     For models with composite keys, pass all key field values to `get()`. For models with
     `AutoKeyField`, use the auto-generated key value or `redis_key`.
 
+## Get Multiple Objects by Key
+
+When you already have a list of Redis keys (for example, from a set intersection, a cache of
+"recently viewed" items, or a secondary index), use `query.get_many()` to hydrate them all in
+a single round-trip. Internally this uses a Redis pipeline to batch `HGETALL` calls, turning
+N sequential lookups into one network exchange.
+
+```python
+keys = ["Restaurant:Burger Palace", "Restaurant:Sushi Zen", "Restaurant:Gone Place"]
+restaurants = Restaurant.query.get_many(redis_keys=keys)
+print(restaurants)
+# => [<Restaurant>, <Restaurant>, None]  -- third key did not exist
+```
+
+The returned list preserves the same order as the input keys. Missing keys appear as `None`
+so you can correlate each position with the original key list.
+
+If you do not need the `None` placeholders, pass `skip_none=True` to drop them.
+
+```python
+restaurants = Restaurant.query.get_many(redis_keys=keys, skip_none=True)
+print(restaurants)
+# => [<Restaurant>, <Restaurant>]  -- only existing objects
+```
+
+An empty input list returns an empty list immediately, without touching Redis.
+
+!!! tip
+    `get_many()` is ideal for the "fan-out then hydrate" pattern: use `query.keys()` or a
+    Redis set operation to collect keys, then hydrate them in bulk. This avoids the overhead
+    of loading and filtering all instances when you already know which keys you want.
+
+!!! note
+    `get_many()` differs from the internal `get_many_objects()` method. The public method
+    takes a list of string keys, preserves input order, and returns `None` for missing entries.
+    The internal method takes a set of bytes keys and silently drops missing entries.
+
 ## Get All Objects
 
 Use `query.all()` to retrieve every instance of a model. This fetches all Redis keys registered

--- a/src/popoto/models/query.py
+++ b/src/popoto/models/query.py
@@ -1554,6 +1554,68 @@ class Query:
         # or not hasattr(instance, 'db_key')
         return instance or None
 
+    def get_many(self, redis_keys: list, skip_none: bool = False) -> list:
+        """Retrieve multiple model instances by their Redis keys in a single pipeline.
+
+        Uses a Redis pipeline to batch HGETALL calls, reducing N sequential
+        round-trips to a single pipelined round-trip. Input order is preserved:
+        each position in the returned list corresponds to the same position in
+        ``redis_keys``.
+
+        Unlike the internal ``get_many_objects()`` static method (which takes a
+        set of bytes keys and silently drops missing entries), this public method
+        takes a list of string keys, preserves order, and returns ``None`` for
+        missing keys.
+
+        Args:
+            redis_keys: List of Redis key strings to look up (e.g.
+                ``["User:alice:acme", "User:bob:acme"]``).
+            skip_none: If True, filter out ``None`` entries from the result so
+                that only successfully hydrated instances are returned. When
+                False (default), the returned list has the same length as
+                ``redis_keys`` with ``None`` at positions where the key was
+                missing.
+
+        Returns:
+            List of Model instances (and/or ``None`` when *skip_none* is False).
+
+        Example:
+            # Bulk hydration after a set-based query
+            keys = ["Product:widget:001", "Product:widget:002", "Product:widget:003"]
+            products = Product.query.get_many(redis_keys=keys)
+            # [<Product>, None, <Product>]  -- second key was missing
+
+            # Skip missing entries
+            products = Product.query.get_many(redis_keys=keys, skip_none=True)
+            # [<Product>, <Product>]
+        """
+        if not redis_keys:
+            return []
+
+        from ..models.encoding import decode_popoto_model_hashmap
+
+        pipeline = POPOTO_REDIS_DB.pipeline()
+        for key in redis_keys:
+            pipeline.hgetall(key)
+        hashes_list = pipeline.execute()
+
+        results = []
+        live_instances = []
+        for hashmap in hashes_list:
+            if hashmap:
+                instance = decode_popoto_model_hashmap(self.model_class, hashmap)
+                results.append(instance)
+                live_instances.append(instance)
+            else:
+                results.append(None)
+
+        if live_instances:
+            _fire_on_read(self.model_class, live_instances)
+
+        if skip_none:
+            return [r for r in results if r is not None]
+        return results
+
     def keys(self, catchall=False, clean=False, **kwargs) -> list:
         """Return a list of Redis key bytes for all instances of this model.
 
@@ -2576,6 +2638,51 @@ class Query:
             instance = instances[0] if len(instances) == 1 else None
 
         return instance or None
+
+    async def async_get_many(self, redis_keys: list, skip_none: bool = False) -> list:
+        """Async version of get_many() using native async Redis.
+
+        Retrieves multiple model instances by their Redis keys in a single
+        async pipeline. See :meth:`Query.get_many` for full documentation.
+
+        Args:
+            redis_keys: List of Redis key strings to look up.
+            skip_none: If True, filter out ``None`` entries from the result.
+
+        Returns:
+            List of Model instances (and/or ``None`` when *skip_none* is False).
+
+        Example:
+            keys = ["Product:widget:001", "Product:widget:002"]
+            products = await Product.query.async_get_many(redis_keys=keys)
+        """
+        if not redis_keys:
+            return []
+
+        from ..models.encoding import decode_popoto_model_hashmap
+
+        async_redis = await get_async_redis_db()
+        pipeline = async_redis.pipeline()
+        for key in redis_keys:
+            pipeline.hgetall(key)
+        hashes_list = await pipeline.execute()
+
+        results = []
+        live_instances = []
+        for hashmap in hashes_list:
+            if hashmap:
+                instance = decode_popoto_model_hashmap(self.model_class, hashmap)
+                results.append(instance)
+                live_instances.append(instance)
+            else:
+                results.append(None)
+
+        if live_instances:
+            await to_thread(_fire_on_read, self.model_class, live_instances)
+
+        if skip_none:
+            return [r for r in results if r is not None]
+        return results
 
     async def async_filter(self, **kwargs) -> list:
         """Async version of filter() using native async Redis.

--- a/tests/test_get_many.py
+++ b/tests/test_get_many.py
@@ -1,0 +1,234 @@
+"""Tests for Query.get_many() and AsyncQuery.async_get_many() methods.
+
+Tests cover:
+- Basic bulk retrieval with order preservation
+- Missing keys return None at correct positions
+- Empty input returns empty list
+- skip_none=True filters out None entries
+- Mixed existing/missing keys
+- Single key (degenerate case)
+- Async parity with sync behavior
+- Large batch retrieval
+"""
+
+import sys
+import os
+import asyncio
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+import pytest
+from src import popoto
+from src.popoto.redis_db import POPOTO_REDIS_DB
+import src.popoto.redis_db as redis_db_module
+
+
+class Item(popoto.Model):
+    name = popoto.KeyField(null=False)
+    value = popoto.IntField(default=0)
+
+
+def setup_module():
+    """Clean up test data before running tests."""
+    Item.delete_all()
+
+
+def teardown_module():
+    """Clean up test data after running tests."""
+    Item.delete_all()
+
+
+def _clean():
+    Item.delete_all()
+
+
+# --- Sync get_many tests ---
+
+
+def test_get_many_basic_retrieval():
+    """get_many returns all instances in correct order."""
+    _clean()
+    a = Item.create(name="alpha", value=1)
+    b = Item.create(name="bravo", value=2)
+    c = Item.create(name="charlie", value=3)
+
+    keys = [a.db_key.redis_key, b.db_key.redis_key, c.db_key.redis_key]
+    results = Item.query.get_many(redis_keys=keys)
+
+    assert len(results) == 3
+    assert results[0].name == "alpha"
+    assert results[1].name == "bravo"
+    assert results[2].name == "charlie"
+    assert results[0].value == 1
+    assert results[1].value == 2
+    assert results[2].value == 3
+    _clean()
+
+
+def test_get_many_order_preservation():
+    """get_many preserves input order even when reversed."""
+    _clean()
+    a = Item.create(name="first", value=10)
+    b = Item.create(name="second", value=20)
+    c = Item.create(name="third", value=30)
+
+    # Request in reverse order
+    keys = [c.db_key.redis_key, a.db_key.redis_key, b.db_key.redis_key]
+    results = Item.query.get_many(redis_keys=keys)
+
+    assert len(results) == 3
+    assert results[0].name == "third"
+    assert results[1].name == "first"
+    assert results[2].name == "second"
+    _clean()
+
+
+def test_get_many_missing_keys():
+    """get_many returns None for keys that do not exist in Redis."""
+    _clean()
+    a = Item.create(name="exists", value=42)
+
+    keys = [a.db_key.redis_key, "Item:nonexistent", "Item:also_missing"]
+    results = Item.query.get_many(redis_keys=keys)
+
+    assert len(results) == 3
+    assert results[0].name == "exists"
+    assert results[1] is None
+    assert results[2] is None
+    _clean()
+
+
+def test_get_many_empty_input():
+    """get_many with empty list returns empty list without hitting Redis."""
+    results = Item.query.get_many(redis_keys=[])
+    assert results == []
+
+
+def test_get_many_skip_none():
+    """get_many with skip_none=True filters out None entries."""
+    _clean()
+    a = Item.create(name="real", value=99)
+
+    keys = ["Item:fake1", a.db_key.redis_key, "Item:fake2"]
+    results = Item.query.get_many(redis_keys=keys, skip_none=True)
+
+    assert len(results) == 1
+    assert results[0].name == "real"
+    _clean()
+
+
+def test_get_many_mixed_valid_missing():
+    """get_many correctly interleaves valid instances and None."""
+    _clean()
+    a = Item.create(name="one", value=1)
+    b = Item.create(name="two", value=2)
+
+    keys = [
+        a.db_key.redis_key,
+        "Item:missing_a",
+        b.db_key.redis_key,
+        "Item:missing_b",
+    ]
+    results = Item.query.get_many(redis_keys=keys)
+
+    assert len(results) == 4
+    assert results[0].name == "one"
+    assert results[1] is None
+    assert results[2].name == "two"
+    assert results[3] is None
+    _clean()
+
+
+def test_get_many_single_key():
+    """get_many works with a single key (degenerate case)."""
+    _clean()
+    a = Item.create(name="solo", value=7)
+
+    results = Item.query.get_many(redis_keys=[a.db_key.redis_key])
+
+    assert len(results) == 1
+    assert results[0].name == "solo"
+    assert results[0].value == 7
+    _clean()
+
+
+def test_get_many_large_batch():
+    """get_many handles a large batch of keys efficiently."""
+    _clean()
+    count = 50
+    items = []
+    for i in range(count):
+        items.append(Item.create(name=f"batch_{i:03d}", value=i))
+
+    keys = [item.db_key.redis_key for item in items]
+    results = Item.query.get_many(redis_keys=keys)
+
+    assert len(results) == count
+    for i, result in enumerate(results):
+        assert result is not None
+        assert result.name == f"batch_{i:03d}"
+        assert result.value == i
+    _clean()
+
+
+# --- Async get_many tests ---
+
+
+@pytest.fixture(autouse=False)
+def reset_async_redis():
+    """Reset async Redis connection for async tests."""
+    redis_db_module._POPOTO_ASYNC_REDIS_DB = None
+    redis_db_module._async_redis_lock = asyncio.Lock()
+
+
+@pytest.mark.asyncio
+async def test_async_get_many_basic(reset_async_redis):
+    """async_get_many returns all instances in correct order."""
+    _clean()
+    a = Item.create(name="async_a", value=10)
+    b = Item.create(name="async_b", value=20)
+
+    keys = [a.db_key.redis_key, b.db_key.redis_key]
+    results = await Item.query.async_get_many(redis_keys=keys)
+
+    assert len(results) == 2
+    assert results[0].name == "async_a"
+    assert results[1].name == "async_b"
+    _clean()
+
+
+@pytest.mark.asyncio
+async def test_async_get_many_missing_keys(reset_async_redis):
+    """async_get_many returns None for missing keys."""
+    _clean()
+    a = Item.create(name="async_exists", value=5)
+
+    keys = [a.db_key.redis_key, "Item:async_missing"]
+    results = await Item.query.async_get_many(redis_keys=keys)
+
+    assert len(results) == 2
+    assert results[0].name == "async_exists"
+    assert results[1] is None
+    _clean()
+
+
+@pytest.mark.asyncio
+async def test_async_get_many_empty(reset_async_redis):
+    """async_get_many with empty list returns empty list."""
+    results = await Item.query.async_get_many(redis_keys=[])
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_async_get_many_skip_none(reset_async_redis):
+    """async_get_many with skip_none=True filters out None."""
+    _clean()
+    a = Item.create(name="async_real", value=42)
+
+    keys = ["Item:async_fake", a.db_key.redis_key]
+    results = await Item.query.async_get_many(redis_keys=keys, skip_none=True)
+
+    assert len(results) == 1
+    assert results[0].name == "async_real"
+    _clean()


### PR DESCRIPTION
## Summary
- Adds `Query.get_many(redis_keys, skip_none=False)` for pipelined bulk retrieval of model instances by Redis key strings, preserving input order and returning `None` for missing keys
- Adds `AsyncQuery.async_get_many()` as the async counterpart using native async Redis pipeline
- 12 tests covering order preservation, missing keys, empty input, skip_none filtering, mixed valid/missing, single key, large batch, and async parity

Closes #318

## Test plan
- [x] `pytest tests/test_get_many.py -x -q` -- 12/12 pass
- [x] `ruff check` and `ruff format` clean
- [x] Full test suite (966 passed, 1 pre-existing failure unrelated to this PR)
- [ ] Reviewer validates bulk retrieval matches documented API contract