### PR TITLE
Test: pre-release edge cases for assess, adaptive assembler, error_summary grouping

### DIFF
--- a/src/popoto/fields/prediction_ledger.py
+++ b/src/popoto/fields/prediction_ledger.py
@@ -602,6 +602,11 @@ class PredictionLedgerMixin:
             )
 
         if not raw_results:
+            # When group_by is provided, an empty set produces no groups — return {}
+            # rather than {"__all__": ...}, which would be semantically misleading
+            # (the caller expects per-group keys, not the ungrouped sentinel).
+            if group_by is not None:
+                return {}
             return {"__all__": cls._stats_for([])}
 
         # Decode members to strings and build a list of (member_key, error)

--- a/tests/test_adaptive_assembler.py
+++ b/tests/test_adaptive_assembler.py
@@ -379,3 +379,33 @@ class TestAdaptiveAssemblerIntegration:
             f"improvements={improvements} mean={mean_imp:.4f} stdev={std_imp:.4f} "
             f"runs_above_5pct={runs_above_5pct}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveAssemblerEdgeCases:
+    def test_inner_exception_does_not_corrupt_window_state(self):
+        """If inner.assemble() raises, window state must be unchanged (no partial append)."""
+        # Build a mock inner that raises RuntimeError on every call.
+        from unittest.mock import MagicMock
+
+        inner = MagicMock(spec=ContextAssembler)
+        inner.score_weights = {"relevance": 0.6, "confidence": 0.4}
+        inner.assemble.side_effect = RuntimeError("inner failure")
+
+        adaptive = AdaptiveAssembler(
+            inner=inner,
+            window_size=3,
+            rng=random.Random(0),
+        )
+
+        # The exception must propagate — inner exceptions are not quality_metric
+        # exceptions and must NOT be swallowed.
+        with pytest.raises(RuntimeError, match="inner failure"):
+            adaptive.assemble(query_cues={"topic": "x"})
+
+        # No partial append happened before the raise — window state is clean.
+        assert len(adaptive._current_window) == 0

--- a/tests/test_context_assembler.py
+++ b/tests/test_context_assembler.py
@@ -631,3 +631,40 @@ class TestRetrievalQuality:
         assert s
         assert "RetrievalQuality" in s
         assert "fok_score=0.7" in s
+
+
+# ---------------------------------------------------------------------------
+# TestAssessWithNoSavedMemories
+# ---------------------------------------------------------------------------
+
+
+class AssessEmptyMemory(Model):
+    """Minimal model with ConfidenceField and ExistenceFilter — no records saved."""
+
+    memory_id = AutoKeyField()
+    agent_id = KeyField()
+    topic = Field(type=str)
+    confidence = ConfidenceField(initial_confidence=0.5)
+    bloom = ExistenceFilter(
+        error_rate=0.01,
+        capacity=10_000,
+        fingerprint_fn=lambda inst: inst.topic,
+    )
+
+
+class TestAssessWithNoSavedMemories:
+    def test_assess_with_empty_db_returns_zero_quality(self):
+        """assess() with a freshly populated model class (no saved records) must not raise."""
+        assembler = ContextAssembler(
+            model_class=AssessEmptyMemory,
+            score_weights={"confidence": 1.0},
+        )
+
+        result = assembler.assess(query_cues={"topic": "anything"})
+
+        # Must return a RetrievalQuality without raising
+        assert isinstance(result, RetrievalQuality)
+        # With ExistenceFilter on an empty DB, definitely_missing=True for all cues.
+        # The early-return path returns avg_confidence=0.5 when ConfidenceField is
+        # present (neutral sentinel: no evidence against, but also none for).
+        assert result.avg_confidence == 0.5

--- a/tests/test_prediction_ledger.py
+++ b/tests/test_prediction_ledger.py
@@ -923,3 +923,12 @@ class TestErrorSummary:
         self._seed_errors(n=6)
         result = PredictionLedgerMixin.error_summary(PredictionItem, limit=3)
         assert result["__all__"]["count"] == 3
+
+    def test_error_summary_group_by_with_empty_errors_returns_empty_groups(self):
+        """error_summary(group_by=...) with zero recorded errors returns {} not {"__all__": ...}."""
+        # No predictions recorded — error set is empty.
+        result = PredictionLedgerMixin.error_summary(PredictionItem, group_by="hour")
+        # When group_by is specified and there are no errors, the correct
+        # return is an empty grouped dict {}, not {"__all__": {count: 0, ...}}.
+        # The "__all__" sentinel belongs to the ungrouped (group_by=None) path only.
+        assert result == {}


### PR DESCRIPTION
## Summary

- Pins `assess()` behavior on an empty DB: with `ExistenceFilter` and `ConfidenceField` installed, a freshly populated model with no saved records returns `RetrievalQuality(avg_confidence=0.5)` via the early-return path — no raise.
- Pins `AdaptiveAssembler` window-state invariant: when `inner.assemble()` raises, the exception propagates and `_current_window` remains empty (no partial append).
- Fixes `error_summary(group_by=...)` early-return: when the error set is empty and `group_by` is not `None`, the function now returns `{}` instead of `{"__all__": {count: 0, ...}}`. The `"__all__"` sentinel belongs to the ungrouped path only.

## Production code changed

`src/popoto/fields/prediction_ledger.py` — `error_summary()` early-return guard:

```python
# Before (semantic surprise — returns "__all__" even when caller asked for groups):
if not raw_results:
    return {"__all__": cls._stats_for([])}

# After (correct — returns empty grouped dict when group_by is set):
if not raw_results:
    if group_by is not None:
        return {}
    return {"__all__": cls._stats_for([])}
```

## Test plan

- [x] `TestAssessWithNoSavedMemories::test_assess_with_empty_db_returns_zero_quality` — passes
- [x] `TestAdaptiveAssemblerEdgeCases::test_inner_exception_does_not_corrupt_window_state` — passes
- [x] `TestErrorSummary::test_error_summary_group_by_with_empty_errors_returns_empty_groups` — passes
- [x] Full suite for all three changed test files: 113 passed
- [x] Ruff check and format: clean