### PR TITLE
Plan: Update popoto_kitchen example app with v1.4.4 features (#339)

### DIFF
--- a/docs/plans/async_docs_examples.md
+++ b/docs/plans/async_docs_examples.md
@@ -1,0 +1,260 @@
+---
+status: Ready
+type: chore
+appetite: Small
+owner: Valor
+created: 2026-04-03
+tracking: https://github.com/tomcounsell/popoto/issues/340
+last_comment_id:
+---
+
+# Add Async Examples to Docs for get_many, check_indexes, clean_indexes
+
+## Problem
+
+The async variants `async_get_many()`, `async_check_indexes()`, and `async_clean_indexes()` are implemented and tested but the documentation pages only show synchronous examples or minimal one-liner references.
+
+**Current behavior:**
+- `docs/query.md` has a full "Get Multiple Objects by Key" section (lines 96-131) with sync examples but no async subsection
+- `docs/api-reference.md` line 868 mentions `async_get_many` in a single sentence but provides no code example
+- `docs/api-reference.md` Async Query Methods table (lines 1095-1103) omits `async_get_many`
+- `docs/api-reference.md` lines 743-759 have a brief async index maintenance table and minimal snippet for `async_check_indexes` / `async_clean_indexes`, but no detailed standalone examples with context
+
+**Desired outcome:**
+- Each async method has a clear code example in the same doc page as its sync counterpart
+- The Async Query Methods table includes `async_get_many`
+- Developers can copy-paste working async examples from the docs
+
+## Prior Art
+
+No prior issues found related to async documentation gaps. The async methods were added across PRs #318 (get_many), #332 (check_indexes), and #334 (clean_indexes). Each PR added the implementation and tests but deferred documentation updates.
+
+## Appetite
+
+**Size:** Small
+
+**Team:** Solo dev
+
+**Interactions:**
+- PM check-ins: 0
+- Review rounds: 1
+
+## Prerequisites
+
+No prerequisites -- this work has no external dependencies.
+
+## Solution
+
+### Key Elements
+
+- **query.md async subsection**: Add an async code block after the sync `get_many()` section
+- **api-reference.md async_get_many row**: Add `async_get_many` to the Async Query Methods table
+- **api-reference.md index maintenance examples**: Expand the existing async index maintenance snippet with fuller examples matching the pattern used in `docs/async.md`
+
+### Technical Approach
+
+Follow the documentation pattern established in `docs/async.md`:
+1. Use the food-delivery domain models (Restaurant, Customer, Driver, Order) already defined in async.md
+2. Show `await` usage inside `async def` functions
+3. Include practical context (when to use, what it returns)
+4. Use `!!! tip` or `!!! note` admonitions for guidance
+
+### Files to Modify
+
+#### 1. `docs/query.md` -- Add async subsection after "Get Multiple Objects by Key"
+
+After the existing sync examples (around line 131), add an async subsection:
+
+```markdown
+### Async Usage
+
+The async counterpart uses a native async Redis pipeline for non-blocking bulk retrieval.
+
+\```python
+async def bulk_lookup():
+    keys = ["Restaurant:Burger Palace", "Restaurant:Sushi Zen", "Restaurant:Gone Place"]
+    restaurants = await Restaurant.query.async_get_many(redis_keys=keys)
+    # => [<Restaurant>, <Restaurant>, None]
+
+    # Drop missing entries
+    restaurants = await Restaurant.query.async_get_many(redis_keys=keys, skip_none=True)
+    # => [<Restaurant>, <Restaurant>]
+\```
+
+See [Async Operations](async.md#async_get_many) for more examples.
+```
+
+#### 2. `docs/api-reference.md` -- Add `async_get_many` to Async Query Methods table
+
+Add a row to the table at line 1103:
+
+```markdown
+| `Model.query.get_many(...)` | `await Model.query.async_get_many(...)` |
+```
+
+#### 3. `docs/api-reference.md` -- Expand async index maintenance examples
+
+Replace the minimal snippet at lines 751-759 with fuller examples that show each method individually with context, matching the style used in `docs/async.md`:
+
+```markdown
+### Async Index Maintenance
+
+| Sync | Async |
+|------|-------|
+| `Model.check_indexes()` | `await Model.async_check_indexes()` |
+| `Model.clean_indexes()` | `await Model.async_clean_indexes()` |
+| `Model.rebuild_indexes()` | `await Model.async_rebuild_indexes()` |
+
+\```python
+async def health_check():
+    """Non-blocking index health audit."""
+    result = await User.async_check_indexes()
+    print(f"Orphaned entries: {result['total']}")
+    # => {'class_set': 0, 'key_fields': {}, 'sorted_fields': {}, ...}
+
+async def scheduled_cleanup():
+    """Production-safe orphan removal in an async worker."""
+    result = await User.async_check_indexes()
+    if result['total'] > 0:
+        removed = await User.async_clean_indexes()
+        print(f"Cleaned {removed} orphans")
+
+        # Verify cleanup
+        after = await User.async_check_indexes()
+        assert after['total'] == 0
+\```
+```
+
+## Failure Path Test Strategy
+
+### Exception Handling Coverage
+- No exception handlers in scope -- this is purely a documentation change
+
+### Empty/Invalid Input Handling
+- Not applicable -- documentation only
+
+### Error State Rendering
+- Not applicable -- documentation only
+
+## Test Impact
+
+No existing tests affected -- this is a documentation-only change with no code modifications.
+
+## Rabbit Holes
+
+- Rewriting the entire async.md page for consistency -- out of scope, async.md already has good examples for these methods
+- Adding async tabs/toggles with mkdocs-material content tabs -- would be nice but is a separate infrastructure decision
+- Documenting async_rebuild_indexes in detail -- already covered adequately in the existing table
+
+## Risks
+
+### Risk 1: Stale examples
+**Impact:** Code examples that don't match actual API behavior
+**Mitigation:** Examples mirror the patterns already validated in `docs/async.md` and `tests/test_async.py`
+
+## Race Conditions
+
+No race conditions identified -- documentation-only change.
+
+## No-Gos (Out of Scope)
+
+- Refactoring existing async.md content
+- Adding mkdocs content tabs for sync/async toggle
+- Writing new tests
+- Modifying any Python source code
+
+## Update System
+
+No update system changes required -- this is a documentation-only change.
+
+## Agent Integration
+
+No agent integration required -- documentation only.
+
+## Documentation
+
+### External Documentation Site
+- [x] The changes ARE the documentation updates
+- [ ] Verify docs build passes with `mkdocs serve`
+
+## Success Criteria
+
+- [ ] `docs/query.md` has async subsection with `async_get_many()` example under "Get Multiple Objects by Key"
+- [ ] `docs/api-reference.md` Async Query Methods table includes `async_get_many` row
+- [ ] `docs/api-reference.md` async index maintenance section has expanded examples for `async_check_indexes()` and `async_clean_indexes()`
+- [ ] All examples follow the food-delivery domain pattern from `docs/async.md`
+- [ ] `mkdocs serve` builds without errors
+- [ ] Documentation updated (`/do-docs`)
+
+## Team Orchestration
+
+### Team Members
+
+- **Builder (docs)**
+  - Name: docs-builder
+  - Role: Add async examples to query.md and api-reference.md
+  - Agent Type: documentarian
+  - Resume: true
+
+- **Validator (docs)**
+  - Name: docs-validator
+  - Role: Verify examples match API and docs build
+  - Agent Type: validator
+  - Resume: true
+
+## Step by Step Tasks
+
+### 1. Add async subsection to query.md
+- **Task ID**: build-query-docs
+- **Depends On**: none
+- **Assigned To**: docs-builder
+- **Agent Type**: documentarian
+- **Parallel**: true
+- Add async subsection after "Get Multiple Objects by Key" section (after line 131)
+- Use Restaurant model examples consistent with existing sync examples on the page
+
+### 2. Update api-reference.md async query table
+- **Task ID**: build-api-ref-table
+- **Depends On**: none
+- **Assigned To**: docs-builder
+- **Agent Type**: documentarian
+- **Parallel**: true
+- Add `async_get_many` row to the Async Query Methods table (after line 1103)
+
+### 3. Expand api-reference.md async index maintenance examples
+- **Task ID**: build-api-ref-indexes
+- **Depends On**: none
+- **Assigned To**: docs-builder
+- **Agent Type**: documentarian
+- **Parallel**: true
+- Replace minimal snippet at lines 751-759 with fuller examples
+- Show async_check_indexes and async_clean_indexes with practical context
+
+### 4. Validate docs build
+- **Task ID**: validate-docs
+- **Depends On**: build-query-docs, build-api-ref-table, build-api-ref-indexes
+- **Assigned To**: docs-validator
+- **Agent Type**: validator
+- **Parallel**: false
+- Run `mkdocs serve` and verify no build errors
+- Verify all three async sections render correctly
+
+## Verification
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| Docs build | `cd /Users/valorengels/src/popoto && mkdocs build --strict 2>&1` | exit code 0 |
+| async_get_many in query.md | `grep -c 'async_get_many' docs/query.md` | output > 0 |
+| async_get_many in api-reference table | `grep 'async_get_many' docs/api-reference.md` | exit code 0 |
+| async_check_indexes example | `grep -c 'async_check_indexes' docs/api-reference.md` | output > 0 |
+| async_clean_indexes example | `grep -c 'async_clean_indexes' docs/api-reference.md` | output > 0 |
+
+## Critique Results
+
+<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+
+---
+
+## Open Questions
+
+None -- the scope is narrow and all patterns are already established in `docs/async.md`.

--- a/docs/plans/integration-tests-v144.md
+++ b/docs/plans/integration-tests-v144.md
@@ -1,0 +1,254 @@
+---
+status: Ready
+type: chore
+appetite: Small
+owner: Valor
+created: 2026-04-03
+tracking: https://github.com/tomcounsell/popoto/issues/337
+last_comment_id:
+---
+
+# Cross-Feature Integration Tests for v1.4.4 APIs
+
+## Problem
+
+The 8 PRs merged on 2026-03-31 (get_many, positional get, check_indexes, clean_indexes, partition_by, companion hash keys) each have thorough isolated tests (97 new tests total), but no tests exercise these features together.
+
+**Current behavior:**
+Each feature is tested in isolation. `test_get_many.py` tests bulk fetch, `test_check_indexes.py` tests orphan detection, `test_clean_indexes.py` tests orphan removal, `test_partitioned_confidence.py` tests partition_by. No test creates a realistic workflow that combines them.
+
+**Desired outcome:**
+A new `tests/test_integration_v144.py` file with three scenarios that exercise feature combinations reflecting real-world usage patterns, plus an async variant for at least one scenario.
+
+## Prior Art
+
+- **PR #332**: Add `Model.check_indexes()` -- established orphan detection across five index types
+- **PR #334**: Add `Model.clean_indexes()` -- established orphan removal with check_indexes round-trip verification
+- **PR #328**: Add partition_by to ConfidenceField -- introduced partitioned companion hash keys
+- **PR #336**: Expose public API for companion hash key methods -- made hash key construction public
+- **PR #330**: Add `get_many()` bulk retrieval -- established mget-based bulk fetch with order preservation
+
+The isolated test files that already cover individual features:
+- `tests/test_get_many.py` -- 11 tests for sync/async get_many
+- `tests/test_check_indexes.py` -- 15 tests for orphan detection and read-only guarantee
+- `tests/test_clean_indexes.py` -- 17 tests for orphan removal and round-trip verification
+- `tests/test_partitioned_confidence.py` -- 22 tests for partition_by lifecycle
+- `tests/test_meta_ttl.py` -- 7 tests for TTL expiry behavior
+
+## Appetite
+
+**Size:** Small
+
+**Team:** Solo dev
+
+**Interactions:**
+- PM check-ins: 0
+- Review rounds: 1
+
+## Prerequisites
+
+No prerequisites -- all features are already merged and their isolated tests pass. Requires Redis on localhost:6379 (standard test environment).
+
+## Solution
+
+### Key Elements
+
+- **Scenario 1: get_many + check_indexes + clean_indexes round-trip** -- Tests the full diagnostic-and-repair workflow on bulk-fetched data
+- **Scenario 2: partition_by + clean_indexes** -- Tests that index health tools work correctly with partitioned companion hashes
+- **Scenario 3: TTL expiry + check_indexes** -- Tests that expired keys are correctly detected as orphans by the index health checker
+
+### Technical Approach
+
+All three scenarios follow a common pattern: create model instances via the ORM, introduce index corruption (by directly deleting Redis keys to bypass ORM cleanup), then verify the health-check and cleanup APIs detect and resolve the issue.
+
+#### Scenario 1: get_many + check_indexes + clean_indexes
+
+1. Create 5+ instances of a model with KeyField and SortedField
+2. Bulk-fetch all with `get_many()` -- verify all returned correctly
+3. Delete 2 instance hashes directly via `POPOTO_REDIS_DB.delete()` (bypassing ORM)
+4. Call `get_many()` again -- verify deleted instances return as `None` at correct positions
+5. Call `check_indexes()` -- verify it reports orphans (class_set >= 2, sorted_fields >= 2)
+6. Call `clean_indexes()` -- verify it returns count > 0
+7. Call `check_indexes()` again -- verify total == 0
+8. Call `get_many()` with `skip_none=True` -- verify only surviving instances returned
+9. Verify surviving instances have correct field values
+
+Model definition:
+```python
+class IntegrationItem(popoto.Model):
+    name = popoto.KeyField()
+    score = popoto.SortedField(type=float)
+    label = popoto.Field(type=str, null=True)
+```
+
+#### Scenario 2: partition_by + clean_indexes
+
+1. Create instances of a ConfidenceField model with `partition_by="category"`
+2. Update confidence values to ensure companion hash entries exist
+3. Delete one instance hash directly via `POPOTO_REDIS_DB.delete()`
+4. Call `check_indexes()` -- verify orphans detected
+5. Call `clean_indexes()` -- verify orphans removed
+6. Call `check_indexes()` -- verify total == 0
+7. Verify surviving instances still have correct confidence data
+
+Model definition:
+```python
+class IntegrationConfidence(popoto.Model):
+    name = popoto.KeyField()
+    category = popoto.KeyField()
+    certainty = ConfidenceField(initial_confidence=0.5, partition_by="category")
+```
+
+Note: `check_indexes()` and `clean_indexes()` scan sorted fields and class sets. The ConfidenceField companion hashes use a separate key structure (`$Confidence:...`). The integration test should verify that after deleting an instance, the class set and any sorted/key field indexes are cleaned, and that the surviving instances' confidence data remains intact.
+
+#### Scenario 3: TTL expiry + check_indexes
+
+1. Define a model with `Meta.ttl = 2` (2-second expiry) and a SortedField
+2. Create an instance
+3. Verify `check_indexes()` reports 0 orphans immediately
+4. Wait for TTL expiry (2.5 seconds)
+5. Verify the instance key no longer exists (`query.get()` returns None)
+6. Call `check_indexes()` -- verify it reports orphans (the sorted field and class set entries survive TTL because they are separate Redis keys)
+7. Call `clean_indexes()` -- verify orphans removed
+8. Call `check_indexes()` -- verify total == 0
+
+Model definition:
+```python
+class IntegrationTTL(popoto.Model):
+    name = popoto.KeyField()
+    score = popoto.SortedField(type=float)
+
+    class Meta:
+        ttl = 2
+```
+
+#### Async variant
+
+Scenario 1 repeated using `async_get_many`, `async_check_indexes`, and `async_clean_indexes`.
+
+## Failure Path Test Strategy
+
+### Exception Handling Coverage
+- No exception handlers in scope -- these are integration tests exercising existing methods
+
+### Empty/Invalid Input Handling
+- Scenario 1 tests `get_many()` with keys pointing to deleted instances (returns None)
+- Scenario 1 tests `get_many(skip_none=True)` filtering behavior after cleanup
+
+### Error State Rendering
+- Not applicable -- library methods return structured data, no user-visible rendering
+
+## Test Impact
+
+No existing tests affected -- this is a greenfield test file (`tests/test_integration_v144.py`) that does not modify any existing test files or production code.
+
+## Rabbit Holes
+
+- **Testing companion hash cleanup in clean_indexes**: The current `clean_indexes()` implementation cleans class sets, key field indexes, sorted field indexes, geo indexes, and composite indexes. It does NOT clean companion hash entries (ConfidenceField data hashes). Do not try to test companion hash cleanup -- that would be a new feature, not an integration test.
+- **Testing all possible feature combinations**: There are many possible pairwise combinations of v1.4.4 features. Focus only on the three scenarios from the issue -- they cover the most realistic workflows.
+- **Performance benchmarking**: Do not add timing assertions or performance tests. This is about correctness only.
+
+## Risks
+
+### Risk 1: TTL test timing sensitivity
+**Impact:** Scenario 3 uses `time.sleep(2.5)` to wait for TTL expiry. On slow CI runners, this could be flaky.
+**Mitigation:** Use a generous buffer (2.5s for a 2s TTL). If flaky, the TTL can be increased to 3s with a 4s wait.
+
+### Risk 2: Test isolation between scenarios
+**Impact:** Shared Redis DB 15 means scenarios could leak state.
+**Mitigation:** Each test class uses unique model class names. The pytest plugin flushes DB between tests. Use `delete_all()` in setup/teardown as a belt-and-suspenders approach.
+
+## Race Conditions
+
+No race conditions identified -- all tests are synchronous (except the async variant which uses `asyncio.run()`) and single-threaded. The TTL scenario has inherent timing sensitivity but no concurrency.
+
+## No-Gos (Out of Scope)
+
+- No production code changes -- test-only issue
+- No companion hash orphan cleanup (not supported by clean_indexes yet)
+- No geo field or composite index integration scenarios (covered adequately in isolated tests)
+- No performance or load testing
+
+## Update System
+
+No update system changes required -- this is a test-only change in the popoto library.
+
+## Agent Integration
+
+No agent integration required -- this is a library test file.
+
+## Documentation
+
+No documentation changes needed -- integration tests are self-documenting via their docstrings and do not require external documentation updates.
+
+## Success Criteria
+
+- [ ] New test file `tests/test_integration_v144.py` created
+- [ ] Scenario 1 (get_many + check_indexes + clean_indexes) passes
+- [ ] Scenario 2 (partition_by + clean_indexes) passes
+- [ ] Scenario 3 (TTL expiry + check_indexes) passes
+- [ ] At least one async variant passes
+- [ ] All existing tests continue to pass
+- [ ] Tests pass (`/do-test`)
+
+## Team Orchestration
+
+### Team Members
+
+- **Builder (integration-tests)**
+  - Name: integration-test-builder
+  - Role: Implement all three test scenarios in a single test file
+  - Agent Type: test-engineer
+  - Resume: true
+
+- **Validator (integration-tests)**
+  - Name: integration-test-validator
+  - Role: Run the test file and verify all scenarios pass
+  - Agent Type: validator
+  - Resume: true
+
+## Step by Step Tasks
+
+### 1. Create integration test file
+- **Task ID**: build-integration-tests
+- **Depends On**: none
+- **Validates**: tests/test_integration_v144.py (create)
+- **Assigned To**: integration-test-builder
+- **Agent Type**: test-engineer
+- **Parallel**: false
+- Create `tests/test_integration_v144.py` with model definitions for all three scenarios
+- Implement `TestGetManyCheckClean` class with Scenario 1 tests
+- Implement `TestPartitionByCleanIndexes` class with Scenario 2 tests
+- Implement `TestTTLExpiryCheckIndexes` class with Scenario 3 tests
+- Implement `TestAsyncIntegration` class with async variant of Scenario 1
+- Use `import popoto` (not `from src import popoto`) matching the style of `test_check_indexes.py`
+- Use `POPOTO_REDIS_DB` for direct Redis manipulation (deleting instance hashes)
+- Import `ConfidenceField` from `popoto.fields.confidence_field` for Scenario 2
+
+### 2. Final Validation
+- **Task ID**: validate-all
+- **Depends On**: build-integration-tests
+- **Assigned To**: integration-test-validator
+- **Agent Type**: validator
+- **Parallel**: false
+- Run `pytest tests/test_integration_v144.py -x -v` and verify all tests pass
+- Run `pytest tests/ -x -q --timeout=60` to verify no existing tests break
+- Verify all success criteria met
+
+## Verification
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| Integration tests pass | `pytest tests/test_integration_v144.py -x -v` | exit code 0 |
+| Full suite | `pytest tests/ -x -q --timeout=60` | exit code 0 |
+| File exists | `test -f tests/test_integration_v144.py` | exit code 0 |
+
+## Critique Results
+
+<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+
+---
+
+## Open Questions
+
+No open questions -- the three scenarios are well-defined in the issue, the existing test files provide clear API usage patterns to follow, and this is a test-only change with no architectural decisions required.

--- a/docs/plans/update_kitchen_sink_v144.md
+++ b/docs/plans/update_kitchen_sink_v144.md
@@ -1,0 +1,223 @@
+---
+status: Planning
+type: chore
+appetite: Small
+owner: agent
+created: 2026-04-03
+tracking: https://github.com/tomcounsell/popoto/issues/339
+last_comment_id:
+---
+
+# Update Kitchen Sink Example App with v1.4.4 Features
+
+## Problem
+
+The kitchen sink example app at `examples/popoto_kitchen/` was built before the 8 PRs merged on 2026-03-31 and does not demonstrate any of the new v1.4.4 features. Developers looking at the example app to learn Popoto miss coverage of ConfidenceField with partition_by, get_many(), check_indexes()/clean_indexes(), and the companion hash key public API.
+
+**Current behavior:**
+The example app demonstrates: KeyField, AutoKeyField, UniqueKeyField, SortedField (with partition_by), GeoField, Relationship, Model Meta options, and partial save with update_fields. It has no usage of ConfidenceField, get_many(), check_indexes(), clean_indexes(), or companion hash key inspection methods.
+
+**Desired outcome:**
+The example app demonstrates all four new features with runnable code that works against a local Redis/Valkey instance. New features fit naturally into the existing food delivery domain.
+
+## Prior Art
+
+- **PR #112**: Add Popoto Kitchen TUI example application -- Created the original TUI app with models, seed data, and Textual screens.
+- **PR #168**: Demo: add edge case mutation flows to Popoto Kitchen (PRs #159-#163) -- Updated the kitchen app to exercise SortedField partition_by fix and partial save. Established the pattern for how to add feature demos to the existing app.
+
+## Appetite
+
+**Size:** Small
+
+**Team:** Solo dev
+
+**Interactions:**
+- PM check-ins: 0
+- Review rounds: 1
+
+## Prerequisites
+
+No prerequisites -- this work has no external dependencies. Requires only a local Redis/Valkey instance (same as the existing example app).
+
+## Solution
+
+### Key Elements
+
+- **ReviewScore model**: A new model using ConfidenceField with `partition_by="restaurant"` to track review confidence per restaurant. This fits the food delivery domain naturally -- confidence in a review score increases with more evidence.
+- **Operations script**: A new `operations.py` module with functions demonstrating `check_indexes()`, `clean_indexes()`, and `get_many()` as operational workflows.
+- **Companion hash key inspection**: Included in operations.py to show how `get_data_hash_key()` reveals the underlying Redis key structure.
+- **Seed data updates**: Seed the new ReviewScore model with sample confidence data.
+
+### Flow
+
+**Seed data** -> ReviewScore instances created with ConfidenceField -> `update_confidence()` called with signals -> **Operations script** -> `check_indexes()` reports health -> `clean_indexes()` removes orphans -> `get_many()` bulk-loads orders -> companion hash key inspection shows Redis internals
+
+### Technical Approach
+
+- Add `ReviewScore` model to `models.py` with `ConfidenceField(partition_by="restaurant")`
+- Add `operations.py` with standalone functions that can be called from `__main__.py --ops`
+- Extend `seed.py` to create ReviewScore instances and apply confidence signals
+- Keep TUI changes minimal -- this is primarily about the model and script layer, not new screens
+
+## Failure Path Test Strategy
+
+### Exception Handling Coverage
+- No exception handlers in scope -- this is example code, not library code. Example scripts will print errors to stdout rather than catching silently.
+
+### Empty/Invalid Input Handling
+- The operations script will handle the case where no models exist (empty database) by printing a message and returning early.
+
+### Error State Rendering
+- Not applicable -- no new TUI screens. Operations output goes to stdout.
+
+## Test Impact
+
+No existing tests affected -- this is purely additive example code. The example app has no test suite of its own; correctness is verified by running the app against Redis.
+
+## Rabbit Holes
+
+- Adding a new TUI screen/tab for operations. The operations are best demonstrated as CLI scripts, not interactive widgets. A TUI screen would require significant Textual code for marginal demo value.
+- Making ConfidenceField queryable/sortable in the TUI. The demo should show the API, not build a full analytics dashboard.
+- Adding tests for the example app itself. The example app is documentation, not production code.
+
+## Risks
+
+### Risk 1: ConfidenceField requires cmsgpack in Redis Lua
+**Impact:** The Bayesian update Lua script uses `cmsgpack.unpack`/`cmsgpack.pack`, which are built into Redis but may not be in all Valkey builds.
+**Mitigation:** This is an existing constraint of ConfidenceField, not new to this work. The example documents this requirement.
+
+## Race Conditions
+
+No race conditions identified -- example scripts run sequentially in a single process.
+
+## No-Gos (Out of Scope)
+
+- No new TUI screens or tabs
+- No modifications to existing screens (dashboard, restaurants, menu, orders, drivers)
+- No async operations or pub/sub demos
+- No EmbeddingField or ContentField demos (require external providers)
+
+## Update System
+
+No update system changes required -- this is example code only.
+
+## Agent Integration
+
+No agent integration required -- this is an example application.
+
+## Documentation
+
+### Inline Documentation
+- [ ] Docstrings on ReviewScore model explaining ConfidenceField usage
+- [ ] Docstrings on operations.py functions explaining each feature demo
+- [ ] Comments in seed.py explaining confidence signal patterns
+
+## Success Criteria
+
+- [ ] At least one model using ConfidenceField with partition_by
+- [ ] Example script demonstrating get_many() usage
+- [ ] Example of check_indexes() followed by clean_indexes() operational workflow
+- [ ] Companion hash key inspection via get_data_hash_key() demonstrated
+- [ ] All examples runnable against a local Redis/Valkey instance
+- [ ] Existing app functionality unchanged
+- [ ] Tests pass (`/do-test`)
+- [ ] Documentation updated (`/do-docs`)
+
+## Team Orchestration
+
+### Team Members
+
+- **Builder (kitchen-sink)**
+  - Name: kitchen-builder
+  - Role: Add new model, operations script, and seed data
+  - Agent Type: builder
+  - Resume: true
+
+- **Validator (kitchen-sink)**
+  - Name: kitchen-validator
+  - Role: Verify all examples run against Redis
+  - Agent Type: validator
+  - Resume: true
+
+## Step by Step Tasks
+
+### 1. Add ReviewScore Model
+- **Task ID**: build-model
+- **Depends On**: none
+- **Validates**: manual run of seed script
+- **Assigned To**: kitchen-builder
+- **Agent Type**: builder
+- **Parallel**: true
+- Add `ReviewScore` model to `examples/popoto_kitchen/models.py` with:
+  - `restaurant` as a `KeyField()` (partition key for the restaurant name)
+  - `reviewer` as a `KeyField()` (the customer username)
+  - `score` as a `ConfidenceField(initial_confidence=0.5, partition_by="restaurant")`
+- Import `ConfidenceField` from `popoto`
+- Add `ReviewScore` to imports in `seed.py` and `__init__.py` if needed
+
+### 2. Add Operations Script
+- **Task ID**: build-operations
+- **Depends On**: none
+- **Assigned To**: kitchen-builder
+- **Agent Type**: builder
+- **Parallel**: true
+- Create `examples/popoto_kitchen/operations.py` with functions:
+  - `demo_get_many()` -- fetch multiple orders by key in one pipeline call
+  - `demo_check_and_clean_indexes()` -- run check_indexes() on all models, then clean_indexes() if orphans found
+  - `demo_companion_hash_keys()` -- show get_data_hash_key() on ReviewScore instances
+  - `run_all()` -- run all demos with labeled output
+- Each function prints its results to stdout with clear section headers
+
+### 3. Update Seed Script
+- **Task ID**: build-seed
+- **Depends On**: build-model
+- **Assigned To**: kitchen-builder
+- **Agent Type**: builder
+- **Parallel**: false
+- Add `seed_review_scores()` function to `seed.py`:
+  - Create ReviewScore instances for a subset of customer/restaurant pairs
+  - Call `ConfidenceField.update_confidence()` with varied signals (0.2-0.9) to build evidence history
+  - Print count of review scores seeded
+- Call `seed_review_scores()` from `seed_database()`
+- Add `ReviewScore` to `clear_database()`
+
+### 4. Update Entry Point
+- **Task ID**: build-entrypoint
+- **Depends On**: build-operations
+- **Assigned To**: kitchen-builder
+- **Agent Type**: builder
+- **Parallel**: false
+- Add `--ops` flag to `__main__.py` argparse
+- When `--ops` is passed, import and call `operations.run_all()` then exit
+- Update module docstring with new usage example
+
+### 5. Validate All Features
+- **Task ID**: validate-all
+- **Depends On**: build-seed, build-entrypoint
+- **Assigned To**: kitchen-validator
+- **Agent Type**: validator
+- **Parallel**: false
+- Run `python -m popoto_kitchen --seed-only --clear` to seed fresh data
+- Run `python -m popoto_kitchen --ops` to execute all operation demos
+- Verify each demo produces output without errors
+- Verify existing app still launches with `python -m popoto_kitchen`
+
+## Verification
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| Tests pass | `pytest tests/ -x -q` | exit code 0 |
+| Models importable | `python -c "from examples.popoto_kitchen.models import ReviewScore"` | exit code 0 |
+| Operations importable | `python -c "from examples.popoto_kitchen.operations import run_all"` | exit code 0 |
+| Lint clean | `python -m ruff check examples/popoto_kitchen/` | exit code 0 |
+
+## Critique Results
+
+<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+
+---
+
+## Open Questions
+
+1. Should the operations script also demonstrate `get_many()` with `skip_none=True` to show both modes, or is a single call sufficient?
+2. Is the ReviewScore model (keyed by restaurant + reviewer) the right domain fit, or would a different model better showcase partition_by?


### PR DESCRIPTION
## Summary
- Adds plan document for updating the kitchen sink example app with v1.4.4 features
- Covers ConfidenceField with partition_by, get_many(), check_indexes()/clean_indexes(), and companion hash key API
- References issue #339

## Plan document
`docs/plans/update_kitchen_sink_v144.md`

**Note:** This PR adds a plan document only. It does not close #339 -- the implementation PR will close it.