### PR TITLE
Add v1.4.4 feature demos to kitchen sink example app

### DIFF
--- a/examples/popoto_kitchen/__main__.py
+++ b/examples/popoto_kitchen/__main__.py
@@ -2,7 +2,9 @@
 
 Usage:
     python -m popoto_kitchen
-    python -m popoto_kitchen --seed  # Seed sample data first
+    python -m popoto_kitchen --seed              # Seed sample data first
+    python -m popoto_kitchen --seed-only --clear  # Seed fresh data only
+    python -m popoto_kitchen --ops               # Run v1.4.4 operations demos
 """
 
 import argparse
@@ -27,6 +29,11 @@ def main():
         "--clear",
         action="store_true",
         help="Clear all existing data before seeding",
+    )
+    parser.add_argument(
+        "--ops",
+        action="store_true",
+        help="Run v1.4.4 operations demos (get_many, check/clean indexes, companion keys)",
     )
     args = parser.parse_args()
 
@@ -54,6 +61,12 @@ def main():
 
         if args.seed_only:
             return
+
+    if args.ops:
+        from .operations import run_all
+
+        run_all()
+        return
 
     from .app import PopotoKitchen
 

--- a/examples/popoto_kitchen/models.py
+++ b/examples/popoto_kitchen/models.py
@@ -7,11 +7,12 @@ These models demonstrate all major Popoto features:
 - Relationship for model associations
 - DatetimeField with auto timestamps
 - Model Meta options (ttl, order_by)
+- ConfidenceField with partition_by (v1.4.4)
 """
 
 from datetime import datetime
 
-from popoto import Field, KeyField, Model, Relationship, SortedField
+from popoto import ConfidenceField, Field, KeyField, Model, Relationship, SortedField
 from popoto.fields.geo_field import GeoField
 from popoto.fields.shortcuts import AutoKeyField, UniqueKeyField
 
@@ -166,6 +167,30 @@ class Order(Model):
         except ValueError:
             pass
         return False
+
+
+
+class ReviewScore(Model):
+    """A review confidence score for a restaurant by a customer.
+
+    Demonstrates:
+    - ConfidenceField with partition_by for per-restaurant confidence tracking
+    - Bayesian confidence updates via ConfidenceField.update_confidence()
+    - Companion hash key inspection via get_data_hash_key()
+
+    The confidence score starts at 0.5 (neutral) and moves toward 1.0 or 0.0
+    as evidence accumulates. Partitioning by restaurant keeps each restaurant's
+    confidence data in a separate Redis hash, avoiding large monolithic hashes.
+
+    Redis key pattern: ReviewScore:<restaurant>:<reviewer>
+    """
+
+    restaurant = KeyField()
+    reviewer = KeyField()
+    score = ConfidenceField(initial_confidence=0.5, partition_by="restaurant")
+
+    def __str__(self) -> str:
+        return f"ReviewScore({self.restaurant}, {self.reviewer}): {self.score:.4f}"
 
 
 # Cuisine types for seeding

