### PR TITLE
Document v1.4.4 kitchen sink demos and add cross-references

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -740,6 +740,12 @@ assert result['total'] == 0
     preserves valid index entries and avoids the query gap that `rebuild_indexes()`
     creates.
 
+!!! example "Live demo"
+    The [Popoto Kitchen example app](../examples/README.md) demonstrates the
+    `check_indexes()` then `clean_indexes()` workflow across all models. Run
+    `python -m popoto_kitchen --ops` to see it in action. Source:
+    [`examples/popoto_kitchen/operations.py`](../examples/popoto_kitchen/operations.py).
+
 ### Async Index Maintenance
 
 | Sync | Async |

--- a/docs/features/confidence-field.md
+++ b/docs/features/confidence-field.md
@@ -195,6 +195,24 @@ report = ConfidenceField.migrate_to_partitioned(Memory, "certainty")
 | `$ConfidencF:{Model}:{field}:data` | HASH | Unpartitioned: all members' confidence metadata |
 | `$ConfidencF:{Model}:{field}:data:{partition_value}` | HASH | Partitioned: members in one partition |
 
+## Working Example: Popoto Kitchen
+
+The [Popoto Kitchen example app](../../examples/README.md) includes a `ReviewScore`
+model that demonstrates `ConfidenceField` with `partition_by="restaurant"`. Run the
+operations demo to see Bayesian updates, companion hash key inspection, and
+partitioned confidence in action:
+
+```bash
+cd examples
+uv run popoto-kitchen --seed-only --clear
+uv run popoto-kitchen --ops
+```
+
+See [`examples/popoto_kitchen/operations.py`](../../examples/popoto_kitchen/operations.py)
+for the full source, and the
+[kitchen demo docs](kitchen-edge-case-demo.md#v144-feature-demos-pr-346)
+for a walkthrough.
+
 ## Companion Fields
 
 `ConfidenceField` works alongside other memory system fields:

--- a/docs/features/kitchen-edge-case-demo.md
+++ b/docs/features/kitchen-edge-case-demo.md
@@ -99,15 +99,57 @@ from the old driver's relationship index and added to the new driver's index.
 5. `Restaurant.query.all()` returns the restaurant under the new key; the old
    key is gone.
 
+## v1.4.4 Feature Demos (PR #346)
+
+PR #346 added a new `ReviewScore` model and an operations script that
+demonstrates four v1.4.4 features outside of the TUI. These are invoked
+via `python -m popoto_kitchen --ops` and print results to stdout.
+
+### ReviewScore Model
+
+A new model using `ConfidenceField` with `partition_by="restaurant"` to
+track review confidence per restaurant. See
+[ConfidenceField docs](confidence-field.md) for the Bayesian update formula.
+
+```python
+class ReviewScore(Model):
+    restaurant = KeyField()
+    reviewer = KeyField()
+    score = ConfidenceField(initial_confidence=0.5, partition_by="restaurant")
+```
+
+The seed script creates 100 review scores with varied confidence signals
+(2-6 signals per review, mix of positive and negative) to build realistic
+evidence histories.
+
+### Operations Script (`operations.py`)
+
+| Demo | Feature | Description |
+|------|---------|-------------|
+| `demo_get_many()` | `query.get_many()` | Bulk-loads Order instances by key in a single pipeline call. Shows both default mode (with `None` placeholders) and `skip_none=True` mode. |
+| `demo_check_and_clean_indexes()` | `check_indexes()` / `clean_indexes()` | Runs a read-only health check on all models, then surgically removes any orphaned index entries found. |
+| `demo_companion_hash_keys()` | `get_data_hash_key()` | Inspects the companion Redis hash keys for ReviewScore's ConfidenceField, showing how `partition_by` creates per-restaurant hashes. Also demonstrates `get_data_hash_key_from_values()` for building keys without a loaded instance. |
+
+### Entry Point Changes
+
+New CLI flags added to `__main__.py`:
+
+- `--ops` -- Run v1.4.4 operations demos and exit
+- `--seed-only --clear` -- Seed fresh data without launching the TUI
+
 ## Running the Demo
 
 ```bash
-# Clear any stale seeded data first (category → KeyField is a breaking schema change)
+# Start the TUI (interactive edge case demos)
+python -m examples.popoto_kitchen
+
+# Clear any stale seeded data first (category -> KeyField is a breaking schema change)
 # In the Dashboard screen, click "Clear All Data", then "Seed Data"
 
-# Start the TUI
-python -m examples.popoto_kitchen
+# Run the v1.4.4 operations demos (non-interactive, stdout output)
+python -m popoto_kitchen --seed-only --clear
+python -m popoto_kitchen --ops
 ```
 
 Navigate to each screen and use the new buttons to observe the edge case
-behaviors described above.
+behaviors described above. Use `--ops` for the v1.4.4 feature demos.

--- a/docs/plans/update_kitchen_sink_v144.md
+++ b/docs/plans/update_kitchen_sink_v144.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: Done
 type: chore
 appetite: Small
 owner: agent

--- a/docs/query.md
+++ b/docs/query.md
@@ -130,6 +130,12 @@ An empty input list returns an empty list immediately, without touching Redis.
     takes a list of string keys, preserves input order, and returns `None` for missing entries.
     The internal method takes a set of bytes keys and silently drops missing entries.
 
+!!! example "Live demo"
+    The [Popoto Kitchen example app](../examples/README.md) demonstrates `get_many()` in its
+    operations script. Run `python -m popoto_kitchen --ops` to see bulk Order loading with both
+    default and `skip_none=True` modes. Source:
+    [`examples/popoto_kitchen/operations.py`](../examples/popoto_kitchen/operations.py).
+
 ## Get All Objects
 
 Use `query.all()` to retrieve every instance of a model. This fetches all Redis keys registered

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,10 @@ uv run popoto-kitchen --clear --seed
 
 # Only seed, don't start the app
 uv run popoto-kitchen --seed-only
+
+# Seed fresh data and run v1.4.4 operations demos
+uv run popoto-kitchen --seed-only --clear
+uv run popoto-kitchen --ops
 ```
 
 ## Features
@@ -104,6 +108,34 @@ uv run popoto-kitchen --seed-only
 | `↑/↓` | Navigate table rows |
 | `Enter` | Select row |
 
+### v1.4.4 Operations Demos
+
+The `--ops` flag runs standalone demos for features added in v1.4.4. These print
+results to stdout rather than launching the TUI.
+
+| Demo | Feature | What it shows |
+|------|---------|---------------|
+| `demo_get_many()` | [`query.get_many()`](../docs/query.md) | Bulk-load instances in a single pipeline call; `skip_none=True` mode |
+| `demo_check_and_clean_indexes()` | [`Model.check_indexes()`](../docs/api-reference.md) / [`Model.clean_indexes()`](../docs/api-reference.md) | Read-only index health check followed by surgical orphan removal |
+| `demo_companion_hash_keys()` | [`get_data_hash_key()`](../docs/features/confidence-field.md) | Inspect companion Redis hash keys for ConfidenceField with partition_by |
+
+See `examples/popoto_kitchen/operations.py` for the full source.
+
+### ReviewScore Model (v1.4.4)
+
+The `ReviewScore` model demonstrates `ConfidenceField` with `partition_by`:
+
+```python
+class ReviewScore(Model):
+    restaurant = KeyField()
+    reviewer = KeyField()
+    score = ConfidenceField(initial_confidence=0.5, partition_by="restaurant")
+```
+
+Each restaurant gets its own companion Redis hash, keeping hash sizes manageable.
+The seed script creates review scores with varied Bayesian confidence signals to
+build realistic evidence histories.
+
 ## Sample Data
 
 The seed script generates:
@@ -112,6 +144,7 @@ The seed script generates:
 - 200 customers
 - 20 drivers
 - 500 orders with various statuses
+- 100 review scores with Bayesian confidence signals (v1.4.4)
 
 All data is located in the NYC area for realistic geo queries.
 
@@ -119,10 +152,11 @@ All data is located in the NYC area for realistic geo queries.
 
 ```
 popoto_kitchen/
-├── __main__.py      # Entry point
+├── __main__.py      # Entry point (--seed, --ops flags)
 ├── app.py           # Main Textual application
-├── models.py        # Popoto models (Restaurant, MenuItem, etc.)
-├── seed.py          # Sample data generator
+├── models.py        # Popoto models (Restaurant, MenuItem, ReviewScore, etc.)
+├── operations.py    # v1.4.4 feature demos (get_many, check/clean indexes, companion keys)
+├── seed.py          # Sample data generator (includes confidence signals)
 ├── screens/
 │   ├── dashboard.py # Overview with stats
 │   ├── restaurants.py # Restaurant CRUD + geo
@@ -135,8 +169,8 @@ popoto_kitchen/
 
 ## Popoto Features Showcased
 
-| Feature | Screen | Example |
-|---------|--------|---------|
+| Feature | Screen / Demo | Example |
+|---------|---------------|---------|
 | KeyField | Restaurants | `Restaurant.name` as unique key |
 | AutoKeyField | Orders, Drivers | UUID-based order IDs |
 | UniqueKeyField | Customers, Drivers | Unique email/phone |
@@ -146,6 +180,11 @@ popoto_kitchen/
 | Meta.order_by | Orders | Default sort by created_at |
 | Range queries | Menu | `price__gte`, `price__lte` |
 | Geo queries | Restaurants, Drivers | `location_radius`, `location_with_distances` |
+| ConfidenceField | `--ops` demo | Bayesian confidence with `partition_by` |
+| get_many() | `--ops` demo | Bulk-load instances in one pipeline call |
+| check_indexes() | `--ops` demo | Read-only index health check |
+| clean_indexes() | `--ops` demo | Surgical orphan removal |
+| get_data_hash_key() | `--ops` demo | Companion hash key inspection |
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Update examples/README.md with v1.4.4 operations demos (get_many, check/clean indexes, companion keys), ReviewScore model docs, updated architecture tree, and expanded features table
- Add v1.4.4 feature demos section to kitchen-edge-case-demo.md describing the new ReviewScore model, operations script, and CLI flags
- Add cross-reference "Live demo" callouts in confidence-field.md, query.md, and api-reference.md pointing to the kitchen sink as a working example
- Mark update_kitchen_sink_v144 plan as Done

Refs: #340, PR #346

## Test plan
- [ ] Verify all markdown links resolve correctly
- [ ] Verify no broken cross-references between docs
- [ ] Confirm examples/README.md renders correctly on GitHub