### PR TITLE
Mark apply-experiment-learnings plan complete

### DIFF
--- a/docs/plans/apply_experiment_learnings.md
+++ b/docs/plans/apply_experiment_learnings.md
@@ -1,5 +1,5 @@
 ---
-status: docs_complete
+status: complete
 type: chore
 appetite: Medium
 owner: Valor Engels
@@ -9,6 +9,7 @@ last_comment_id:
 revision_applied: true
 revision_date: 2026-04-17
 docs_complete_date: 2026-04-17
+allow_unchecked: true
 ---
 
 # Apply experiment learnings: fix overrides, ground truth, and update constants
@@ -249,14 +250,14 @@ No agent integration required — Popoto is a library consumed by other projects
 
 ## Success Criteria
 
-- [ ] `tests/benchmarks/test_overrides_reach.py::test_all_constants_patchable` passes for all 19 constants.
-- [ ] `WriteFilterMixin` and `PredictionLedgerMixin` reads of `Defaults.*` happen at method-call / attribute-access time, not class-definition time.
-- [ ] Family-factory scenarios define ground truth from a signal distinct from the retrieval signal. Each scenario has a code comment explaining which signal drives ground truth and which drives retrieval.
-- [ ] A `--parametric` sweep produces nDCG@5 variance > 0.05 for at least 5 constants.
-- [ ] `src/popoto/fields/constants.py` has best-value updates for every sensitive constant, each annotated with the sweep date.
-- [ ] Inert constants have inline `# empirically inert (sweep YYYY-MM-DD)` comments.
-- [ ] `latest.json` symlink points to the newest sweep JSON (should already; verify).
-- [ ] `pytest` passes with no regressions after constant changes.
+- [x] `tests/benchmarks/test_overrides_reach.py::test_all_constants_patchable` passes for all 19 constants. *(30 override-reach tests passing in PR #361.)*
+- [x] `WriteFilterMixin` and `PredictionLedgerMixin` reads of `Defaults.*` happen at method-call / attribute-access time, not class-definition time. *(Converted to `@property` in PR #361.)*
+- [x] Family-factory scenarios define ground truth from a signal distinct from the retrieval signal. Each scenario has a code comment explaining which signal drives ground truth and which drives retrieval. *(B1/B2/C1/C4 applied in PR #361; 4 family sanity tests passing.)*
+- [ ] A `--parametric` sweep produces nDCG@5 variance > 0.05 for at least 5 constants. *(4/5 achieved — PredictionLedger/PolicyCache/ContextAssembler gap explicitly tracked in follow-up issue #362.)*
+- [x] `src/popoto/fields/constants.py` has best-value updates for every sensitive constant, each annotated with the sweep date. *(`DECAY_RATE` 0.5→0.1, `WF_MIN_THRESHOLD` 0.2→0.1 from sweep 2026-04-17.)*
+- [x] Inert constants have inline `# empirically inert (sweep YYYY-MM-DD)` comments. *(22 constants annotated in PR #361.)*
+- [x] `latest.json` symlink points to the newest sweep JSON (should already; verify). *(Repointed to `sweep_20260417_141047.json` during patch cycle.)*
+- [x] `pytest` passes with no regressions after constant changes. *(1510 passed / 14 skipped on session branch.)*
 - [x] Tests pass (`/do-test`). *(Full suite 1510 passed, 14 skipped; override-reach 30 passed; family ground-truth decoupling 4 passed — verified on PR #361.)*
 - [x] Documentation updated (`/do-docs`). *(Plan doc cross-links, inline constant comments, `apply_overrides` docstring, and user-facing reference doc cascade all shipped in PR #361 docs stage.)*
 


### PR DESCRIPTION
## Summary
- Tick 7 Success Criteria boxes on the plan — all delivered by PR #361
- Leave criterion 4 unchecked (4/5 constants variance target) — gap explicitly tracked in follow-up #362
- Add `allow_unchecked: true` to frontmatter to clear the merge gate on #361

## Context
PR #361 delivered all phases of the plan. Reviewer approved the 4/5 sensitivity gap because completing criterion 4 requires new family scenarios explicitly out-of-scope per the plan's C2 rollback. Follow-up issue #362 captures the remaining work.

## Test plan
- [x] Plan frontmatter parses as YAML