--- a/examples/popoto_kitchen/operations.py
+++ b/examples/popoto_kitchen/operations.py
@@ -1,0 +1,180 @@
+"""Operational workflow demos for Popoto Kitchen.
+
+Demonstrates v1.4.4 features that are useful for production operations:
+- get_many() for bulk-loading instances in a single pipeline call
+- check_indexes() for read-only index health checks
+- clean_indexes() for removing orphaned index entries
+- get_data_hash_key() for inspecting companion hash key structure
+
+Run via: python -m popoto_kitchen --ops
+"""
+
+from popoto import ConfidenceField
+
+from .models import (
+    Customer,
+    Driver,
+    MenuItem,
+    Order,
+    Restaurant,
+    ReviewScore,
+)
+
+
+def demo_get_many():
+    """Demonstrate bulk-loading multiple model instances with get_many().
+
+    get_many() uses a Redis pipeline to batch HGETALL calls, reducing N
+    sequential round-trips to a single pipelined round-trip. Input order
+    is preserved in the result list.
+    """
+    print("=" * 60)
+    print("DEMO: get_many() - Bulk Instance Loading")
+    print("=" * 60)
+
+    # Collect some order keys to bulk-load
+    all_orders = Order.query.filter(limit=5)
+    if not all_orders:
+        print("  No orders found. Run --seed first.")
+        return
+
+    # Extract the Redis keys from the order instances
+    order_keys = [order.db_key.redis_key for order in all_orders]
+    print(f"\n  Fetching {len(order_keys)} orders by key in one pipeline call...")
+    for key in order_keys:
+        print(f"    - {key}")
+
+    # get_many() returns instances in the same order as the input keys.
+    # None appears at positions where the key was missing.
+    loaded_orders = Order.query.get_many(redis_keys=order_keys)
+    print(f"\n  Results ({len(loaded_orders)} items):")
+    for i, order in enumerate(loaded_orders):
+        if order is not None:
+            print(f"    [{i}] {order} - ${order.total:.2f}")
+        else:
+            print(f"    [{i}] None (key not found)")
+
+    # Demonstrate skip_none=True mode: filters out missing entries
+    print("\n  With skip_none=True (filters out None entries):")
+    # Add a fake key to show the difference
+    keys_with_missing = order_keys + ["Order:nonexistent-key"]
+    loaded = Order.query.get_many(redis_keys=keys_with_missing, skip_none=True)
+    print(f"    Input: {len(keys_with_missing)} keys")
+    print(f"    Output: {len(loaded)} instances (None entries filtered)")
+
+
+def demo_check_and_clean_indexes():
+    """Demonstrate check_indexes() and clean_indexes() for index health.
+
+    check_indexes() is a read-only health check that scans all index types
+    (class set, key fields, sorted fields, geo fields, composite indexes)
+    and counts orphaned entries -- references to instances that no longer
+    exist in Redis.
+
+    clean_indexes() is the write counterpart: it removes orphaned entries
+    found by the same scan logic. Safe to run in production during
+    low-traffic periods.
+    """
+    print("\n" + "=" * 60)
+    print("DEMO: check_indexes() / clean_indexes() - Index Health")
+    print("=" * 60)
+
+    all_models = [Restaurant, MenuItem, Customer, Driver, Order, ReviewScore]
+
+    for model in all_models:
+        print(f"\n  Checking {model.__name__}...")
+        result = model.check_indexes()
+
+        total_orphans = result.get("total", 0)
+        if total_orphans == 0:
+            print("    All indexes healthy (0 orphans)")
+        else:
+            print(f"    Found {total_orphans} orphaned index entries:")
+            if result.get("class_set"):
+                print(f"      class_set: {result['class_set']}")
+            for field_type in ("key_fields", "sorted_fields", "geo_fields"):
+                field_data = result.get(field_type, {})
+                for field_name, count in field_data.items():
+                    if count > 0:
+                        print(f"      {field_type}.{field_name}: {count}")
+
+            # Clean up the orphans
+            print("    Cleaning orphaned entries...")
+            removed = model.clean_indexes()
+            print(f"    Removed {removed} orphaned index entries")
+
+
+def demo_companion_hash_keys():
+    """Demonstrate get_data_hash_key() for inspecting Redis key structure.
+
+    ConfidenceField stores metadata in a companion Redis hash separate from
+    the model instance. get_data_hash_key() reveals the actual Redis key used,
+    which is useful for monitoring, debugging, and direct Redis inspection.
+
+    When partition_by is set, each partition gets its own hash key, keeping
+    hash sizes manageable.
+    """
+    print("\n" + "=" * 60)
+    print("DEMO: get_data_hash_key() - Companion Hash Key Inspection")
+    print("=" * 60)
+
+    # Find some ReviewScore instances to inspect
+    reviews = ReviewScore.query.filter(limit=5)
+    if not reviews:
+        print("  No ReviewScore instances found. Run --seed first.")
+        return
+
+    score_field = ReviewScore._meta.fields["score"]
+
+    print("\n  ReviewScore uses ConfidenceField(partition_by='restaurant')")
+    print("  Each restaurant gets its own companion hash in Redis:\n")
+
+    seen_keys = set()
+    for review in reviews:
+        # get_data_hash_key() shows the actual Redis key for this instance's
+        # confidence data. With partition_by="restaurant", the key includes
+        # the restaurant name.
+        hash_key = score_field.get_data_hash_key(review, "score")
+        instance_key = review.db_key.redis_key
+
+        print(f"    Instance: {instance_key}")
+        print(f"    Hash key: {hash_key}")
+
+        # Read the confidence metadata
+        data = ConfidenceField.get_confidence_data(review, "score")
+        print(f"    Confidence: {data['confidence']:.4f}")
+        print(
+            f"    Evidence: {data['evidence_count']} "
+            f"(+{data['corroborations']} / -{data['contradictions']})"
+        )
+        print()
+
+        seen_keys.add(hash_key)
+
+    print(f"  Unique companion hash keys seen: {len(seen_keys)}")
+    print("  (One per restaurant partition)")
+
+    # Also demonstrate get_data_hash_key_from_values() for query paths
+    print("\n  Building hash key from explicit partition values:")
+    explicit_key = score_field.get_data_hash_key_from_values(
+        ReviewScore, "score", restaurant=reviews[0].restaurant
+    )
+    print(f"    restaurant='{reviews[0].restaurant}' -> {explicit_key}")
+
+
+def run_all():
+    """Run all operational demos with labeled output."""
+    print("\nPopoto Kitchen - v1.4.4 Operations Demo")
+    print("=" * 60)
+
+    demo_get_many()
+    demo_check_and_clean_indexes()
+    demo_companion_hash_keys()
+
+    print("\n" + "=" * 60)
+    print("All operations demos complete.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    run_all()

--- a/examples/popoto_kitchen/seed.py
+++ b/examples/popoto_kitchen/seed.py
@@ -6,10 +6,13 @@ Generates:
 - 500 customers
 - 50 drivers with random locations
 - 2,000 orders (mix of statuses)
+- 100 review scores with confidence signals (v1.4.4)
 """
 
 import random
 from datetime import datetime, timedelta
+
+from popoto import ConfidenceField
 
 from .models import (
     CUISINES,
@@ -18,6 +21,7 @@ from .models import (
     MenuItem,
     Order,
     Restaurant,
+    ReviewScore,
 )
 
 # Sample data for generating realistic names
@@ -287,7 +291,7 @@ def restaurant_name(cuisine: str) -> str:
 def clear_database():
     """Clear all existing data including secondary indexes."""
     # Delete models with relationships first, then referenced models
-    for model in [Order, MenuItem, Customer, Driver, Restaurant]:
+    for model in [Order, MenuItem, Customer, Driver, ReviewScore, Restaurant]:
         model.delete_all()
     print("Cleared all Popoto Kitchen data")
 
@@ -465,12 +469,70 @@ def seed_database(
         if (i + 1) % 500 == 0:
             print(f"  Created {i + 1} orders...")
 
+    # Seed review scores using ConfidenceField
+    review_count = seed_review_scores(restaurants, customers)
+
     print("\nSeeding complete!")
     print(f"  - {len(restaurants)} restaurants")
     print(f"  - {len(menu_items)} menu items")
     print(f"  - {len(customers)} customers")
     print(f"  - {len(drivers)} drivers")
     print(f"  - {num_orders} orders")
+    print(f"  - {review_count} review scores")
+
+
+
+def seed_review_scores(restaurants, customers, reviews_per_restaurant=5):
+    """Seed ReviewScore instances with Bayesian confidence signals.
+
+    Creates review scores for a subset of customer/restaurant pairs and
+    applies varied confidence signals to build evidence history. This
+    demonstrates ConfidenceField's Bayesian update mechanism where each
+    signal nudges the confidence toward 0 or 1 with diminishing effect.
+
+    Args:
+        restaurants: List of Restaurant instances to review.
+        customers: List of Customer instances who leave reviews.
+        reviews_per_restaurant: Number of reviews per restaurant (default 5).
+
+    Returns:
+        int: Total number of ReviewScore instances created.
+    """
+    print("Seeding review scores...")
+    count = 0
+
+    # Use a subset of restaurants (first 20) and random customers
+    sample_restaurants = restaurants[:20]
+
+    for restaurant in sample_restaurants:
+        # Pick random customers to be reviewers for this restaurant
+        reviewers = random.sample(
+            customers, min(reviews_per_restaurant, len(customers))
+        )
+
+        for customer in reviewers:
+            review = ReviewScore(
+                restaurant=restaurant.name,
+                reviewer=customer.username,
+            )
+            review.save()
+
+            # Apply 2-6 confidence signals to build evidence history.
+            # Signals near 1.0 = positive review, near 0.0 = negative.
+            # Mix of signals creates realistic confidence distributions.
+            num_signals = random.randint(2, 6)
+            for _ in range(num_signals):
+                # Most reviews are positive (0.6-0.95), some negative (0.1-0.4)
+                if random.random() > 0.25:
+                    signal = random.uniform(0.6, 0.95)
+                else:
+                    signal = random.uniform(0.1, 0.4)
+                ConfidenceField.update_confidence(review, "score", signal=signal)
+
+            count += 1
+
+    print(f"  Created {count} review scores with confidence signals")
+    return count
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `ReviewScore` model with `ConfidenceField(partition_by="restaurant")` to demonstrate Bayesian confidence tracking
- Create `operations.py` with demos for `get_many()`, `check_indexes()`/`clean_indexes()`, and companion hash key inspection via `get_data_hash_key()`
- Extend seed script with review score data and confidence signal generation
- Add `--ops` CLI flag to `__main__.py` for running operation demos

## Test plan

- [x] All 1430 tests pass (`pytest tests/ -x -q`)
- [x] `python -c "from examples.popoto_kitchen.models import ReviewScore"` succeeds
- [x] `python -c "from examples.popoto_kitchen.operations import run_all"` succeeds
- [x] `python -m ruff check examples/popoto_kitchen/` clean
- [ ] Run `python -m popoto_kitchen --seed-only --clear` against local Redis
- [ ] Run `python -m popoto_kitchen --ops` to verify all demos produce output

Closes #339

Plan: docs/plans/update_kitchen_sink_v144.md