### PR TITLE
Add Model.check_indexes() read-only index health check

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -612,6 +612,103 @@ print(f"Permanently removed {deleted_count} restaurants")
 
 ---
 
+## Index Maintenance
+
+Popoto maintains secondary indexes (sorted sets, key field sets, geo indexes, composite
+indexes, and the class set) alongside your model data. Over time, indexes can accumulate
+orphaned entries -- references to instance keys that no longer exist in Redis. This
+typically happens after direct Redis deletions, TTL expirations, or interrupted operations.
+
+### Model.check_indexes()
+
+```python
+@classmethod
+Model.check_indexes(batch_size: int = 1000) -> dict
+```
+
+Read-only health check that counts orphaned index entries. Scans all five index types
+and checks whether each referenced instance key still exists in Redis.
+
+This method makes **zero writes** to Redis. It is safe to call in production at any time.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `batch_size` | `int` | 1000 | Number of EXISTS commands per pipeline batch. Lower values use less memory but require more round-trips. |
+
+**Returns:** Dict with orphan counts per index type:
+
+```python
+{
+    'class_set': int,
+    'key_fields': {field_name: int, ...},
+    'sorted_fields': {field_name: int, ...},
+    'geo_fields': {field_name: int, ...},
+    'composite_indexes': {index_key: int, ...},
+    'total': int,
+}
+```
+
+```python
+# Check for orphaned index entries
+result = User.check_indexes()
+if result['total'] > 0:
+    print(f"Found {result['total']} orphaned index entries")
+    # Optionally repair
+    User.rebuild_indexes()
+
+# Check with smaller batches for memory-constrained environments
+result = User.check_indexes(batch_size=100)
+```
+
+!!! tip
+    Use `check_indexes()` as a diagnostic step before deciding whether to run the
+    destructive `rebuild_indexes()`. This is especially useful in production where
+    you want to assess index health without modifying any data.
+
+### Model.rebuild_indexes()
+
+```python
+@classmethod
+Model.rebuild_indexes(batch_size: int = 1000) -> int
+```
+
+Delete all secondary indexes and reconstruct them from source hash data. This is useful
+for repairing corrupted indexes, after bulk data imports that bypassed normal `save()`
+hooks, or when upgrading field types that change index structure.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `batch_size` | `int` | 1000 | Number of instances to process per pipeline batch. |
+
+**Returns:** Number of instances processed.
+
+```python
+# Rebuild all indexes for User model
+count = User.rebuild_indexes()
+print(f"Rebuilt indexes for {count} users")
+```
+
+!!! warning
+    `rebuild_indexes()` is a destructive operation that deletes and recreates all
+    secondary indexes. During the rebuild window, queries relying on those indexes
+    may return incomplete results.
+
+### Async Index Maintenance
+
+| Sync | Async |
+|------|-------|
+| `Model.check_indexes()` | `await Model.async_check_indexes()` |
+| `Model.rebuild_indexes()` | `await Model.async_rebuild_indexes()` |
+
+```python
+# Async health check and conditional repair
+result = await User.async_check_indexes()
+if result['total'] > 0:
+    await User.async_rebuild_indexes()
+```
+
+---
+
 ### Meta Inner Class
 
 Configure model-level behavior by defining a `Meta` inner class. See [Meta Options](meta.md) for

--- a/docs/async.md
+++ b/docs/async.md
@@ -532,7 +532,7 @@ and edge cases. Each scenario listed below has at least one dedicated test.
 | **Client-side filtering** | Filtering on plain `Field` (non-indexed) via `async_filter` |
 | **Meta options** | `Meta.order_by` default sorting, `Meta.ttl` automatic expiration |
 | **Atomicity** | Pipeline-based `async_save`, concurrent writes (last-write-wins) |
-| **Index maintenance** | `async_rebuild_indexes` via `to_thread` |
+| **Index maintenance** | `async_check_indexes`, `async_rebuild_indexes` via `to_thread` |
 
 Run the async tests with:
 

--- a/docs/plans/check-indexes.md
+++ b/docs/plans/check-indexes.md
@@ -181,11 +181,12 @@ No agent integration required -- this is a library method in the popoto package.
 ## Documentation
 
 ### Inline Documentation
