### PR TITLE
Plan revision: apply critique findings to OllamaProvider plan (#354)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -202,6 +202,30 @@ popoto.configure(embedding_provider=provider)
 OpenAI embeddings ignore the `input_type` parameter. Batch size limit is 2048
 texts per API call.
 
+#### Ollama (local, no API key)
+
+`OllamaProvider` connects to a locally-running [Ollama](https://ollama.com) server. No API key or extra Python package required — it uses only Python's standard library.
+
+```bash
+# 1. Start Ollama
+ollama serve
+
+# 2. Pull a model
+ollama pull nomic-embed-text
+```
+
+```python
+from popoto.embeddings.ollama import OllamaProvider
+
+provider = OllamaProvider(
+    base_url="http://localhost:11434",  # default
+    model="nomic-embed-text",           # default (768-dim)
+)
+popoto.configure(embedding_provider=provider)
+```
+
+Dimensions are auto-detected from the first `embed()` call. Pass `dim=<n>` if you need to read the `dimensions` property before any call has been made.
+
 #### Custom Providers
 
 Implement `AbstractEmbeddingProvider` to use any embedding service:

--- a/docs/features/content-and-embedding-fields.md
+++ b/docs/features/content-and-embedding-fields.md
@@ -126,6 +126,44 @@ provider = OpenAIProvider(
 
 Install: `pip install popoto[openai]`
 
+#### OllamaProvider
+
+Local embeddings via a [self-hosted Ollama server](https://ollama.com). No API key required — all inference runs on your own hardware.
+
+```python
+from popoto.embeddings.ollama import OllamaProvider
+
+provider = OllamaProvider(
+    base_url="http://localhost:11434",  # default
+    model="nomic-embed-text",           # default (768-dim)
+    dim=None,                           # auto-detected on first embed()
+)
+```
+
+No extra installation needed — `OllamaProvider` uses only Python's standard library.
+
+**Setup:**
+
+```bash
+# 1. Install and start Ollama (https://ollama.com)
+ollama serve
+
+# 2. Pull a model
+ollama pull nomic-embed-text
+```
+
+Common models and their dimensions:
+
+| Model | Dimensions |
+|-------|-----------|
+| `nomic-embed-text` | 768 |
+| `mxbai-embed-large` | 1024 |
+| `all-minilm` | 384 |
+
+The `dim` parameter is optional. When omitted, dimensions are auto-detected from the first `embed()` call. Pass `dim=<n>` explicitly if you need to access the `dimensions` property before the first call.
+
+Error messages are clear: a connection failure reminds you to run `ollama serve`, and a missing model reminds you to run `ollama pull <model>`.
+
 #### Custom Providers
 
 Implement `AbstractEmbeddingProvider`:
@@ -242,6 +280,7 @@ invalidate_cache()
 |-------|---------|----------|
 | Base | `pip install popoto` | ContentField (no extra deps) |
 | Embeddings | `pip install popoto[embeddings]` | numpy |
+| Ollama | `pip install popoto[embeddings]` | numpy (no extra Python deps) |
 | Voyage AI | `pip install popoto[voyage]` | numpy, voyageai |
 | OpenAI | `pip install popoto[openai]` | numpy, openai |
 
@@ -252,6 +291,7 @@ invalidate_cache()
 | `POPOTO_CONTENT_PATH` | `~/.popoto/content` | Base directory for content files and embeddings |
 | `VOYAGE_API_KEY` | *(none)* | API key for VoyageProvider (alternative to passing `api_key=`) |
 | `OPENAI_API_KEY` | *(none)* | API key for OpenAIProvider (alternative to passing `api_key=`) |
+| *(none)* | — | OllamaProvider requires no API key |
 
 ## See Also
 

--- a/docs/guides/agent-memory-quickstart.md
+++ b/docs/guides/agent-memory-quickstart.md
@@ -281,7 +281,7 @@ results = Memory.query.semantic_search(
 
 **What you get:** Memories are searchable by meaning, not just keywords. Combined with decay and confidence, the most relevant, recent, and trusted memories surface first.
 
-> **Install extras:** `pip install popoto[voyage]` for Voyage AI embeddings, or `pip install popoto[openai]` for OpenAI. See [Content and Embedding Fields](../features/content-and-embedding-fields.md) for all provider options.
+> **Install extras:** `pip install popoto[voyage]` for Voyage AI embeddings, `pip install popoto[openai]` for OpenAI, or use `OllamaProvider` from `popoto.embeddings.ollama` for fully local inference with no API key (requires a running [Ollama](https://ollama.com) server). See [Content and Embedding Fields](../features/content-and-embedding-fields.md) for all provider options.
 
 ## Import Cheat Sheet
 

--- a/docs/plans/ollama_provider.md
+++ b/docs/plans/ollama_provider.md
@@ -6,6 +6,7 @@ owner: valorengels
 created: 2026-04-14
 tracking: https://github.com/tomcounsell/popoto/issues/354
 last_comment_id:
+revision_applied: true
 ---
 
 # OllamaProvider for Local Embeddings
@@ -124,11 +125,13 @@ The implementation mirrors the existing `openai.py` almost exactly, with `urllib
 
 - Mirror the structure of `openai.py`: same constructor pattern, same `embed()` signature, same property implementations
 - Use `urllib.request.urlopen()` with `json.dumps().encode()` for the POST body and `json.loads()` for the response
-- Wrap connection errors in a clear `RuntimeError` with actionable message
+- Wrap `URLError` (connection refused) in a `RuntimeError` with "ollama serve" hint; wrap `HTTPError` with JSON body parsing (see below)
 - Default model: `nomic-embed-text`, default base_url: `http://localhost:11434`
-- `max_batch_size`: 512 (Ollama handles batches well locally; conservative default)
+- `max_batch_size`: 32 (conservative for local inference — local forward-pass with 512 texts can OOM on modest hardware; users who need higher throughput can subclass and override)
 - No retry/backoff -- local inference should fast-fail
 - No `input_type` handling -- Ollama ignores it
+- **`dimensions` property guard (C1):** When `self._dim is None` (i.e., `embed()` has not yet been called and no `dim` was passed to the constructor), the `dimensions` property MUST raise `RuntimeError("OllamaProvider: dimensions unknown — call embed() first or pass dim=<n> to the constructor")`. Never return `None` or `0` silently — the `AbstractEmbeddingProvider` contract types `dimensions` as `int`.
+- **HTTP error discrimination (C2):** Non-2xx responses from Ollama raise `urllib.error.HTTPError`. Handle explicitly: `except urllib.error.HTTPError as e: body = e.read().decode(); parsed = json.loads(body) if body else {}; msg = parsed.get("error", ""); if "not found" in msg.lower() or "model" in msg.lower(): raise RuntimeError(f"Model '{self._model}' not found. Run: ollama pull {self._model}") from e; else: raise RuntimeError(f"Ollama HTTP {e.code}: {msg}") from e`. This ensures "not found" and "other HTTP error" paths produce distinct, actionable messages.
 
 ## Failure Path Test Strategy
 
@@ -243,12 +246,12 @@ No agent integration required -- this is a Popoto library embedding provider use
 - Implement `OllamaProvider(base_url="http://localhost:11434", model="nomic-embed-text", dim=None)`
 - Implement `embed()` using `urllib.request.urlopen()` POST to `/api/embed` with JSON body `{"model": model, "input": texts}`
 - Parse response JSON `{"embeddings": [[...], ...]}` and return the embeddings list
-- Auto-detect dimensions from first response vector length; cache in `self._dim`
-- If `dim` is provided to constructor, use it directly (skip auto-detection)
+- Auto-detect dimensions from first response vector length; cache in `self._dim`; if `dim` is provided to constructor, use it directly (skip auto-detection)
+- `dimensions` property: if `self._dim is None`, raise `RuntimeError("OllamaProvider: dimensions unknown — call embed() first or pass dim=<n> to the constructor")` — never return `None` silently
 - Raise `RuntimeError` with "ollama serve" message on `URLError` (connection refused)
-- Raise `RuntimeError` with "ollama pull <model>" message on HTTP error indicating missing model
+- For `HTTPError`: read body, parse JSON `{"error": "..."}`, branch on "not found"/"model" keywords to raise `RuntimeError(f"Model '{self._model}' not found. Run: ollama pull {self._model}")`, else raise generic `RuntimeError(f"Ollama HTTP {e.code}: {msg}")`
 - Return `[]` for empty input list
-- Set `max_batch_size` to 512
+- Set `max_batch_size` to 32 (conservative for local inference; users may subclass to override)
 
 ### 2. Update embeddings __init__ exports
 - **Task ID**: build-exports
@@ -282,6 +285,7 @@ No agent integration required -- this is a Popoto library embedding provider use
 ### 4. Validate implementation
 - **Task ID**: validate-provider
 - **Depends On**: build-tests
+- **Validates**: `pytest tests/test_ollama_provider.py tests/test_embedding_provider.py -v`
 - **Assigned To**: provider-validator
 - **Agent Type**: validator
 - **Parallel**: false
@@ -323,9 +327,14 @@ No agent integration required -- this is a Popoto library embedding provider use
 
 ## Critique Results
 
-<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+<!-- Populated by /do-plan-critique (war room). -->
 | Severity | Critic | Finding | Addressed By | Implementation Note |
 |----------|--------|---------|--------------|---------------------|
+| CONCERN | Skeptic, Adversary | C1: `dimensions` returns `None` before first `embed()` — type contract violation against `AbstractEmbeddingProvider.dimensions -> int` | Technical Approach; Task 1 | Raise `RuntimeError` in `dimensions` property when `self._dim is None`: "OllamaProvider: dimensions unknown — call embed() first or pass dim=<n> to the constructor" |
+| CONCERN | Skeptic, Adversary | C2: HTTP error discrimination unreliable — plan lacked spec for parsing Ollama's JSON error body from `HTTPError` | Technical Approach; Task 1 | `except HTTPError as e: body = e.read().decode(); parsed = json.loads(body) if body else {}; msg = parsed.get("error", ""); branch on "not found"/"model" keywords for specific vs generic RuntimeError` |
+| CONCERN | Skeptic, Operator | C3: `max_batch_size=512` unvalidated for local inference — may OOM on modest hardware | Technical Approach; Task 1 | Lower to `max_batch_size=32`; document that users may subclass to override |
+| NIT | Archaeologist | N1: Minimum Ollama version for `/api/embed` not documented | ollama.py (inline comment) | Add one-line comment in `ollama.py` noting minimum Ollama version that introduced `/api/embed` |
+| NIT | Operator | N2: Tasks 4–6 missing `**Validates**:` fields — inconsistent with tasks 1–3 | Task 4 | Add `**Validates**: pytest tests/test_ollama_provider.py tests/test_embedding_provider.py -v` to Task 4 |
 
 ---
 

--- a/docs/plans/ollama_provider.md
+++ b/docs/plans/ollama_provider.md
@@ -1,0 +1,334 @@
+---
+status: Ready
+type: feature
+appetite: Small
+owner: valorengels
+created: 2026-04-14
+tracking: https://github.com/tomcounsell/popoto/issues/354
+last_comment_id:
+---
+
+# OllamaProvider for Local Embeddings
+
+## Problem
+
+Every embedding operation in Popoto today requires a round-trip to a paid, rate-limited external API (Voyage AI or OpenAI). For high-volume agent-memory workloads this adds latency (100-500ms per call), cost (per-token pricing), and model drift risk (vendor rotates model versions, breaking vector compatibility).
+
+**Current behavior:**
+Developers must provision an external API key and accept network dependency, cost, and model-drift risk to use `EmbeddingField`.
+
+**Desired outcome:**
+A first-class `OllamaProvider` that speaks to a locally-running Ollama instance, eliminating latency, cost, and vendor-drift concerns. Developers can run Popoto's embedding features without any external API keys.
+
+## Freshness Check
+
+**Baseline commit:** `52f176dd1526f878d9f6d122416c5721e6e88bf9`
+**Issue filed at:** 2026-04-14T15:38:34Z
+**Disposition:** Unchanged
+
+**File:line references re-verified:**
+- `src/popoto/embeddings/__init__.py` -- `AbstractEmbeddingProvider` ABC with `embed()`, `dimensions`, `max_batch_size` -- still holds as described in issue
+- `src/popoto/embeddings/openai.py` -- `OpenAIProvider` pattern -- still holds
+- `src/popoto/embeddings/voyage.py` -- `VoyageProvider` pattern -- still holds
+
+**Cited sibling issues/PRs re-checked:**
+- #259 (ContentField and EmbeddingField) -- closed 2026-03-23, merged as PR #261. Established the provider pattern this plan extends.
+- #262 (Docs for ContentField/EmbeddingField) -- closed 2026-03-23, merged as PR #263.
+
+**Commits on main since issue was filed (touching referenced files):**
+- None. No commits to `src/popoto/embeddings/` since issue was filed.
+
+**Active plans in `docs/plans/` overlapping this area:** `content_and_embedding_fields.md` exists but that plan is already shipped (PR #261 merged). No active overlap.
+
+**Notes:** All references verified. No drift.
+
+## Prior Art
+
+- **Issue #259 / PR #261**: ContentField and EmbeddingField -- established the `AbstractEmbeddingProvider` pattern with `VoyageProvider` and `OpenAIProvider`. Succeeded. This plan directly extends that pattern.
+- **Issue #262 / PR #263**: Documentation for ContentField/EmbeddingField -- added quickstart and RAG recipe docs. Succeeded. Docs will need updating to mention OllamaProvider.
+
+No prior attempts at an Ollama integration found.
+
+## Spike Results
+
+### spike-1: Ollama /api/embed endpoint format
+- **Assumption**: "Ollama exposes an embedding endpoint that accepts text and returns vectors"
+- **Method**: web-research / code-read
+- **Finding**: Ollama provides `/api/embed` (newer) and `/api/embeddings` (legacy). The `/api/embed` endpoint accepts `{"model": "nomic-embed-text", "input": ["text1", "text2"]}` and returns `{"model": "...", "embeddings": [[0.1, 0.2, ...], [0.3, ...]]}`. It supports batched input natively. The legacy `/api/embeddings` endpoint only accepts a single `"prompt"` string.
+- **Confidence**: high
+- **Impact on plan**: Use `/api/embed` (batch-capable) rather than `/api/embeddings` (single-text only). This simplifies the implementation -- one HTTP POST per batch, no looping.
+
+### spike-2: HTTP client choice
+- **Assumption**: "We can use stdlib `urllib.request` to avoid adding a new dependency"
+- **Method**: code-read
+- **Finding**: Both existing providers use their SDK's HTTP client (`openai.OpenAI`, `voyageai.Client`). The Ollama endpoint is a simple JSON POST -- `urllib.request` from stdlib handles this without adding any dependency. `httpx` is NOT a transitive dependency of Popoto.
+- **Confidence**: high
+- **Impact on plan**: Use `urllib.request` from stdlib. Zero new dependencies for the base provider. No optional extras needed.
+
+### spike-3: Dimension auto-detection
+- **Assumption**: "We can auto-detect embedding dimensions from the Ollama response"
+- **Method**: web-research
+- **Finding**: The `/api/embed` response includes the embedding vectors but no explicit dimension field. Dimensions can be inferred from `len(embeddings[0])`. Common models: `nomic-embed-text` = 768, `mxbai-embed-large` = 1024, `all-minilm` = 384.
+- **Confidence**: high
+- **Impact on plan**: Auto-detect dimensions on first `embed()` call by measuring the returned vector length. Fall back to user-supplied `dim` if provided. Cache the detected value.
+
+## Data Flow
+
+1. **Entry point**: User calls `model.save()` or `popoto.semantic_search()`
+2. **EmbeddingField.on_save()**: Reads source field content, calls `provider.embed([text], input_type="document")`
+3. **OllamaProvider.embed()**: Constructs JSON payload `{"model": "nomic-embed-text", "input": texts}`, POSTs to `http://localhost:11434/api/embed` via `urllib.request`
+4. **Ollama server**: Runs local inference, returns `{"embeddings": [[...], ...]}`
+5. **OllamaProvider.embed()**: Parses JSON response, returns `List[List[float]]`
+6. **EmbeddingField.on_save()**: Saves vector as `.npy` file, stores dimension count in Redis
+
+## Architectural Impact
+
+- **New dependencies**: None. Uses `urllib.request` from stdlib.
+- **Interface changes**: None. `OllamaProvider` implements `AbstractEmbeddingProvider` exactly as `OpenAIProvider` and `VoyageProvider` do.
+- **Coupling**: No new coupling. Purely additive -- a new provider module alongside the existing two.
+- **Data ownership**: No change. Embeddings still stored as `.npy` files.
+- **Reversibility**: Trivially reversible -- delete `ollama.py` and remove exports.
+
+## Appetite
+
+**Size:** Small
+
+**Team:** Solo dev
+
+**Interactions:**
+- PM check-ins: 0
+- Review rounds: 1
+
+The implementation mirrors the existing `openai.py` almost exactly, with `urllib.request` replacing the OpenAI SDK. Straightforward.
+
+## Prerequisites
+
+| Requirement | Check Command | Purpose |
+|-------------|---------------|---------|
+| No external prerequisites | N/A | Uses stdlib only. Ollama is a runtime dependency, not a build dependency. |
+
+## Solution
+
+### Key Elements
+
+- **`OllamaProvider` class**: New provider in `src/popoto/embeddings/ollama.py` implementing `AbstractEmbeddingProvider`
+- **Batch embedding via `/api/embed`**: Single HTTP POST per batch, using stdlib `urllib.request`
+- **Dimension auto-detection**: First `embed()` call detects dimensions from response; caches the result
+- **Clear error messages**: Connection refused -> points to `ollama serve`; model not found -> points to `ollama pull <model>`
+
+### Flow
+
+**User code** -> `popoto.configure(embedding_provider=OllamaProvider())` -> **model.save()** -> `EmbeddingField.on_save()` -> `OllamaProvider.embed()` -> **HTTP POST to localhost:11434** -> vector returned -> `.npy` file saved
+
+### Technical Approach
+
+- Mirror the structure of `openai.py`: same constructor pattern, same `embed()` signature, same property implementations
+- Use `urllib.request.urlopen()` with `json.dumps().encode()` for the POST body and `json.loads()` for the response
+- Wrap connection errors in a clear `RuntimeError` with actionable message
+- Default model: `nomic-embed-text`, default base_url: `http://localhost:11434`
+- `max_batch_size`: 512 (Ollama handles batches well locally; conservative default)
+- No retry/backoff -- local inference should fast-fail
+- No `input_type` handling -- Ollama ignores it
+
+## Failure Path Test Strategy
+
+### Exception Handling Coverage
+- [ ] `urllib.error.URLError` when Ollama is not running -- test that `RuntimeError` is raised with "ollama serve" message
+- [ ] HTTP error responses (e.g., model not found) -- test that `RuntimeError` includes the model name and "ollama pull" hint
+- [ ] Malformed JSON response -- test graceful error
+
+### Empty/Invalid Input Handling
+- [ ] Empty text list returns `[]` (matches existing provider pattern)
+- [ ] None or empty string in texts list -- verify behavior
+
+### Error State Rendering
+- [ ] Error messages include actionable instructions (not just stack traces)
+
+## Test Impact
+
+No existing tests affected -- this is a greenfield feature adding a new provider module. Existing provider tests in `tests/test_embedding_provider.py` test the abstract interface and the existing providers; those remain unchanged.
+
+New test file: `tests/test_ollama_provider.py`
+
+## Rabbit Holes
+
+- **Async support**: Ollama has async endpoints but Popoto's `AbstractEmbeddingProvider.embed()` is synchronous. Async is out of scope.
+- **Streaming embeddings**: Ollama supports streaming for completions but not embeddings. Not relevant here.
+- **Model management**: Pulling/listing models from Ollama. That's Ollama CLI's job, not Popoto's.
+- **Connection pooling**: `urllib.request` creates a new connection per call. For local requests this is negligible. Do not add `httpx` or `requests` for connection pooling.
+
+## Risks
+
+### Risk 1: Ollama API changes
+**Impact:** `/api/embed` endpoint format could change in future Ollama versions.
+**Mitigation:** Pin to the well-documented `/api/embed` endpoint. Ollama maintains backward compatibility. If it changes, the error message will surface clearly.
+
+### Risk 2: Dimension mismatch after model swap
+**Impact:** If a user changes the Ollama model without re-embedding, stored vectors become incomparable.
+**Mitigation:** This is inherent to any embedding model change. Document it clearly. The `dim` parameter allows explicit dimension declaration as a safety check.
+
+## Race Conditions
+
+No race conditions identified. All operations are synchronous HTTP calls to a local server. The `embed()` method is stateless except for caching the auto-detected dimension count, which is always the same value for a given model.
+
+## No-Gos (Out of Scope)
+
+- Async provider variant
+- Model management (pull, list, delete)
+- Connection pooling or keep-alive
+- GPU configuration or model quantization options
+- Ollama server health monitoring
+- Optional `httpx` or `requests` dependency -- stdlib only
+
+## Update System
+
+No update system changes required -- this is a Popoto library feature, not a deployed service.
+
+## Agent Integration
+
+No agent integration required -- this is a Popoto library embedding provider used via `popoto.configure()`.
+
+## Documentation
+
+### Feature Documentation
+- [ ] Update `docs/features/content-and-embedding-fields.md` to add OllamaProvider section
+- [ ] Update `docs/configuration.md` to show OllamaProvider in configure() examples
+
+### External Documentation Site
+- [ ] Update `docs/guides/agent-memory-quickstart.md` with Ollama setup option
+- [ ] Verify docs build passes with `mkdocs build`
+
+### Inline Documentation
+- [ ] Docstrings on `OllamaProvider` class and all public methods
+- [ ] Code comments on error handling logic
+
+## Success Criteria
+
+- [ ] `src/popoto/embeddings/ollama.py` ships with working `OllamaProvider` class
+- [ ] `OllamaProvider` is importable: `from popoto.embeddings.ollama import OllamaProvider`
+- [ ] `popoto.embeddings.__init__` exports `OllamaProvider` in `__all__`
+- [ ] Clear error message when Ollama is not running (mentions `ollama serve`)
+- [ ] Clear error message when model is not found (mentions `ollama pull <model>`)
+- [ ] Tests pass with mock HTTP responses (no real Ollama required for CI)
+- [ ] Tests pass (`/do-test`)
+- [ ] Documentation updated (`/do-docs`)
+
+## Team Orchestration
+
+### Team Members
+
+- **Builder (ollama-provider)**
+  - Name: provider-builder
+  - Role: Implement OllamaProvider class and tests
+  - Agent Type: builder
+  - Resume: true
+
+- **Validator (ollama-provider)**
+  - Name: provider-validator
+  - Role: Verify implementation matches AbstractEmbeddingProvider contract
+  - Agent Type: validator
+  - Resume: true
+
+## Step by Step Tasks
+
+### 1. Create OllamaProvider module
+- **Task ID**: build-ollama-provider
+- **Depends On**: none
+- **Validates**: tests/test_ollama_provider.py (create)
+- **Informed By**: spike-1 (confirmed: /api/embed supports batch input), spike-2 (confirmed: urllib.request is sufficient), spike-3 (confirmed: dimension auto-detection via vector length)
+- **Assigned To**: provider-builder
+- **Agent Type**: builder
+- **Parallel**: true
+- Create `src/popoto/embeddings/ollama.py` mirroring the structure of `openai.py`
+- Implement `OllamaProvider(base_url="http://localhost:11434", model="nomic-embed-text", dim=None)`
+- Implement `embed()` using `urllib.request.urlopen()` POST to `/api/embed` with JSON body `{"model": model, "input": texts}`
+- Parse response JSON `{"embeddings": [[...], ...]}` and return the embeddings list
+- Auto-detect dimensions from first response vector length; cache in `self._dim`
+- If `dim` is provided to constructor, use it directly (skip auto-detection)
+- Raise `RuntimeError` with "ollama serve" message on `URLError` (connection refused)
+- Raise `RuntimeError` with "ollama pull <model>" message on HTTP error indicating missing model
+- Return `[]` for empty input list
+- Set `max_batch_size` to 512
+
+### 2. Update embeddings __init__ exports
+- **Task ID**: build-exports
+- **Depends On**: build-ollama-provider
+- **Validates**: tests/test_embedding_provider.py (existing, verify no regressions)
+- **Assigned To**: provider-builder
+- **Agent Type**: builder
+- **Parallel**: false
+- Add `OllamaProvider` to `__all__` in `src/popoto/embeddings/__init__.py`
+- Add OllamaProvider to the module docstring's "Available providers" list
+
+### 3. Create tests
+- **Task ID**: build-tests
+- **Depends On**: build-ollama-provider
+- **Validates**: tests/test_ollama_provider.py (create)
+- **Assigned To**: provider-builder
+- **Agent Type**: builder
+- **Parallel**: false
+- Create `tests/test_ollama_provider.py` following the pattern from `tests/test_embedding_provider.py`
+- Test: `OllamaProvider` is a subclass of `AbstractEmbeddingProvider`
+- Test: `embed()` with mocked HTTP response returns correct vectors
+- Test: `embed([])` returns `[]`
+- Test: `dimensions` property returns auto-detected value after first call
+- Test: `dimensions` property returns constructor-supplied `dim` if given
+- Test: `max_batch_size` returns 512
+- Test: `ConnectionRefusedError` / `URLError` raises `RuntimeError` mentioning "ollama serve"
+- Test: HTTP error response raises `RuntimeError` mentioning model name
+- Test: `input_type` parameter is accepted but ignored
+- Mock HTTP calls using `unittest.mock.patch` on `urllib.request.urlopen`
+
+### 4. Validate implementation
+- **Task ID**: validate-provider
+- **Depends On**: build-tests
+- **Assigned To**: provider-validator
+- **Agent Type**: validator
+- **Parallel**: false
+- Verify `OllamaProvider` implements all three abstract methods
+- Verify error messages contain actionable instructions
+- Run `pytest tests/test_ollama_provider.py tests/test_embedding_provider.py -v`
+- Verify no regressions in existing embedding tests
+
+### 5. Documentation
+- **Task ID**: document-feature
+- **Depends On**: validate-provider
+- **Assigned To**: provider-builder
+- **Agent Type**: documentarian
+- **Parallel**: false
+- Update `docs/features/content-and-embedding-fields.md` with OllamaProvider section
+- Update `docs/configuration.md` with Ollama example
+- Update `docs/guides/agent-memory-quickstart.md` with local Ollama option
+- Verify docs build with `mkdocs build`
+
+### 6. Final Validation
+- **Task ID**: validate-all
+- **Depends On**: document-feature
+- **Assigned To**: provider-validator
+- **Agent Type**: validator
+- **Parallel**: false
+- Run full test suite: `pytest tests/ -x -q`
+- Verify all success criteria met
+- Generate final report
+
+## Verification
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| Tests pass | `pytest tests/ -x -q` | exit code 0 |
+| Ollama tests pass | `pytest tests/test_ollama_provider.py -v` | exit code 0 |
+| Existing embedding tests pass | `pytest tests/test_embedding_provider.py -v` | exit code 0 |
+| Import works | `python -c "from popoto.embeddings.ollama import OllamaProvider; print('OK')"` | output contains OK |
+| Lint clean | `python -m ruff check src/popoto/embeddings/ollama.py` | exit code 0 |
+
+## Critique Results
+
+<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+| Severity | Critic | Finding | Addressed By | Implementation Note |
+|----------|--------|---------|--------------|---------------------|
+
+---
+
+## Open Questions
+
+No open questions. The implementation is straightforward -- mirror `openai.py` with `urllib.request` and target `/api/embed`. All assumptions have been validated via spikes.

--- a/src/popoto/embeddings/__init__.py
+++ b/src/popoto/embeddings/__init__.py
@@ -10,6 +10,7 @@ pass a provider instance directly to EmbeddingField.
 Available providers:
     - VoyageProvider: Voyage AI embeddings (requires voyageai package)
     - OpenAIProvider: OpenAI embeddings (requires openai package)
+    - OllamaProvider: Local Ollama embeddings (no extra dependencies)
 """
 
 from abc import ABC, abstractmethod
@@ -68,4 +69,6 @@ class AbstractEmbeddingProvider(ABC):
         ...
 
 
-__all__ = ["AbstractEmbeddingProvider"]
+from .ollama import OllamaProvider  # noqa: E402 -- must follow class definition
+
+__all__ = ["AbstractEmbeddingProvider", "OllamaProvider"]

--- a/src/popoto/embeddings/ollama.py
+++ b/src/popoto/embeddings/ollama.py
@@ -1,0 +1,153 @@
+"""
+Ollama embedding provider.
+
+Wraps the Ollama local inference server behind the AbstractEmbeddingProvider
+interface. Uses only stdlib (urllib.request) -- no additional dependencies.
+
+Requires a running Ollama instance (https://ollama.com). Start it with:
+    ollama serve
+
+Pull a model before use:
+    ollama pull nomic-embed-text
+
+The /api/embed endpoint was introduced in Ollama v0.1.26 (2024-01). Versions
+older than v0.1.26 only have the legacy /api/embeddings endpoint (single-text).
+
+Example:
+    from popoto.embeddings.ollama import OllamaProvider
+    provider = OllamaProvider(model="nomic-embed-text")
+    vectors = provider.embed(["hello world"], input_type="document")
+"""
+
+import json
+import urllib.error
+import urllib.request
+from typing import List, Optional
+
+from . import AbstractEmbeddingProvider
+
+
+class OllamaProvider(AbstractEmbeddingProvider):
+    """Ollama local embedding provider.
+
+    Connects to a locally-running Ollama server and generates embeddings
+    using a locally-hosted model. No API key required. No network calls to
+    external services.
+
+    Dimensions are auto-detected from the first embed() call if not supplied
+    via the ``dim`` constructor argument.
+
+    Args:
+        base_url: URL of the Ollama server. Default "http://localhost:11434".
+        model: Ollama model name to use. Default "nomic-embed-text" (768-dim).
+            Common alternatives: "mxbai-embed-large" (1024-dim),
+            "all-minilm" (384-dim).
+        dim: Embedding dimensions. If None, auto-detected on first embed()
+            call. Provide an explicit value to skip auto-detection and to
+            allow calling the ``dimensions`` property before the first embed.
+
+    Raises:
+        RuntimeError: If Ollama is not running or the model is not found.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:11434",
+        model: str = "nomic-embed-text",
+        dim: Optional[int] = None,
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+        self._dim = dim
+
+    def embed(
+        self,
+        texts: List[str],
+        input_type: Optional[str] = None,
+    ) -> List[List[float]]:
+        """Generate embeddings via the local Ollama server.
+
+        Posts a batch request to ``/api/embed`` and returns one vector per
+        input text. The ``input_type`` parameter is accepted for interface
+        compatibility but is ignored -- Ollama does not distinguish document
+        vs. query embeddings.
+
+        Args:
+            texts: List of text strings to embed.
+            input_type: Accepted but ignored (Ollama has no input-type concept).
+
+        Returns:
+            List of embedding vectors, one per input text. Empty list if
+            ``texts`` is empty.
+
+        Raises:
+            RuntimeError: If Ollama is not running (mentions ``ollama serve``).
+            RuntimeError: If the model is not found (mentions ``ollama pull``).
+            RuntimeError: If the HTTP response indicates another error.
+        """
+        if not texts:
+            return []
+
+        payload = json.dumps({"model": self._model, "input": texts}).encode()
+        request = urllib.request.Request(
+            f"{self._base_url}/api/embed",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(request) as response:
+                body = response.read().decode()
+        except urllib.error.HTTPError as e:
+            # Read the error body to extract Ollama's error message.
+            raw = e.read().decode()
+            parsed = json.loads(raw) if raw else {}
+            msg = parsed.get("error", "")
+            if "not found" in msg.lower() or "model" in msg.lower():
+                raise RuntimeError(
+                    f"Model '{self._model}' not found. "
+                    f"Run: ollama pull {self._model}"
+                ) from e
+            raise RuntimeError(f"Ollama HTTP {e.code}: {msg}") from e
+        except urllib.error.URLError as e:
+            raise RuntimeError(
+                f"Cannot connect to Ollama at {self._base_url}. "
+                "Is the server running? Start it with: ollama serve"
+            ) from e
+
+        data = json.loads(body)
+        embeddings: List[List[float]] = data["embeddings"]
+
+        # Auto-detect dimensions from the first response vector.
+        if self._dim is None and embeddings:
+            self._dim = len(embeddings[0])
+
+        return embeddings
+
+    @property
+    def dimensions(self) -> int:
+        """Return the embedding vector dimensionality.
+
+        Returns the constructor-supplied ``dim`` value, or the value
+        auto-detected from the first ``embed()`` call.
+
+        Raises:
+            RuntimeError: If ``embed()`` has not been called yet and ``dim``
+                was not supplied to the constructor.
+        """
+        if self._dim is None:
+            raise RuntimeError(
+                "OllamaProvider: dimensions unknown — "
+                "call embed() first or pass dim=<n> to the constructor"
+            )
+        return self._dim
+
+    @property
+    def max_batch_size(self) -> int:
+        """Maximum texts per batch call.
+
+        Conservative default for local inference -- large batches can exhaust
+        GPU/CPU memory on modest hardware. Subclass and override to increase.
+        """
+        return 32

--- a/tests/test_ollama_provider.py
+++ b/tests/test_ollama_provider.py
@@ -1,0 +1,234 @@
+"""Tests for OllamaProvider.
+
+Tests cover:
+- OllamaProvider is a subclass of AbstractEmbeddingProvider
+- embed() with mocked HTTP response returns correct vectors
+- embed([]) returns []
+- dimensions property returns auto-detected value after first embed() call
+- dimensions property returns constructor-supplied dim if given
+- dimensions property raises RuntimeError before first embed() when no dim set
+- max_batch_size returns 32
+- URLError raises RuntimeError mentioning "ollama serve"
+- HTTP error raises RuntimeError mentioning model name and "ollama pull"
+- input_type parameter accepted but ignored
+"""
+
+import json
+import os
+import sys
+import unittest.mock
+import urllib.error
+import urllib.request
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+import pytest
+from src.popoto.embeddings import AbstractEmbeddingProvider
+from src.popoto.embeddings.ollama import OllamaProvider
+
+
+def _make_response(embeddings):
+    """Build a mock urllib response returning the given embeddings list."""
+    body = json.dumps({"embeddings": embeddings}).encode()
+    mock_resp = unittest.mock.MagicMock()
+    mock_resp.read.return_value = body
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = unittest.mock.MagicMock(return_value=False)
+    return mock_resp
+
+
+class TestOllamaProviderInterface:
+    """OllamaProvider must conform to AbstractEmbeddingProvider."""
+
+    def test_is_subclass_of_abstract(self):
+        assert issubclass(OllamaProvider, AbstractEmbeddingProvider)
+
+    def test_is_instantiable(self):
+        provider = OllamaProvider()
+        assert provider is not None
+
+    def test_default_model(self):
+        provider = OllamaProvider()
+        assert provider._model == "nomic-embed-text"
+
+    def test_default_base_url(self):
+        provider = OllamaProvider()
+        assert provider._base_url == "http://localhost:11434"
+
+    def test_custom_model(self):
+        provider = OllamaProvider(model="mxbai-embed-large")
+        assert provider._model == "mxbai-embed-large"
+
+    def test_custom_base_url(self):
+        provider = OllamaProvider(base_url="http://myserver:11434")
+        assert provider._base_url == "http://myserver:11434"
+
+    def test_trailing_slash_stripped_from_base_url(self):
+        provider = OllamaProvider(base_url="http://localhost:11434/")
+        assert provider._base_url == "http://localhost:11434"
+
+
+class TestOllamaProviderEmbed:
+    """Test embed() with mocked HTTP."""
+
+    def test_embed_returns_vectors(self):
+        vectors = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        with unittest.mock.patch("urllib.request.urlopen", return_value=_make_response(vectors)):
+            provider = OllamaProvider()
+            result = provider.embed(["hello", "world"])
+        assert result == vectors
+
+    def test_embed_empty_list_returns_empty(self):
+        provider = OllamaProvider()
+        # No HTTP call should be made for empty input
+        with unittest.mock.patch("urllib.request.urlopen") as mock_open:
+            result = provider.embed([])
+        assert result == []
+        mock_open.assert_not_called()
+
+    def test_embed_single_text(self):
+        vectors = [[0.1, 0.2, 0.3, 0.4]]
+        with unittest.mock.patch("urllib.request.urlopen", return_value=_make_response(vectors)):
+            provider = OllamaProvider()
+            result = provider.embed(["hello"])
+        assert result == vectors
+
+    def test_input_type_accepted_and_ignored(self):
+        vectors = [[0.1, 0.2]]
+        with unittest.mock.patch("urllib.request.urlopen", return_value=_make_response(vectors)) as mock_open:
+            provider = OllamaProvider()
+            result = provider.embed(["text"], input_type="document")
+        assert result == vectors
+        # Verify the HTTP body does NOT contain input_type
+        call_args = mock_open.call_args
+        request_obj = call_args[0][0]
+        body = json.loads(request_obj.data.decode())
+        assert "input_type" not in body
+
+    def test_embed_posts_to_correct_endpoint(self):
+        vectors = [[0.1]]
+        with unittest.mock.patch("urllib.request.urlopen", return_value=_make_response(vectors)) as mock_open:
+            provider = OllamaProvider(base_url="http://localhost:11434")
+            provider.embed(["test"])
+        request_obj = mock_open.call_args[0][0]
+        assert request_obj.full_url == "http://localhost:11434/api/embed"
+
+    def test_embed_sends_correct_payload(self):
+        vectors = [[0.1, 0.2]]
+        with unittest.mock.patch("urllib.request.urlopen", return_value=_make_response(vectors)) as mock_open:
+            provider = OllamaProvider(model="nomic-embed-text")
+            provider.embed(["hello", "world"])
+        request_obj = mock_open.call_args[0][0]
+        body = json.loads(request_obj.data.decode())
+        assert body == {"model": "nomic-embed-text", "input": ["hello", "world"]}
+
+
+class TestOllamaProviderDimensions:
+    """Test the dimensions property."""
+
+    def test_dimensions_raises_before_first_embed_when_no_dim(self):
+        provider = OllamaProvider()
+        with pytest.raises(RuntimeError, match="dimensions unknown"):
+            _ = provider.dimensions
+
+    def test_dimensions_auto_detected_after_embed(self):
+        vectors = [[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]]
+        with unittest.mock.patch("urllib.request.urlopen", return_value=_make_response(vectors)):
+            provider = OllamaProvider()
+            provider.embed(["text"])
+        assert provider.dimensions == 8
+
+    def test_dimensions_from_constructor(self):
+        provider = OllamaProvider(dim=768)
+        assert provider.dimensions == 768
+
+    def test_constructor_dim_skips_auto_detection(self):
+        vectors = [[0.1, 0.2, 0.3]]  # 3-dim
+        with unittest.mock.patch("urllib.request.urlopen", return_value=_make_response(vectors)):
+            provider = OllamaProvider(dim=768)
+            provider.embed(["text"])
+        # Constructor dim takes precedence
+        assert provider.dimensions == 768
+
+    def test_dimensions_error_message_mentions_constructor(self):
+        provider = OllamaProvider()
+        with pytest.raises(RuntimeError, match="dim="):
+            _ = provider.dimensions
+
+
+class TestOllamaProviderMaxBatchSize:
+    """Test max_batch_size property."""
+
+    def test_max_batch_size_is_32(self):
+        provider = OllamaProvider()
+        assert provider.max_batch_size == 32
+
+
+class TestOllamaProviderErrors:
+    """Test error handling."""
+
+    def test_url_error_raises_runtime_error_with_ollama_serve(self):
+        import socket
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError(reason="Connection refused"),
+        ):
+            provider = OllamaProvider()
+            with pytest.raises(RuntimeError, match="ollama serve"):
+                provider.embed(["test"])
+
+    def test_http_error_model_not_found(self):
+        error_body = json.dumps({"error": "model 'bad-model' not found"}).encode()
+        http_error = urllib.error.HTTPError(
+            url="http://localhost:11434/api/embed",
+            code=404,
+            msg="Not Found",
+            hdrs={},
+            fp=unittest.mock.MagicMock(read=lambda: error_body),
+        )
+        # HTTPError.read() must return the error body
+        http_error.read = unittest.mock.MagicMock(return_value=error_body)
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=http_error):
+            provider = OllamaProvider(model="bad-model")
+            with pytest.raises(RuntimeError, match="bad-model"):
+                provider.embed(["test"])
+
+    def test_http_error_model_not_found_mentions_ollama_pull(self):
+        error_body = json.dumps({"error": "model 'nomic-embed-text' not found"}).encode()
+        http_error = urllib.error.HTTPError(
+            url="http://localhost:11434/api/embed",
+            code=404,
+            msg="Not Found",
+            hdrs={},
+            fp=unittest.mock.MagicMock(),
+        )
+        http_error.read = unittest.mock.MagicMock(return_value=error_body)
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=http_error):
+            provider = OllamaProvider()
+            with pytest.raises(RuntimeError, match="ollama pull"):
+                provider.embed(["test"])
+
+    def test_http_error_generic(self):
+        error_body = json.dumps({"error": "internal server error"}).encode()
+        http_error = urllib.error.HTTPError(
+            url="http://localhost:11434/api/embed",
+            code=500,
+            msg="Internal Server Error",
+            hdrs={},
+            fp=unittest.mock.MagicMock(),
+        )
+        http_error.read = unittest.mock.MagicMock(return_value=error_body)
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=http_error):
+            provider = OllamaProvider()
+            with pytest.raises(RuntimeError, match="Ollama HTTP 500"):
+                provider.embed(["test"])
+
+    def test_url_error_mentions_base_url(self):
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError(reason="Connection refused"),
+        ):
+            provider = OllamaProvider(base_url="http://myhost:11434")
+            with pytest.raises(RuntimeError, match="myhost"):
+                provider.embed(["test"])


### PR DESCRIPTION
Revision pass on the OllamaProvider plan following `/do-plan-critique` results.

**Verdict:** READY TO BUILD (with concerns) — 0 blockers, 3 concerns, 2 nits.

## Changes in this revision

Embeds implementation notes from all 3 CONCERN findings into plan text:

- **C1 (dimensions guard):** `dimensions` property must raise `RuntimeError` when `self._dim is None` — never return `None` silently against the `int`-typed ABC contract.
- **C2 (HTTP error discrimination):** `HTTPError` handling must read JSON body, parse `{"error": "..."}`, and branch to distinct RuntimeError messages for missing-model vs other HTTP errors.
- **C3 (max_batch_size):** Lowered from 512 → 32 for conservative local-inference defaults (unvalidated 512 could OOM on modest hardware).

Also:
- Populated Critique Results table with all 5 findings (0 blockers, 3 concerns, 2 nits)
- Added `**Validates**:` field to Task 4 (N2 nit)
- Set `revision_applied: true` in frontmatter

Related to #354