-- [ ] Comprehensive docstring on `check_indexes()` with Args, Returns, Example sections (matching `rebuild_indexes()` docstring style at line 2707)
-- [ ] Comprehensive docstring on `async_check_indexes()` matching async conventions in the file
+- [x] Comprehensive docstring on `check_indexes()` with Args, Returns, Example sections (matching `rebuild_indexes()` docstring style at line 2707)
+- [x] Comprehensive docstring on `async_check_indexes()` matching async conventions in the file
 
 ### External Documentation Site
-- [ ] No external docs site changes needed -- popoto does not currently have a docs site
+- [x] Added Index Maintenance section to `docs/api-reference.md` with full docs for `check_indexes()` and `rebuild_indexes()`
+- [x] Updated `docs/async.md` index maintenance row to include `async_check_indexes`
 
 ## Success Criteria
 

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -2844,6 +2844,178 @@ class Model(metaclass=ModelBase):
         return count
 
     @classmethod
+    def check_indexes(cls, batch_size: int = 1000) -> dict:
+        """Read-only health check that counts orphaned index entries.
+
+        Scans all five index types (class set, key fields, sorted fields,
+        geo fields, composite indexes) and checks whether each referenced
+        instance key still exists in Redis. Returns a structured dict with
+        orphan counts per index type.
+
+        This method makes zero writes to Redis. It is safe to call in
+        production at any time. Note that counts are point-in-time snapshots;
+        concurrent writes may cause minor discrepancies.
+
+        Args:
+            batch_size: Number of EXISTS commands per pipeline batch.
+                Default is 1000. Lower values use less memory but require
+                more round-trips.
+
+        Returns:
+            Dict with orphan counts per index type::
+
+                {
+                    'class_set': int,
+                    'key_fields': {field_name: int, ...},
+                    'sorted_fields': {field_name: int, ...},
+                    'geo_fields': {field_name: int, ...},
+                    'composite_indexes': {index_key: int, ...},
+                    'total': int,
+                }
+
+        Example:
+            result = User.check_indexes()
+            if result['total'] > 0:
+                print(f"Found {result['total']} orphaned index entries")
+                User.rebuild_indexes()
+        """
+
+        def _count_orphans(keys_to_check: list) -> int:
+            """Pipeline EXISTS in batches, return count of non-existent keys."""
+            orphan_count = 0
+            for i in range(0, len(keys_to_check), batch_size):
+                batch = keys_to_check[i : i + batch_size]
+                pipe = POPOTO_REDIS_DB.pipeline()
+                for key in batch:
+                    pipe.exists(key)
+                results = pipe.execute()
+                orphan_count += sum(1 for exists in results if not exists)
+            return orphan_count
+
+        def _scan_set_members(set_key: str) -> list:
+            """SSCAN all members of a Redis set."""
+            members = []
+            cursor = 0
+            while True:
+                cursor, batch = POPOTO_REDIS_DB.sscan(set_key, cursor, count=1000)
+                members.extend(batch)
+                if cursor == 0:
+                    break
+            return members
+
+        def _scan_sorted_set_members(zset_key: str) -> list:
+            """ZSCAN all members of a Redis sorted set."""
+            members = []
+            cursor = 0
+            while True:
+                cursor, batch = POPOTO_REDIS_DB.zscan(zset_key, cursor, count=1000)
+                members.extend(member for member, _score in batch)
+                if cursor == 0:
+                    break
+            return members
+
+        def _scan_hash_values(hash_key: str) -> list:
+            """HSCAN all values of a Redis hash."""
+            values = []
+            cursor = 0
+            while True:
+                cursor, batch = POPOTO_REDIS_DB.hscan(hash_key, cursor, count=1000)
+                values.extend(batch.values())
+                if cursor == 0:
+                    break
+            return values
+
+        result = {
+            "class_set": 0,
+            "key_fields": {},
+            "sorted_fields": {},
+            "geo_fields": {},
+            "composite_indexes": {},
+            "total": 0,
+        }
+
+        # 1. Check class set
+        class_set_key = cls._meta.db_class_set_key.redis_key
+        members = _scan_set_members(class_set_key)
+        if members:
+            result["class_set"] = _count_orphans(members)
+
+        # 2. Check key field sets
+        for field_name in cls._meta.key_field_names:
+            field = cls._meta.fields[field_name]
+            # Skip auto fields - they don't maintain index sets
+            if getattr(field, "auto", False):
+                continue
+            base_key = field.get_special_use_field_db_key(cls, field_name)
+            pattern = base_key.redis_key + ":*"
+            field_orphans = 0
+            for key in POPOTO_REDIS_DB.scan_iter(match=pattern, count=1000):
+                if isinstance(key, bytes):
+                    key = key.decode("utf-8")
+                members = _scan_set_members(key)
+                if members:
+                    field_orphans += _count_orphans(members)
+            result["key_fields"][field_name] = field_orphans
+
+        # 3. Check sorted field sets
+        for field_name in cls._meta.sorted_field_names:
+            field = cls._meta.fields[field_name]
+            base_key = field.get_special_use_field_db_key(cls, field_name)
+            pattern = base_key.redis_key + "*"
+            field_orphans = 0
+            for key in POPOTO_REDIS_DB.scan_iter(match=pattern, count=1000):
+                if isinstance(key, bytes):
+                    key = key.decode("utf-8")
+                members = _scan_sorted_set_members(key)
+                if members:
+                    field_orphans += _count_orphans(members)
+            result["sorted_fields"][field_name] = field_orphans
+
+        # 4. Check geo fields
+        for field_name in cls._meta.geo_field_names:
+            geo_key = GeoField.get_geo_db_key(cls, field_name)
+            members = _scan_sorted_set_members(geo_key.redis_key)
+            field_orphans = 0
+            if members:
+                field_orphans = _count_orphans(members)
+            result["geo_fields"][field_name] = field_orphans
+
+        # 5. Check composite indexes
+        for field_names, is_unique in cls._meta.indexes:
+            index_key = cls._meta.get_index_key(tuple(field_names))
+            values = _scan_hash_values(index_key)
+            index_orphans = 0
+            if values:
+                index_orphans = _count_orphans(values)
+            result["composite_indexes"][index_key] = index_orphans
+
+        # Compute total
+        result["total"] = (
+            result["class_set"]
+            + sum(result["key_fields"].values())
+            + sum(result["sorted_fields"].values())
+            + sum(result["geo_fields"].values())
+            + sum(result["composite_indexes"].values())
+        )
+
+        return result
+
+    @classmethod
+    async def async_check_indexes(cls, batch_size: int = 1000) -> dict:
+        """Async version of check_indexes().
+
+        Runs the synchronous check_indexes() method in a thread pool
+        to avoid blocking the event loop.
+
+        Args:
+            batch_size: Number of EXISTS commands per pipeline batch.
+
+        Returns:
+            Dict with orphan counts per index type (same as check_indexes).
+        """
+        return await to_thread(cls.check_indexes, batch_size=batch_size)
+
+    @classmethod
     async def async_rebuild_indexes(cls, batch_size: int = 1000) -> int:
         """Async version of rebuild_indexes().
 

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -3012,6 +3012,11 @@ class Model(metaclass=ModelBase):
 
         Returns:
             Dict with orphan counts per index type (same as check_indexes).
+
+        Example:
+            result = await User.async_check_indexes()
+            if result['total'] > 0:
+                await User.async_rebuild_indexes()
         """
         return await to_thread(cls.check_indexes, batch_size=batch_size)
 

--- a/tests/test_check_indexes.py
+++ b/tests/test_check_indexes.py
@@ -1,0 +1,359 @@
+"""Tests for Model.check_indexes() read-only health check.
+
+Verifies orphan detection across all five index types (class set, key fields,
+sorted fields, geo fields, composite indexes), read-only guarantee, and async
+counterpart.
+
+Related: Issue #322
+"""
+
+import asyncio
+
+import popoto
+from popoto.redis_db import POPOTO_REDIS_DB
+from popoto.fields.geo_field import GeoField
+
+
+# ---------------------------------------------------------------------------
+# Test model definitions
+# ---------------------------------------------------------------------------
+
+
+class CheckUser(popoto.Model):
+    """Simple model with a key field and sorted field."""
+
+    email = popoto.KeyField()
+    score = popoto.SortedField(type=float)
+    name = popoto.Field(type=str, null=True)
+
+
+class CheckGeoPlace(popoto.Model):
+    """Model with a geo field."""
+
+    name = popoto.KeyField()
+    location = GeoField()
+
+
+class CheckComposite(popoto.Model):
+    """Model with a composite index."""
+
+    item_id = popoto.KeyField()
+    category = popoto.Field(type=str)
+    brand = popoto.Field(type=str)
+
+    class Meta:
+        indexes = ((("category", "brand"), False),)
+
+
+class CheckMinimal(popoto.Model):
+    """Model with no sorted, geo, or composite indexes."""
+
+    uuid = popoto.AutoKeyField()
+    data = popoto.Field(type=str, null=True)
+
+
+class CheckPartitioned(popoto.Model):
+    """Model with a partitioned sorted field."""
+
+    uuid = popoto.AutoKeyField()
+    category = popoto.KeyField()
+    price = popoto.SortedField(type=float, partition_by="category")
+
+
+# ---------------------------------------------------------------------------
+# Tests: No orphans (healthy state)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckIndexesHealthy:
+    """Tests that check_indexes returns zeros when there are no orphans."""
+
+    def test_no_instances_returns_zeros(self):
+        """Model with no instances returns all-zero counts."""
+        result = CheckUser.check_indexes()
+        assert result["class_set"] == 0
+        assert result["key_fields"]["email"] == 0
+        assert result["sorted_fields"]["score"] == 0
+        assert result["total"] == 0
+
+    def test_healthy_instances_return_zeros(self):
+        """Model with valid instances returns zero orphans."""
+        CheckUser.create(email="alice@test.com", score=10.0, name="Alice")
+        CheckUser.create(email="bob@test.com", score=20.0, name="Bob")
+
+        result = CheckUser.check_indexes()
+        assert result["class_set"] == 0
+        assert result["key_fields"]["email"] == 0
+        assert result["sorted_fields"]["score"] == 0
+        assert result["total"] == 0
+
+    def test_healthy_geo_returns_zero(self):
+        """Geo field with valid instances returns zero orphans."""
+        CheckGeoPlace.create(name="office", location=(40.7128, -74.0060))
+
+        result = CheckGeoPlace.check_indexes()
+        assert result["class_set"] == 0
+        assert result["geo_fields"]["location"] == 0
+        assert result["total"] == 0
+
+    def test_healthy_composite_returns_zero(self):
+        """Composite index with valid instances returns zero orphans."""
+        CheckComposite.create(item_id="item1", category="electronics", brand="acme")
+
+        result = CheckComposite.check_indexes()
+        assert result["class_set"] == 0
+        assert result["composite_indexes"] is not None
+        assert result["total"] == 0
+
+    def test_minimal_model_returns_zeros(self):
+        """Model with no sorted/geo/composite indexes returns empty sub-dicts."""
+        CheckMinimal.create(data="test")
+
+        result = CheckMinimal.check_indexes()
+        assert result["class_set"] == 0
+        assert result["sorted_fields"] == {}
+        assert result["geo_fields"] == {}
+        assert result["composite_indexes"] == {}
+        assert result["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: Orphan detection
+# ---------------------------------------------------------------------------
+
+
+class TestCheckIndexesOrphanDetection:
+    """Tests that orphaned index entries are correctly detected."""
+
+    def test_class_set_orphan(self):
+        """Detects orphan in class set when instance hash is deleted."""
+        user = CheckUser.create(email="orphan@test.com", score=5.0)
+        redis_key = user.db_key.redis_key
+
+        # Delete the instance hash directly, leaving stale index entries
+        POPOTO_REDIS_DB.delete(redis_key)
+
+        result = CheckUser.check_indexes()
+        assert result["class_set"] >= 1
+        assert result["total"] >= 1
+
+    def test_key_field_orphan(self):
+        """Detects orphan in key field index when instance hash is deleted."""
+        user = CheckUser.create(email="keyorphan@test.com", score=5.0)
+        redis_key = user.db_key.redis_key
+
+        POPOTO_REDIS_DB.delete(redis_key)
+
+        result = CheckUser.check_indexes()
+        assert result["key_fields"]["email"] >= 1
+
+    def test_sorted_field_orphan(self):
+        """Detects orphan in sorted field index when instance hash is deleted."""
+        user = CheckUser.create(email="sortorphan@test.com", score=15.0)
+        redis_key = user.db_key.redis_key
+
+        POPOTO_REDIS_DB.delete(redis_key)
+
+        result = CheckUser.check_indexes()
+        assert result["sorted_fields"]["score"] >= 1
+
+    def test_geo_field_orphan(self):
+        """Detects orphan in geo field index when instance hash is deleted."""
+        place = CheckGeoPlace.create(name="ghost", location=(51.5074, -0.1278))
+        redis_key = place.db_key.redis_key
+
+        POPOTO_REDIS_DB.delete(redis_key)
+
+        result = CheckGeoPlace.check_indexes()
+        assert result["geo_fields"]["location"] >= 1
+        assert result["total"] >= 1
+
+    def test_composite_index_orphan(self):
+        """Detects orphan in composite index when instance hash is deleted."""
+        item = CheckComposite.create(
+            item_id="ghost_item", category="tools", brand="wrench_co"
+        )
+        redis_key = item.db_key.redis_key
+
+        POPOTO_REDIS_DB.delete(redis_key)
+
+        result = CheckComposite.check_indexes()
+        # Composite index should detect the orphan
+        assert result["total"] >= 1
+        total_composite = sum(result["composite_indexes"].values())
+        assert total_composite >= 1
+
+    def test_partitioned_sorted_field_orphan(self):
+        """Detects orphan in partitioned sorted field index."""
+        item = CheckPartitioned.create(category="electronics", price=99.99)
+        redis_key = item.db_key.redis_key
+
+        POPOTO_REDIS_DB.delete(redis_key)
+
+        result = CheckPartitioned.check_indexes()
+        assert result["sorted_fields"]["price"] >= 1
+
+    def test_multiple_orphans_counted(self):
+        """Multiple orphaned entries are counted correctly."""
+        users = []
+        for i in range(5):
+            u = CheckUser.create(email=f"multi{i}@test.com", score=float(i))
+            users.append(u)
+
+        # Delete 3 of 5 instance hashes
+        for u in users[:3]:
+            POPOTO_REDIS_DB.delete(u.db_key.redis_key)
+
+        result = CheckUser.check_indexes()
+        assert result["class_set"] == 3
+        assert result["key_fields"]["email"] == 3
+        assert result["sorted_fields"]["score"] == 3
+
+    def test_total_is_sum_of_all_types(self):
+        """Total field equals the sum of all orphan counts across types."""
+        user = CheckUser.create(email="totalcheck@test.com", score=42.0)
+        POPOTO_REDIS_DB.delete(user.db_key.redis_key)
+
+        result = CheckUser.check_indexes()
+        expected_total = (
+            result["class_set"]
+            + sum(result["key_fields"].values())
+            + sum(result["sorted_fields"].values())
+            + sum(result["geo_fields"].values())
+            + sum(result["composite_indexes"].values())
+        )
+        assert result["total"] == expected_total
+
+
+# ---------------------------------------------------------------------------
+# Tests: Read-only guarantee
+# ---------------------------------------------------------------------------
+
+
+class TestCheckIndexesReadOnly:
+    """Verify check_indexes makes zero writes to Redis."""
+
+    def test_read_only_no_orphans(self):
+        """check_indexes does not modify Redis state with healthy data."""
+        CheckUser.create(email="readonly1@test.com", score=1.0)
+        CheckUser.create(email="readonly2@test.com", score=2.0)
+
+        # Snapshot all keys and their values
+        all_keys = set(POPOTO_REDIS_DB.keys("*"))
+        snapshot = {}
+        for key in all_keys:
+            key_type = POPOTO_REDIS_DB.type(key)
+            if isinstance(key_type, bytes):
+                key_type = key_type.decode("utf-8")
+            if key_type == "string":
+                snapshot[key] = POPOTO_REDIS_DB.get(key)
+            elif key_type == "hash":
+                snapshot[key] = POPOTO_REDIS_DB.hgetall(key)
+            elif key_type == "set":
+                snapshot[key] = POPOTO_REDIS_DB.smembers(key)
+            elif key_type == "zset":
+                snapshot[key] = POPOTO_REDIS_DB.zrange(key, 0, -1, withscores=True)
+
+        # Run check
+        CheckUser.check_indexes()
+
+        # Verify no keys were added or removed
+        all_keys_after = set(POPOTO_REDIS_DB.keys("*"))
+        assert all_keys == all_keys_after
+
+        # Verify no values changed
+        for key in all_keys:
+            key_type = POPOTO_REDIS_DB.type(key)
+            if isinstance(key_type, bytes):
+                key_type = key_type.decode("utf-8")
+            if key_type == "string":
+                assert snapshot[key] == POPOTO_REDIS_DB.get(key)
+            elif key_type == "hash":
+                assert snapshot[key] == POPOTO_REDIS_DB.hgetall(key)
+            elif key_type == "set":
+                assert snapshot[key] == POPOTO_REDIS_DB.smembers(key)
+            elif key_type == "zset":
+                assert snapshot[key] == POPOTO_REDIS_DB.zrange(
+                    key, 0, -1, withscores=True
+                )
+
+    def test_read_only_with_orphans(self):
+        """check_indexes does not modify Redis state even when orphans exist."""
+        user = CheckUser.create(email="readonly_orphan@test.com", score=5.0)
+        POPOTO_REDIS_DB.delete(user.db_key.redis_key)
+
+        # Snapshot
+        all_keys = set(POPOTO_REDIS_DB.keys("*"))
+
+        # Run check
+        result = CheckUser.check_indexes()
+        assert result["total"] > 0
+
+        # Verify no keys were added or removed
+        all_keys_after = set(POPOTO_REDIS_DB.keys("*"))
+        assert all_keys == all_keys_after
+
+
+# ---------------------------------------------------------------------------
+# Tests: Return structure
+# ---------------------------------------------------------------------------
+
+
+class TestCheckIndexesReturnStructure:
+    """Verify the return dict structure."""
+
+    def test_return_keys_present(self):
+        """Return dict contains all expected keys."""
+        result = CheckUser.check_indexes()
+        assert "class_set" in result
+        assert "key_fields" in result
+        assert "sorted_fields" in result
+        assert "geo_fields" in result
+        assert "composite_indexes" in result
+        assert "total" in result
+
+    def test_return_types(self):
+        """Return dict values have correct types."""
+        result = CheckUser.check_indexes()
+        assert isinstance(result["class_set"], int)
+        assert isinstance(result["key_fields"], dict)
+        assert isinstance(result["sorted_fields"], dict)
+        assert isinstance(result["geo_fields"], dict)
+        assert isinstance(result["composite_indexes"], dict)
+        assert isinstance(result["total"], int)
+
+    def test_batch_size_parameter(self):
+        """batch_size parameter is accepted and produces same results."""
+        CheckUser.create(email="batch@test.com", score=1.0)
+
+        result_default = CheckUser.check_indexes()
+        result_small = CheckUser.check_indexes(batch_size=1)
+        result_large = CheckUser.check_indexes(batch_size=10000)
+
+        assert result_default == result_small == result_large
+
+
+# ---------------------------------------------------------------------------
+# Tests: Async version
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncCheckIndexes:
+    """Verify async_check_indexes matches sync behavior."""
+
+    def test_async_returns_same_as_sync(self):
+        """async_check_indexes returns the same result as check_indexes."""
+        CheckUser.create(email="async@test.com", score=7.0)
+
+        sync_result = CheckUser.check_indexes()
+        async_result = asyncio.run(CheckUser.async_check_indexes())
+        assert sync_result == async_result
+
+    def test_async_detects_orphans(self):
+        """async_check_indexes correctly detects orphans."""
+        user = CheckUser.create(email="async_orphan@test.com", score=3.0)
+        POPOTO_REDIS_DB.delete(user.db_key.redis_key)
+
+        result = asyncio.run(CheckUser.async_check_indexes())
+        assert result["total"] >= 1
+        assert result["class_set"] >= 1


### PR DESCRIPTION
## Summary

- Adds `Model.check_indexes(batch_size=1000)` classmethod that scans all five index types (class set, key fields, sorted fields, geo fields, composite indexes) and returns a structured dict with orphan counts per type
- Uses SSCAN/ZSCAN/HSCAN for member discovery and pipelined EXISTS for batch existence checks -- zero writes to Redis
- Adds `Model.async_check_indexes()` async counterpart via `asyncio.to_thread()`
- 20 tests covering healthy state, orphan detection for all index types, read-only guarantee, return structure, and async behavior

Closes #322

## Test plan

- [x] `pytest tests/test_check_indexes.py -x -q` -- 20 passed
- [x] Full suite `pytest tests/ -x -q` -- 1256 passed, 10 skipped
- [x] Lint clean (`ruff check` -- only pre-existing warnings)
- [x] Format clean (`ruff format --check`)
- [x] `python -c "from popoto import Model; assert hasattr(Model, 'check_indexes')"` -- passes
- [x] `python -c "from popoto import Model; assert hasattr(Model, 'async_check_indexes')"` -- passes