### PR TITLE
DX: integration feedback items from #370

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,19 @@ Agents using `ContextAssembler` can now ask "how much should I trust this contex
 
 - `PredictionLedgerMixin.error_summary(group_by=...)` returned `{"__all__": ...}` instead of `{}` when called on a model with zero recorded predictions and a non-`None` `group_by`
 
+#### Migration
+
+If you were using a custom `"echoed"` outcome (or any application-specific
+label semantically between `"used"` and `"dismissed"`):
+
+- Map it to `"used"` if the agent reasoned over the memory (staged read
+  should be confirmed; prediction auto-resolves with moderate error).
+- Map it to `"dismissed"` if the overlap was purely coincidental keyword
+  match (staged read discarded; confidence/cycle weakened).
+
+`on_context_used()` raises `ValueError` on unknown outcome labels — coerce
+to a valid value before calling.
+
 #### Notes
 
 - All metacognitive features are **opt-in** and additive — existing `ContextAssembler` API is unchanged

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,6 +16,19 @@ from popoto import ModelException, KeyMutationError, QueryException, PublisherEx
 
 ---
 
+## Version introspection
+
+`popoto.__version__` resolves to the installed distribution's version string via `importlib.metadata` (PEP 566). `pyproject.toml` is the single source of truth — the package exposes whatever release-please wrote to `[project].version`. When importing from an uninstalled source tree, `__version__` falls back to the PEP 440-compliant sentinel `"0.0.0+unknown"`.
+
+```python
+import popoto
+print(popoto.__version__)  # e.g. "1.6.0"
+```
+
+No separate `VERSION` file, no static string in `__init__.py` — so there is no risk of version skew between the code on disk and the version reported at runtime.
+
+---
+
 ## Model Class
 
 `popoto.Model` is the base class for all Popoto models. Define public attributes as `Field` instances.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1514,7 +1514,7 @@ Fire when application reports how agent responded to surfaced memories. Applies 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `instances` | `list` | Model instances that were in the agent's context. |
-| `outcome_map` | `dict` | Maps instance Redis keys to outcomes: `"acted"`, `"dismissed"`, `"deferred"`, `"contradicted"`. Instances not in the map default to `"deferred"`. |
+| `outcome_map` | `dict` | Maps instance Redis keys to outcomes: `"acted"`, `"used"`, `"dismissed"`, `"deferred"`, `"contradicted"`. Instances not in the map default to `"deferred"`. |
 | `pipeline` | `redis.client.Pipeline` | Optional pipeline for batching. |
 
 **Raises:** `ValueError` if any outcome string is not valid.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1959,6 +1959,22 @@ Dataclass returned by `ContextAssembler.assess()` and attached to `AssemblyResul
 | `score_distribution` | `list[float]` | Full list of per-record composite scores. Empty when unavailable. |
 | `per_cue_fok` | `dict` | Maps cue value → `{cue_familiarity, partial_retrieval_count, subthreshold_activation, component_score}`. |
 
+#### RetrievalQuality.from\_records(records, query\_cues=None, score\_weights=None, max\_items=10, surfacing\_threshold=0.5)
+
+Classmethod factory that builds a `RetrievalQuality` over an already-retrieved list of records. Intended for custom retrieval pipelines (BM25, RRF, hybrid, vector recall) that want the metacognitive signal without adopting `ContextAssembler`.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `records` | `list` | | Non-empty list of Popoto Model instances of a single concrete class. Empty list returns a zero-valued `RetrievalQuality`. |
+| `query_cues` | `dict` \| `None` | `None` | Same shape as `ContextAssembler.assess(query_cues=...)`. When falsy, `fok_score` is `0.0` and `per_cue_fok` is empty. |
+| `score_weights` | `dict` \| `None` | `None` | Maps sorted-field names to weights. Used for `score_spread` and `staleness_ratio`. When `None`, both default to `0.0` and `score_distribution` is empty. |
+| `max_items` | `int` | `10` | Denominator for `partial_retrieval_count` in the FOK formula. Matches `ContextAssembler` default. |
+| `surfacing_threshold` | `float` | `0.5` | Threshold for `subthreshold_activation` and `staleness_ratio`. Matches `ContextAssembler` default. |
+
+**Returns:** `RetrievalQuality`.
+
+**Raises:** `TypeError` if `records` contains instances of more than one concrete model class (score weights and capability field names are per-model-class).
+
 See [Metacognitive Layer](features/metacognitive-layer.md) for full documentation.
 
 ### ContextAssembler

--- a/docs/features/metacognitive-layer.md
+++ b/docs/features/metacognitive-layer.md
@@ -113,6 +113,23 @@ messages = [
 
 **Performance note:** `assess_quality=True` adds bounded overhead — one `might_exist` call per query cue plus one `get_confidence` read per selected record (up to `max_items` reads). On a warm cache with 10 items, expect roughly 5% additional latency on `assemble()`. Confidence reads are pipelined in a single Redis round-trip batch.
 
+### Building `RetrievalQuality` from a custom pipeline
+
+If you run your own retrieval (BM25, RRF, hybrid, vector recall) and want the metacognitive signal without adopting `ContextAssembler`, call the `RetrievalQuality.from_records()` classmethod on the already-retrieved list:
+
+```python
+from popoto import RetrievalQuality
+
+records = my_bm25_pipeline(query)  # any list of Popoto Model instances
+quality = RetrievalQuality.from_records(
+    records,
+    query_cues={"topic": query},
+    score_weights={"relevance": 1.0},
+)
+```
+
+The factory introspects `records[0]._meta.fields` once to locate `ConfidenceField`, `ExistenceFilter`, and `DecayingSortedField` capabilities, then delegates to the same pure helpers `ContextAssembler.assess()` uses. Heterogeneous record lists (two or more concrete model classes) raise `TypeError` — score weights are per-model-class and would silently produce incorrect metrics otherwise. An empty list returns a zero-valued `RetrievalQuality` without raising.
+
 ---
 
 ## Tier 2: `error_summary(group_by=...)` + `"used"` outcome

--- a/docs/features/observation-protocol.md
+++ b/docs/features/observation-protocol.md
@@ -122,7 +122,7 @@ Supporting notes:
 Internal ORM infrastructure for tracking proactively surfaced memories.
 
 - **Key pattern**: `$RP:{ClassName}:pending:{partition}` (sorted set scored by surfaced_at)
-- **Lifecycle**: pending -> acted | dismissed | deferred | contradicted | expired
+- **Lifecycle**: pending -> acted | used | dismissed | deferred | contradicted | expired
 - **TTL**: 3600s (1 hour). Unresolved proposals are treated as deferred.
 
 ```python

--- a/docs/features/observation-protocol.md
+++ b/docs/features/observation-protocol.md
@@ -43,6 +43,10 @@ ObservationProtocol.on_context_used(memories, outcome_map)
 
 See [Metacognitive Layer](metacognitive-layer.md) for the full effects comparison table.
 
+### Migrating custom outcomes
+
+If you were using a custom `"echoed"` outcome (or any bespoke label between `"used"` and `"dismissed"`), map it to `"used"` when the agent reasoned over the memory or to `"dismissed"` when the overlap was coincidental; `on_context_used()` raises `ValueError` on unknown labels, so coerce to a valid outcome before calling.
+
 ## Usage
 
 ```python
@@ -95,13 +99,23 @@ Defaults.AUTO_DISCHARGE_CONFIDENCE_THRESHOLD = 0.1
 
 ## Effects Matrix
 
-When `on_context_used()` fires, effects are dispatched per-primitive:
+Each row lists what the field/mixin does for each outcome. `—` means no effect.
+
+| Effect              | acted           | used            | dismissed    | deferred | contradicted        |
+|---------------------|-----------------|-----------------|--------------|----------|---------------------|
+| ConfidenceField     | strengthen      | —               | —            | —        | weaken              |
+| CyclicDecayField    | strengthen      | —               | weaken       | —        | weaken (aggressive) |
+| DecayingSortedField | touch           | —               | —            | —        | —                   |
+| AccessTracker       | confirm         | confirm         | discard      | discard  | discard             |
+| PredictionLedger    | auto-resolve    | moderate err    | auto-resolve | —        | auto-resolve        |
+
+Supporting notes:
 
 - **DecayingSortedField**: `acted` calls `touch()` to refresh the decay clock.
-- **AccessTrackerMixin**: `acted` calls `confirm_access()`; all others call `discard_staged_access()`.
-- **CyclicDecayField**: `acted` strengthens cycles and resolves pressure; `dismissed` and `contradicted` weaken cycles.
+- **AccessTrackerMixin**: `acted` and `used` call `confirm_access()`; `dismissed`, `deferred`, and `contradicted` call `discard_staged_access()`.
+- **CyclicDecayField**: `acted` strengthens cycles and resolves pressure; `dismissed` and `contradicted` weaken cycles (`contradicted` more aggressively).
 - **ConfidenceField**: `acted` corroborates; `contradicted` contradicts.
-- **PredictionLedgerMixin**: `acted`, `dismissed`, and `contradicted` auto-resolve pending predictions with appropriate error values.
+- **PredictionLedgerMixin**: `acted`, `used`, `dismissed`, and `contradicted` auto-resolve pending predictions with appropriate error values (`used` maps to moderate error `Defaults.PL_AUTO_RESOLVE_USED`).
 
 ## RecallProposal
 

--- a/docs/guides/popoto-memory-roadmap.md
+++ b/docs/guides/popoto-memory-roadmap.md
@@ -287,7 +287,7 @@ class RecallProposal:
 
     Key pattern: $RP:{ClassName}:pending:{agent_partition} → ZSET by surfaced_at
 
-    Statuses: pending → acted | dismissed | deferred | contradicted | expired
+    Statuses: pending → acted | used | dismissed | deferred | contradicted | expired
 
     Proposals that expire (not resolved within TTL) are treated as deferred.
     """

--- a/src/popoto/__init__.py
+++ b/src/popoto/__init__.py
@@ -1,3 +1,10 @@
+from importlib.metadata import PackageNotFoundError, version as _get_version
+
+try:
+    __version__ = _get_version("popoto")
+except PackageNotFoundError:  # pragma: no cover — fallback for source-tree imports
+    __version__ = "0.0.0+unknown"
+
 from .exceptions import (
     ModelException,
     QueryException,
@@ -139,6 +146,7 @@ def configure(
 
 
 __all__ = [
+    "__version__",
     "Field",
     "IntField",
     "FloatField",

--- a/src/popoto/fields/observation.py
+++ b/src/popoto/fields/observation.py
@@ -142,8 +142,8 @@ class ObservationProtocol:
         Args:
             instances: List of Model instances that were in the agent's context.
             outcome_map: Dict mapping instance Redis keys (str) to outcome
-                strings: "acted", "dismissed", "deferred", "contradicted".
-                Instances not in the map default to "deferred".
+                strings: "acted", "used", "dismissed", "deferred",
+                "contradicted". Instances not in the map default to "deferred".
             pipeline: Optional Redis pipeline for batch operations.
 
         Note:
@@ -199,7 +199,8 @@ def _apply_outcome(instance, outcome, pipeline=None):
 
     Args:
         instance: A Model instance.
-        outcome: One of "acted", "dismissed", "deferred", "contradicted".
+        outcome: One of "acted", "used", "dismissed", "deferred",
+            "contradicted".
         pipeline: Optional Redis pipeline for batch operations.
     """
     # Use internal pipeline for atomicity if none provided
@@ -420,7 +421,7 @@ class RecallProposal:
     """Internal tracking for proactively surfaced memories.
 
     Key pattern: $RP:{ClassName}:pending:{partition} -> ZSET scored by surfaced_at
-    Statuses: pending -> acted | dismissed | deferred | contradicted | expired
+    Statuses: pending -> acted | used | dismissed | deferred | contradicted | expired
     TTL: default 3600s (1 hour). Unresolved proposals treated as deferred.
 
     This is internal ORM infrastructure, not a user-facing Model.

--- a/src/popoto/fields/observation.py
+++ b/src/popoto/fields/observation.py
@@ -24,6 +24,11 @@ Five outcomes:
       ``deferred``: ``used`` records a confirmed-read trace, ``deferred``
       discards staged reads.
 
+See Also:
+    For the effects-per-field matrix (what each outcome does to ConfidenceField,
+    CyclicDecayField, DecayingSortedField, AccessTracker, PredictionLedger), see
+    the "Effects Matrix" section of docs/features/observation-protocol.md.
+
 RecallProposal:
     Internal ORM infrastructure for tracking proactively surfaced memories.
     Redis ZSET keyed by model class and partition, scored by surfaced_at.
@@ -140,6 +145,15 @@ class ObservationProtocol:
                 strings: "acted", "dismissed", "deferred", "contradicted".
                 Instances not in the map default to "deferred".
             pipeline: Optional Redis pipeline for batch operations.
+
+        Note:
+            This method validates ``outcome_map`` strictly against
+            ``VALID_OUTCOMES``. Application-specific outcomes (e.g. a custom
+            ``"echoed"`` label) must be coerced to one of the five valid
+            values before calling, otherwise a ``ValueError`` is raised.
+            See ``docs/features/observation-protocol.md`` (where the
+            protocol lives) for guidance on mapping bespoke outcomes into
+            the canonical vocabulary.
 
         Raises:
             ValueError: If any outcome string is not a valid outcome.

--- a/src/popoto/recipes/context_assembler.py
+++ b/src/popoto/recipes/context_assembler.py
@@ -199,12 +199,413 @@ class RetrievalQuality:
     score_distribution: list = field(default_factory=list)
     per_cue_fok: dict = field(default_factory=dict)
 
+    @classmethod
+    def from_records(
+        cls,
+        records,
+        query_cues=None,
+        score_weights=None,
+        max_items=DEFAULT_MAX_ITEMS,
+        surfacing_threshold=DEFAULT_SURFACING_THRESHOLD,
+    ) -> "RetrievalQuality":
+        """Build a RetrievalQuality over an already-retrieved list of records.
+
+        Intended for custom retrieval pipelines (BM25, RRF, hybrid) that
+        want the metacognitive layer without adopting
+        :class:`ContextAssembler`. All model capabilities (ConfidenceField,
+        ExistenceFilter, DecayingSortedField) are introspected from
+        ``records[0]._meta.fields``. Heterogeneous record lists are
+        rejected with ``TypeError`` — score weights and capability field
+        names are per-model-class, so a mixed list would silently produce
+        incorrect FOK / score_spread / staleness_ratio values.
+
+        Args:
+            records: Non-empty list of Popoto Model instances of a single
+                concrete class. When empty, returns a zero-valued
+                :class:`RetrievalQuality`.
+            query_cues: Optional dict of query cues — same shape as
+                ``ContextAssembler.assess(query_cues=...)``. When falsy,
+                ``fok_score`` is 0.0 and ``per_cue_fok`` is empty.
+            score_weights: Optional dict mapping sorted-field names to
+                weights. Used for ``score_spread`` and ``staleness_ratio``.
+                When None, both default to 0.0 and ``score_distribution``
+                is empty.
+            max_items: Denominator for ``partial_retrieval_count`` in the
+                FOK formula. Default matches ``ContextAssembler``.
+            surfacing_threshold: Threshold for subthreshold_activation and
+                staleness_ratio. Default matches ``ContextAssembler``.
+
+        Returns:
+            A :class:`RetrievalQuality` dataclass. Field semantics match
+            the assembler path exactly — see class docstring.
+
+        Raises:
+            TypeError: If ``records`` contains instances of more than one
+                concrete model class.
+
+        Example:
+            >>> from popoto import RetrievalQuality
+            >>> records = my_bm25_pipeline(query)  # custom retrieval
+            >>> quality = RetrievalQuality.from_records(
+            ...     records,
+            ...     query_cues={"topic": query},
+            ...     score_weights={"relevance": 1.0},
+            ... )
+            >>> if quality.fok_score < 0.3:
+            ...     return "low confidence retrieval"
+        """
+        # Empty list -> zero-valued quality, no warning.
+        if not records:
+            return cls()
+
+        # Mixed-model guard (C4): fail loudly, not silently.
+        distinct_types = {type(r) for r in records}
+        if len(distinct_types) > 1:
+            class_names = sorted(t.__name__ for t in distinct_types)
+            raise TypeError(
+                "RetrievalQuality.from_records requires a homogeneous list "
+                f"of records; got {len(distinct_types)} distinct model "
+                f"classes: {class_names}"
+            )
+
+        # All records are the same class — introspect once at the entry point.
+        model_class = type(records[0])
+        existence_filter = None
+        confidence_field_name = None
+        decaying_sorted_field_name = None
+        for name, f in model_class._meta.fields.items():
+            if isinstance(f, ExistenceFilter) and existence_filter is None:
+                existence_filter = f
+            if isinstance(f, ConfidenceField) and confidence_field_name is None:
+                confidence_field_name = name
+            if (
+                isinstance(f, DecayingSortedField)
+                and decaying_sorted_field_name is None
+            ):
+                decaying_sorted_field_name = name
+
+        # Delegate numeric work to the pure module-level helpers (C2).
+        avg_conf = _avg_confidence(
+            records,
+            confidence_field_name=confidence_field_name,
+            model_class=model_class,
+        )
+
+        if score_weights is None:
+            # Skip score_spread / staleness_ratio entirely.
+            score_spread = 0.0
+            distribution: list = []
+            staleness = 0.0
+        else:
+            score_spread, distribution = _compute_score_spread(
+                records,
+                model_class=model_class,
+                score_weights=score_weights,
+            )
+            staleness = _staleness_ratio(
+                records,
+                model_class=model_class,
+                score_weights=score_weights,
+                surfacing_threshold=surfacing_threshold,
+                decaying_sorted_field_name=decaying_sorted_field_name,
+            )
+
+        if not query_cues:
+            fok_score = 0.0
+            per_cue: dict = {}
+        else:
+            # FOK needs pull-candidates; we have already-retrieved records,
+            # so those are the candidates by construction.
+            fok_score, per_cue = _compute_fok(
+                query_cues,
+                records,
+                model_class=model_class,
+                score_weights=score_weights or {},
+                max_items=max_items,
+                surfacing_threshold=surfacing_threshold,
+                existence_filter=existence_filter,
+            )
+
+        return cls(
+            avg_confidence=avg_conf,
+            score_spread=score_spread,
+            fok_score=fok_score,
+            staleness_ratio=staleness,
+            score_distribution=distribution,
+            per_cue_fok=per_cue,
+        )
+
 
 # FOK formula weights — hard-coded per design spec (see plan
 # "Rabbit Holes": adjusting these is out-of-scope).
 FOK_WEIGHT_CUE_FAMILIARITY = 0.4
 FOK_WEIGHT_PARTIAL_RETRIEVAL = 0.4
 FOK_WEIGHT_SUBTHRESHOLD_ACTIVATION = 0.2
+
+
+# ---------------------------------------------------------------------------
+# Module-level quality helpers (pure, keyword-only; issue #370 C2)
+#
+# These functions are the single source of truth for RetrievalQuality
+# computation. Both the ContextAssembler instance methods and the public
+# RetrievalQuality.from_records() classmethod introspect model capability
+# fields ONCE at the entry point and then forward explicit kwargs into
+# these helpers. Helpers do not introspect — that is the caller's job.
+# ---------------------------------------------------------------------------
+
+
+def _cue_familiarity(cue_value, *, existence_filter, model_class) -> float:
+    """Return the FOK cue_familiarity component for a single cue value.
+
+    ``existence_filter`` is the ``ExistenceFilter`` field (or ``None``).
+    ``model_class`` is the concrete Popoto model — required because
+    ``ExistenceFilter.might_exist`` is a method on the filter that takes
+    the model class as the first argument.
+
+    Returns ``0.5`` (neutral) when no ExistenceFilter is available OR the
+    membership check fails. ``1.0`` when the bloom says might_exist,
+    ``0.0`` when definitely_missing.
+    """
+    if existence_filter is None:
+        return 0.5
+    try:
+        present = existence_filter.might_exist(model_class, str(cue_value))
+    except Exception as e:
+        logger.warning("cue_familiarity check failed for %r: %s", cue_value, e)
+        return 0.5
+    return 1.0 if present else 0.0
+
+
+def _score_proxy_for_records(records, *, model_class, score_weights):
+    """Pipelined ZSCORE proxy for composite scores.
+
+    Read-only (no ZUNIONSTORE, no temp keys). Only sorted-field-backed
+    entries in ``score_weights`` contribute; other weights are ignored
+    (ConfidenceField / WriteFilter are computed elsewhere in the quality
+    signal).
+    """
+    if not records:
+        return {}
+
+    sorted_field_names = []
+    for field_name in score_weights:
+        try:
+            f = model_class._meta.fields.get(field_name)
+        except Exception:
+            f = None
+        if f is not None and isinstance(f, SortedFieldMixin):
+            sorted_field_names.append(field_name)
+
+    if not sorted_field_names:
+        return {r_key: 0.0 for r_key in (_get_key(r) for r in records)}
+
+    per_field_keys = {}
+    for field_name in sorted_field_names:
+        f = model_class._meta.fields[field_name]
+        per_field_keys[field_name] = []
+        for record in records:
+            try:
+                key = f.get_special_use_field_db_key(record, field_name).redis_key
+            except Exception:
+                key = None
+            per_field_keys[field_name].append(key)
+
+    pipe = POPOTO_REDIS_DB.pipeline()
+    for field_name in sorted_field_names:
+        zset_keys = per_field_keys[field_name]
+        for record, zset_key in zip(records, zset_keys):
+            if zset_key is None:
+                pipe.zscore("", "")  # placeholder
+                continue
+            pipe.zscore(zset_key, _get_key(record))
+    raw = pipe.execute()
+
+    scores = {_get_key(r): 0.0 for r in records}
+    idx = 0
+    for field_name in sorted_field_names:
+        weight = float(score_weights.get(field_name, 0.0))
+        for record in records:
+            r_key = _get_key(record)
+            val = raw[idx]
+            idx += 1
+            if val is not None:
+                try:
+                    scores[r_key] += weight * float(val)
+                except (TypeError, ValueError):
+                    pass
+    return scores
+
+
+def _compute_score_spread(records, *, model_class, score_weights):
+    """Coefficient of variation of composite-score proxy across records.
+
+    Returns ``(score_spread, distribution_list)``. Falls back to
+    ``(0.0, [])`` on empty input or when ``abs(mean) < 1e-9``.
+    """
+    if not records:
+        return 0.0, []
+    try:
+        proxy = _score_proxy_for_records(
+            records, model_class=model_class, score_weights=score_weights
+        )
+    except Exception as e:
+        logger.warning("_compute_score_spread proxy failed: %s", e)
+        return 0.0, []
+    scores = list(proxy.values())
+    if not scores:
+        return 0.0, []
+    try:
+        mean = statistics.fmean(scores)
+    except statistics.StatisticsError:
+        return 0.0, scores
+    if abs(mean) < 1e-9:
+        return 0.0, scores
+    try:
+        stddev = statistics.pstdev(scores)
+    except statistics.StatisticsError:
+        return 0.0, scores
+    return stddev / mean, scores
+
+
+def _avg_confidence(records, *, confidence_field_name, model_class):
+    """Mean ConfidenceField.get_confidence() across records.
+
+    Returns ``1.0`` (neutral) when the model has no ConfidenceField.
+    Per-record exceptions log and fall back to ``initial_confidence``.
+    """
+    if not records or not confidence_field_name:
+        return 1.0
+    field_obj = model_class._meta.fields.get(confidence_field_name)
+    initial = getattr(field_obj, "initial_confidence", 0.5)
+
+    total = 0.0
+    count = 0
+    for record in records:
+        try:
+            val = ConfidenceField.get_confidence(record, confidence_field_name)
+        except Exception as e:
+            logger.warning(
+                "get_confidence failed for %s: %s — using initial_confidence",
+                _get_key(record),
+                e,
+            )
+            val = initial
+        total += float(val)
+        count += 1
+    if count == 0:
+        return 1.0
+    return total / count
+
+
+def _compute_fok(
+    query_cues,
+    pull_candidates,
+    *,
+    model_class,
+    score_weights,
+    max_items,
+    surfacing_threshold,
+    existence_filter,
+):
+    """FOK score + per-cue breakdown.
+
+    Mirrors the pre-refactor ``ContextAssembler._compute_fok`` exactly.
+    Empty ``query_cues`` -> ``(0.0, {})`` with a warning.
+    """
+    if not query_cues:
+        logger.warning("_compute_fok called with empty query_cues")
+        return 0.0, {}
+
+    n_candidates = len(pull_candidates)
+    capped_max_items = max(max_items, 1)
+    partial_retrieval = min(n_candidates, capped_max_items) / capped_max_items
+
+    subthreshold_frac = 0.0
+    if n_candidates > 0 and score_weights:
+        try:
+            proxy_scores = _score_proxy_for_records(
+                pull_candidates,
+                model_class=model_class,
+                score_weights=score_weights,
+            )
+            below_threshold = sum(
+                1 for s in proxy_scores.values() if 0 < s < surfacing_threshold
+            )
+            subthreshold_frac = below_threshold / max(n_candidates, 1)
+        except Exception as e:
+            logger.warning("Subthreshold activation computation failed: %s", e)
+            subthreshold_frac = 0.0
+
+    per_cue = {}
+    total = 0.0
+    for cue_value in query_cues.values():
+        familiarity = _cue_familiarity(
+            cue_value,
+            existence_filter=existence_filter,
+            model_class=model_class,
+        )
+        component_score = (
+            FOK_WEIGHT_CUE_FAMILIARITY * familiarity
+            + FOK_WEIGHT_PARTIAL_RETRIEVAL * partial_retrieval
+            + FOK_WEIGHT_SUBTHRESHOLD_ACTIVATION * subthreshold_frac
+        )
+        per_cue[str(cue_value)] = {
+            "cue_familiarity": familiarity,
+            "partial_retrieval_count": partial_retrieval,
+            "subthreshold_activation": subthreshold_frac,
+            "component_score": component_score,
+        }
+        total += component_score
+
+    fok_score = total / len(query_cues) if query_cues else 0.0
+    return fok_score, per_cue
+
+
+def _staleness_ratio(
+    records,
+    *,
+    model_class,
+    score_weights,
+    surfacing_threshold,
+    decaying_sorted_field_name,
+):
+    """Fraction of records whose DecayingSortedField score is below the
+    surfacing threshold. ``0.0`` when the model has no DecayingSortedField
+    or when that field is not in ``score_weights``.
+    """
+    if not records or not decaying_sorted_field_name:
+        return 0.0
+    field_name = decaying_sorted_field_name
+    try:
+        _score_proxy_for_records(
+            records, model_class=model_class, score_weights=score_weights
+        )
+    except Exception as e:
+        logger.warning("_staleness_ratio proxy failed: %s", e)
+        return 0.0
+    if field_name not in score_weights:
+        return 0.0
+    f = model_class._meta.fields[field_name]
+    pipe = POPOTO_REDIS_DB.pipeline()
+    for record in records:
+        try:
+            zkey = f.get_special_use_field_db_key(record, field_name).redis_key
+            pipe.zscore(zkey, _get_key(record))
+        except Exception:
+            pipe.zscore("", "")
+    raw = pipe.execute()
+
+    stale_count = 0
+    for val in raw:
+        if val is None:
+            stale_count += 1
+            continue
+        try:
+            if float(val) < surfacing_threshold:
+                stale_count += 1
+        except (TypeError, ValueError):
+            stale_count += 1
+    return stale_count / len(records)
 
 
 # ---------------------------------------------------------------------------
@@ -622,280 +1023,66 @@ class ContextAssembler:
     # ------------------------------------------------------------------
 
     def _cue_familiarity(self, cue_value) -> float:
-        """Compute FOK cue_familiarity component for a single cue value.
+        """Thin wrapper around the module-level :func:`_cue_familiarity`.
 
-        When the model has no ExistenceFilter, fall back to a neutral
-        ``0.5`` (we cannot prove absence, we cannot prove presence).
-        When present and ``might_exist`` returns True, ``1.0``; when
-        present and False, ``0.0``.
+        Introspects ``self`` exactly once and forwards explicit kwargs so
+        the pure helper is the single source of truth (issue #370 C2).
         """
-        if self._existence_filter is None:
-            return 0.5
-        try:
-            present = self._existence_filter.might_exist(
-                self.model_class, str(cue_value)
-            )
-        except Exception as e:
-            logger.warning("cue_familiarity check failed for %r: %s", cue_value, e)
-            return 0.5
-        return 1.0 if present else 0.0
+        return _cue_familiarity(
+            cue_value,
+            existence_filter=self._existence_filter,
+            model_class=self.model_class,
+        )
 
     def _compute_fok(self, query_cues, pull_candidates):
-        """Compute FOK score and per-cue breakdown.
-
-        Returns a tuple ``(fok_score, per_cue_map)``.
-
-        Formula (per design spec, hard-coded):
-            fok = mean_over_cues(
-                0.4 * cue_familiarity
-                + 0.4 * partial_retrieval_count
-                + 0.2 * subthreshold_activation
-            )
-
-        * ``cue_familiarity``: 1.0 if ExistenceFilter says might_exist,
-          0.0 if definitely_missing, 0.5 if no ExistenceFilter on model.
-        * ``partial_retrieval_count``: ``min(len(candidates), max_items) /
-          max_items`` — did we surface enough raw candidates to have
-          something to pick from?
-        * ``subthreshold_activation``: fraction of candidates with score
-          strictly between 0 and the surfacing threshold — "almost
-          remembered" content. Computed over pull candidates using the
-          composite score proxy (see ``_score_proxy_for_records``).
-
-        Edge cases:
-        * Empty ``query_cues`` -> ``fok_score = 0.0``, empty per-cue map,
-          with a logged warning. Do not raise.
-        * ``pull_candidates`` is empty -> partial_retrieval and subthreshold
-          both contribute 0.
-        """
-        if not query_cues:
-            logger.warning("_compute_fok called with empty query_cues")
-            return 0.0, {}
-
-        n_candidates = len(pull_candidates)
-        max_items = max(self.max_items, 1)
-        partial_retrieval = min(n_candidates, max_items) / max_items
-
-        # Subthreshold activation: pull candidates with score below the
-        # surfacing_threshold but > 0. Uses the composite-score proxy.
-        subthreshold_frac = 0.0
-        if n_candidates > 0 and self.score_weights:
-            try:
-                proxy_scores = self._score_proxy_for_records(pull_candidates)
-                below_threshold = sum(
-                    1 for s in proxy_scores.values() if 0 < s < self.surfacing_threshold
-                )
-                subthreshold_frac = below_threshold / max(n_candidates, 1)
-            except Exception as e:
-                logger.warning("Subthreshold activation computation failed: %s", e)
-                subthreshold_frac = 0.0
-
-        per_cue = {}
-        total = 0.0
-        for cue_value in query_cues.values():
-            familiarity = self._cue_familiarity(cue_value)
-            component_score = (
-                FOK_WEIGHT_CUE_FAMILIARITY * familiarity
-                + FOK_WEIGHT_PARTIAL_RETRIEVAL * partial_retrieval
-                + FOK_WEIGHT_SUBTHRESHOLD_ACTIVATION * subthreshold_frac
-            )
-            per_cue[str(cue_value)] = {
-                "cue_familiarity": familiarity,
-                "partial_retrieval_count": partial_retrieval,
-                "subthreshold_activation": subthreshold_frac,
-                "component_score": component_score,
-            }
-            total += component_score
-
-        fok_score = total / len(query_cues) if query_cues else 0.0
-        return fok_score, per_cue
+        """Thin wrapper around the module-level :func:`_compute_fok`."""
+        return _compute_fok(
+            query_cues,
+            pull_candidates,
+            model_class=self.model_class,
+            score_weights=self.score_weights,
+            max_items=self.max_items,
+            surfacing_threshold=self.surfacing_threshold,
+            existence_filter=self._existence_filter,
+        )
 
     def _score_proxy_for_records(self, records):
-        """Build a per-record composite-score proxy via pipelined ZSCORE.
-
-        Returns ``{redis_key: composite_score}``. The proxy mirrors
-        composite_score's ZUNIONSTORE aggregation: for each weighted field
-        in ``self.score_weights``, read the sorted set score for this
-        record and add ``weight * score`` to the running total. Fields
-        that are not sorted-set-backed (e.g., ConfidenceField) are read
-        via their companion hash instead.
-
-        This is a read-only helper; it does NOT mutate any Redis state
-        and does NOT recreate temp keys. It is meant for quality probes
-        where we need per-record scores without the overhead (and side
-        effects) of a full composite_score call.
+        """Thin wrapper around the module-level
+        :func:`_score_proxy_for_records`.
         """
-        if not records:
-            return {}
-
-        # We compute composite per record using only SortedFieldMixin-backed
-        # index fields. ConfidenceField / WriteFilter priority / AccessTracker
-        # are supported by composite_score proper via companion hashes; for a
-        # cheap proxy we restrict to the sorted-field path, which covers the
-        # common cases (DecayingSortedField, CyclicDecayField, SortedField).
-        sorted_field_names = []
-        for field_name in self.score_weights:
-            try:
-                f = self.model_class._meta.fields.get(field_name)
-            except Exception:
-                f = None
-            if f is not None and isinstance(f, SortedFieldMixin):
-                sorted_field_names.append(field_name)
-
-        if not sorted_field_names:
-            # No sorted-field indexes -> no proxy scores.
-            return {r_key: 0.0 for r_key in (_get_key(r) for r in records)}
-
-        # Build ZSET key per field (resolves partition_by via the instance).
-        per_field_keys = {}
-        for field_name in sorted_field_names:
-            f = self.model_class._meta.fields[field_name]
-            per_field_keys[field_name] = []
-            for record in records:
-                try:
-                    key = f.get_special_use_field_db_key(record, field_name).redis_key
-                except Exception:
-                    key = None
-                per_field_keys[field_name].append(key)
-
-        # Pipeline all ZSCORE calls.
-        pipe = POPOTO_REDIS_DB.pipeline()
-        for field_name in sorted_field_names:
-            zset_keys = per_field_keys[field_name]
-            for record, zset_key in zip(records, zset_keys):
-                if zset_key is None:
-                    pipe.zscore("", "")  # placeholder that returns None
-                    continue
-                pipe.zscore(zset_key, _get_key(record))
-        raw = pipe.execute()
-
-        # Re-aggregate per record.
-        scores = {_get_key(r): 0.0 for r in records}
-        idx = 0
-        for field_name in sorted_field_names:
-            weight = float(self.score_weights.get(field_name, 0.0))
-            for record in records:
-                r_key = _get_key(record)
-                val = raw[idx]
-                idx += 1
-                if val is not None:
-                    try:
-                        scores[r_key] += weight * float(val)
-                    except (TypeError, ValueError):
-                        pass
-        return scores
+        return _score_proxy_for_records(
+            records,
+            model_class=self.model_class,
+            score_weights=self.score_weights,
+        )
 
     def _compute_score_spread(self, records):
-        """Coefficient of variation of composite-score proxy across records.
-
-        Returns ``(score_spread, distribution_list)``. Falls back to
-        ``(0.0, [])`` on empty input or when ``abs(mean) < 1e-9``.
+        """Thin wrapper around the module-level
+        :func:`_compute_score_spread`.
         """
-        if not records:
-            return 0.0, []
-        try:
-            proxy = self._score_proxy_for_records(records)
-        except Exception as e:
-            logger.warning("_compute_score_spread proxy failed: %s", e)
-            return 0.0, []
-        scores = list(proxy.values())
-        if not scores:
-            return 0.0, []
-        try:
-            mean = statistics.fmean(scores)
-        except statistics.StatisticsError:
-            return 0.0, scores
-        if abs(mean) < 1e-9:
-            # stddev/mean is undefined when mean is zero (empty or all-zero).
-            return 0.0, scores
-        try:
-            stddev = statistics.pstdev(scores)
-        except statistics.StatisticsError:
-            return 0.0, scores
-        return stddev / mean, scores
+        return _compute_score_spread(
+            records,
+            model_class=self.model_class,
+            score_weights=self.score_weights,
+        )
 
     def _avg_confidence(self, records):
-        """Mean ConfidenceField.get_confidence() across records.
-
-        Returns ``1.0`` (neutral) when the model has no ConfidenceField,
-        matching "no evidence against the retrieval." Per-record exceptions
-        are logged and the record contributes the field's
-        ``initial_confidence`` as a sentinel rather than aborting the
-        whole metric.
-        """
-        if not records or not self._confidence_field_name:
-            return 1.0
-        field = self.model_class._meta.fields.get(self._confidence_field_name)
-        initial = getattr(field, "initial_confidence", 0.5)
-
-        total = 0.0
-        count = 0
-        for record in records:
-            try:
-                val = ConfidenceField.get_confidence(
-                    record, self._confidence_field_name
-                )
-            except Exception as e:
-                logger.warning(
-                    "get_confidence failed for %s: %s — using initial_confidence",
-                    _get_key(record),
-                    e,
-                )
-                val = initial
-            total += float(val)
-            count += 1
-        if count == 0:
-            return 1.0
-        return total / count
+        """Thin wrapper around the module-level :func:`_avg_confidence`."""
+        return _avg_confidence(
+            records,
+            confidence_field_name=self._confidence_field_name,
+            model_class=self.model_class,
+        )
 
     def _staleness_ratio(self, records):
-        """Fraction of records whose DecayingSortedField score is below
-        the field's decay threshold.
-
-        Returns ``0.0`` when the model has no DecayingSortedField (we
-        cannot measure staleness without a decay signal). The "decay
-        threshold" is interpreted as ``self.surfacing_threshold`` — the
-        same threshold used to filter push-path records. A record whose
-        decayed score is below this threshold is considered "stale"
-        for the purposes of the retrieval quality signal.
-        """
-        if not records or not self._decaying_sorted_field_name:
-            return 0.0
-        field_name = self._decaying_sorted_field_name
-        try:
-            decayed_scores = self._score_proxy_for_records(records)
-        except Exception as e:
-            logger.warning("_staleness_ratio proxy failed: %s", e)
-            return 0.0
-        # Use only the decaying field's contribution. The proxy already
-        # weights by score_weights. If DecayingSortedField isn't in the
-        # configured weights, we cannot judge staleness.
-        if field_name not in self.score_weights:
-            return 0.0
-        # When there's only one weighted field, proxy == weighted score; when
-        # mixed, the other weighted contributions inflate the score. Use
-        # direct ZSCORE for the decaying field to get a clean read.
-        f = self.model_class._meta.fields[field_name]
-        pipe = POPOTO_REDIS_DB.pipeline()
-        for record in records:
-            try:
-                zkey = f.get_special_use_field_db_key(record, field_name).redis_key
-                pipe.zscore(zkey, _get_key(record))
-            except Exception:
-                pipe.zscore("", "")  # placeholder None
-        raw = pipe.execute()
-
-        stale_count = 0
-        for val in raw:
-            if val is None:
-                stale_count += 1
-                continue
-            try:
-                if float(val) < self.surfacing_threshold:
-                    stale_count += 1
-            except (TypeError, ValueError):
-                stale_count += 1
-        return stale_count / len(records)
+        """Thin wrapper around the module-level :func:`_staleness_ratio`."""
+        return _staleness_ratio(
+            records,
+            model_class=self.model_class,
+            score_weights=self.score_weights,
+            surfacing_threshold=self.surfacing_threshold,
+            decaying_sorted_field_name=self._decaying_sorted_field_name,
+        )
 
     def _compute_quality(self, selected, all_pull_candidates, query_cues):
         """Assemble a RetrievalQuality over the selected records.

--- a/tests/test_context_assembler.py
+++ b/tests/test_context_assembler.py
@@ -78,6 +78,26 @@ class FullMemory(Model):
     )
 
 
+class FixtureMemory(Model):
+    """Deterministic fixture for numeric-regression tests (item 2a-pre, C3).
+
+    No CyclicDecayField (keeps scoring strictly on the DecayingSortedField).
+    Topics fingerprinted into ExistenceFilter for cue_familiarity.
+    """
+
+    memory_id = AutoKeyField()
+    agent_id = KeyField()
+    topic = Field(type=str)
+    content = Field(type=str)
+    relevance = DecayingSortedField(partition_by="agent_id")
+    confidence = ConfidenceField(initial_confidence=0.5)
+    bloom = ExistenceFilter(
+        error_rate=0.01,
+        capacity=10_000,
+        fingerprint_fn=lambda inst: inst.topic,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -96,11 +116,16 @@ def _clean_all():
     _clean_keys(
         "*SimpleMemory*",
         "*FullMemory*",
+        "*FixtureMemory*",
+        "*AltFixtureMemory*",
         "$EF:*Memory*",
         "$CoOcF:*Memory*",
         "$ConfidencF:*Memory*",
         "$SortedF:*Memory*",
+        "$DecayingSortF:*Memory*",
         "$CyclicDF:*Memory*",
+        "$KeyF:*Memory*",
+        "$Class:*Memory*",
         "$RP:*Memory*",
     )
 
@@ -631,6 +656,240 @@ class TestRetrievalQuality:
         assert s
         assert "RetrievalQuality" in s
         assert "fok_score=0.7" in s
+
+
+# ---------------------------------------------------------------------------
+# TestRetrievalQualityAssembler (numeric regression guard for item 2a refactor)
+# ---------------------------------------------------------------------------
+
+
+class TestRetrievalQualityAssembler:
+    """Numeric-fixture regression guard protecting the Item 2a helper
+    extraction (C2/C3). Hardcoded expected values were captured against the
+    pre-refactor code — any drift indicates the wrapper methods stopped
+    routing state through to the module-level helpers correctly.
+    """
+
+    @staticmethod
+    def _isclose(a, b):
+        import math
+
+        return math.isclose(a, b, rel_tol=1e-9, abs_tol=1e-9)
+
+    def test_assess_numeric_fixture(self):
+        """Three records with known confidences + two query cues produce
+        hardcoded scalar values for the RetrievalQuality metrics. Any
+        numeric drift after the helper refactor fails this test.
+
+        Fixture:
+            * 3 FixtureMemory instances (topics: alpha, beta, gamma),
+              confidences post-update: 0.9 signal, 0.5 signal, 0.3 signal
+            * score_weights={"relevance": 1.0}, max_items=5,
+              surfacing_threshold=0.5
+            * query_cues={"topic": "alpha", "other": "beta"}
+              (both topics are in the ExistenceFilter fingerprint)
+            * partition_filters={"agent_id": "a"}
+        """
+        m1 = FixtureMemory(agent_id="a", topic="alpha", content="c1")
+        m1.save()
+        m2 = FixtureMemory(agent_id="a", topic="beta", content="c2")
+        m2.save()
+        m3 = FixtureMemory(agent_id="a", topic="gamma", content="c3")
+        m3.save()
+
+        ConfidenceField.update_confidence(m1, "confidence", signal=0.9)
+        ConfidenceField.update_confidence(m2, "confidence", signal=0.5)
+        ConfidenceField.update_confidence(m3, "confidence", signal=0.3)
+
+        assembler = ContextAssembler(
+            model_class=FixtureMemory,
+            score_weights={"relevance": 1.0},
+            max_items=5,
+            surfacing_threshold=0.5,
+        )
+
+        quality = assembler.assess(
+            query_cues={"topic": "alpha", "other": "beta"},
+            partition_filters={"agent_id": "a"},
+        )
+
+        # Hardcoded expected scalars captured against the pre-refactor
+        # implementation. DO NOT tweak these to paper over a refactor —
+        # any divergence means the refactor changed numeric behavior.
+        assert self._isclose(quality.avg_confidence, 0.5666666666666667)
+        assert self._isclose(quality.score_spread, 0.0)
+        assert self._isclose(quality.fok_score, 0.64)
+        assert self._isclose(quality.staleness_ratio, 1.0)
+
+        # Per-cue components also hardcoded.
+        assert set(quality.per_cue_fok.keys()) == {"alpha", "beta"}
+        for cue in ("alpha", "beta"):
+            comp = quality.per_cue_fok[cue]
+            assert self._isclose(comp["cue_familiarity"], 1.0)
+            assert self._isclose(comp["partial_retrieval_count"], 0.6)
+            assert self._isclose(comp["subthreshold_activation"], 0.0)
+            assert self._isclose(comp["component_score"], 0.64)
+
+        # score_distribution contents: three zero-valued proxy scores
+        # (decayed to 0 because DecayingSortedField starts at 0 score on a
+        # freshly saved record — the deterministic fixture relies on this).
+        assert len(quality.score_distribution) == 3
+        for s in quality.score_distribution:
+            assert self._isclose(s, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# TestRetrievalQualityFromRecords (issue #370 item 2b: C1 parity + C4 guard)
+# ---------------------------------------------------------------------------
+
+
+class AltFixtureMemory(Model):
+    """A second model class for the mixed-record TypeError test (C4)."""
+
+    memory_id = AutoKeyField()
+    agent_id = KeyField()
+    topic = Field(type=str)
+    relevance = DecayingSortedField(partition_by="agent_id")
+
+
+class TestRetrievalQualityFromRecords:
+    """Public classmethod: RetrievalQuality.from_records(records, ...).
+
+    Parity contract (C1): same records, same assembler config, the
+    classmethod and ``ContextAssembler.assemble(..., assess_quality=True)``
+    produce numerically equal scalar fields within 1e-9.
+    """
+
+    @staticmethod
+    def _isclose(a, b):
+        import math
+
+        return math.isclose(a, b, rel_tol=1e-9, abs_tol=1e-9)
+
+    def test_from_records_matches_assemble_quality(self):
+        """C1: ``from_records`` numerically matches ``assemble(..., assess_quality=True)``
+        when given identical records and identical assembler config
+        (score_weights, max_items, surfacing_threshold, query_cues).
+        """
+        import math
+
+        # Save records, then compute quality two ways and compare.
+        saved = []
+        for i, topic in enumerate(("one", "two", "three")):
+            m = FixtureMemory(agent_id="a", topic=topic, content=f"c{i}")
+            m.save()
+            ConfidenceField.update_confidence(m, "confidence", signal=0.5 + 0.1 * i)
+            saved.append(m)
+
+        score_weights = {"relevance": 1.0}
+        max_items = 5
+        surfacing_threshold = 0.5
+        query_cues = {"topic": "one"}
+
+        # Assembler path — use assemble(..., assess_quality=True) so that
+        # its metadata["quality"] reflects the SELECTED records.
+        assembler = ContextAssembler(
+            model_class=FixtureMemory,
+            score_weights=score_weights,
+            max_items=max_items,
+            surfacing_threshold=surfacing_threshold,
+        )
+        result = assembler.assemble(
+            query_cues=query_cues,
+            partition_filters={"agent_id": "a"},
+            assess_quality=True,
+        )
+        assembler_quality = result.metadata["quality"]
+
+        # Custom-pipeline path — hand the exact selected records to
+        # from_records. `result.records` is what assemble() produced
+        # and what its quality was computed against.
+        custom_quality = RetrievalQuality.from_records(
+            result.records,
+            query_cues=query_cues,
+            score_weights=score_weights,
+            max_items=max_items,
+            surfacing_threshold=surfacing_threshold,
+        )
+
+        assert self._isclose(
+            custom_quality.avg_confidence, assembler_quality.avg_confidence
+        )
+        assert self._isclose(
+            custom_quality.score_spread, assembler_quality.score_spread
+        )
+        assert self._isclose(custom_quality.fok_score, assembler_quality.fok_score)
+        assert self._isclose(
+            custom_quality.staleness_ratio, assembler_quality.staleness_ratio
+        )
+
+        # score_distribution element-wise tolerant comparison
+        assert len(custom_quality.score_distribution) == len(
+            assembler_quality.score_distribution
+        )
+        for a, b in zip(
+            custom_quality.score_distribution, assembler_quality.score_distribution
+        ):
+            assert math.isclose(a, b, rel_tol=1e-9, abs_tol=1e-9)
+
+        # per_cue_fok keys match; each component within tolerance.
+        assert set(custom_quality.per_cue_fok.keys()) == set(
+            assembler_quality.per_cue_fok.keys()
+        )
+        for cue, comp in custom_quality.per_cue_fok.items():
+            expected = assembler_quality.per_cue_fok[cue]
+            for k in (
+                "cue_familiarity",
+                "partial_retrieval_count",
+                "subthreshold_activation",
+                "component_score",
+            ):
+                assert math.isclose(comp[k], expected[k], rel_tol=1e-9, abs_tol=1e-9)
+
+    def test_from_records_empty_returns_zero(self):
+        """Empty records list -> zero-valued RetrievalQuality; does NOT raise."""
+        q = RetrievalQuality.from_records([])
+        assert isinstance(q, RetrievalQuality)
+        assert q.avg_confidence == 0.0
+        assert q.score_spread == 0.0
+        assert q.fok_score == 0.0
+        assert q.staleness_ratio == 0.0
+        assert q.score_distribution == []
+        assert q.per_cue_fok == {}
+
+    def test_from_records_no_cues_no_weights(self):
+        """query_cues=None + score_weights=None -> zero FOK / spread /
+        staleness, avg_confidence still computed from ConfidenceField.
+        """
+        m = FixtureMemory(agent_id="a", topic="solo", content="body")
+        m.save()
+        ConfidenceField.update_confidence(m, "confidence", signal=0.7)
+
+        q = RetrievalQuality.from_records([m])
+        assert isinstance(q, RetrievalQuality)
+        assert q.fok_score == 0.0
+        assert q.per_cue_fok == {}
+        assert q.score_spread == 0.0
+        assert q.score_distribution == []
+        assert q.staleness_ratio == 0.0
+        # avg_confidence is still computed (ConfidenceField is present).
+        assert 0.0 <= q.avg_confidence <= 1.0
+
+    def test_from_records_mixed_models_raises(self):
+        """C4: heterogeneous record lists raise TypeError whose message
+        names BOTH classes.
+        """
+        m1 = FixtureMemory(agent_id="a", topic="x", content="c")
+        m1.save()
+        m2 = AltFixtureMemory(agent_id="a", topic="y")
+        m2.save()
+
+        with pytest.raises(TypeError) as excinfo:
+            RetrievalQuality.from_records([m1, m2])
+
+        msg = str(excinfo.value)
+        assert "FixtureMemory" in msg
+        assert "AltFixtureMemory" in msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_observation_protocol.py
+++ b/tests/test_observation_protocol.py
@@ -1006,3 +1006,94 @@ class TestUsedOutcome:
     def test_used_empty_instances_noop(self):
         """on_context_used with empty instance list is a no-op even for 'used'."""
         ObservationProtocol.on_context_used([], {"rk1": "used"})  # no raise
+
+
+# ---------------------------------------------------------------------------
+# Docstring / feature-doc integration tests (issue #370, item 1 + item 4)
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureDocAndDocstrings:
+    """Assert integrator-facing docstrings and the feature doc stay in sync."""
+
+    _REPO_ROOT = os.path.dirname(SCRIPT_DIR)
+    _FEATURE_DOC = os.path.join(
+        _REPO_ROOT, "docs", "features", "observation-protocol.md"
+    )
+
+    def test_observation_protocol_doc_contains_effects_table(self):
+        """The feature doc's Effects Matrix section includes all five outcomes
+        and all five row labels (ConfidenceField, CyclicDecayField,
+        DecayingSortedField, AccessTracker, PredictionLedger).
+        """
+        with open(self._FEATURE_DOC, encoding="utf-8") as f:
+            text = f.read()
+
+        # All five outcome column headers must appear.
+        for outcome in ("acted", "used", "dismissed", "deferred", "contradicted"):
+            assert (
+                outcome in text
+            ), f"Expected outcome {outcome!r} in {self._FEATURE_DOC}"
+
+        # All five row labels must appear.
+        for row_label in (
+            "ConfidenceField",
+            "CyclicDecayField",
+            "DecayingSortedField",
+            "AccessTracker",
+            "PredictionLedger",
+        ):
+            assert (
+                row_label in text
+            ), f"Expected row label {row_label!r} in {self._FEATURE_DOC}"
+
+        # And there must be a table (pipe-separated row with the columns).
+        assert (
+            "| acted" in text or "|acted" in text
+        ), "Expected a Markdown table with an 'acted' column in the Effects Matrix"
+
+    def test_observation_module_docstring_points_to_feature_doc(self):
+        """The module docstring of popoto.fields.observation references the
+        feature doc so integrators using help() find the full matrix.
+        """
+        from popoto.fields import observation
+
+        assert observation.__doc__ is not None
+        assert "docs/features/observation-protocol.md" in observation.__doc__, (
+            "Expected module docstring to reference "
+            "docs/features/observation-protocol.md as a See Also pointer"
+        )
+
+    def test_on_context_used_docstring_mentions_coerce(self):
+        """on_context_used() docstring must warn integrators about strict
+        VALID_OUTCOMES validation, mention 'coerce', 'ValueError', and
+        cross-reference observation-protocol.md (NOT metacognitive-layer.md).
+        """
+        doc = ObservationProtocol.on_context_used.__doc__
+        assert doc is not None
+        for needle in ("coerce", "ValueError", "observation-protocol.md"):
+            assert (
+                needle in doc
+            ), f"Expected {needle!r} in on_context_used docstring, got:\n{doc}"
+
+    def test_changelog_has_used_migration_note(self):
+        """CHANGELOG.md v1.5.0 section includes a Migration note mentioning
+        the bespoke 'echoed' outcome integrators need to map into the
+        canonical vocabulary.
+        """
+        changelog = os.path.join(self._REPO_ROOT, "CHANGELOG.md")
+        with open(changelog, encoding="utf-8") as f:
+            text = f.read()
+
+        # Locate the v1.5.0 section (up to the next H2).
+        start = text.find("## [1.5.0")
+        assert start != -1, "Could not find v1.5.0 section in CHANGELOG"
+        end = text.find("\n## [", start + 1)
+        section = text[start:end] if end != -1 else text[start:]
+
+        assert (
+            "Migration" in section
+        ), "Expected 'Migration' sub-section in v1.5.0 CHANGELOG entry"
+        assert (
+            "echoed" in section
+        ), "Expected 'echoed' migration guidance in v1.5.0 CHANGELOG entry"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,43 @@
+"""Tests for popoto.__version__ (issue #370 item 3)."""
+
+import re
+from pathlib import Path
+
+import popoto
+
+
+def test_version_attribute_exists():
+    """popoto.__version__ is a non-empty PEP 440-looking string."""
+    assert hasattr(popoto, "__version__"), "popoto.__version__ is missing"
+    assert isinstance(popoto.__version__, str)
+    assert popoto.__version__, "popoto.__version__ is empty"
+    # PEP 440 minimum: N.N.N... optionally followed by + local / .devN etc.
+    assert re.match(
+        r"^\d+\.\d+\.\d+", popoto.__version__
+    ), f"popoto.__version__={popoto.__version__!r} does not match N.N.N prefix"
+
+
+def test_version_matches_pyproject():
+    """__version__ should begin with the pyproject.toml project version.
+
+    Allows dev/post suffixes (e.g. 1.5.0.dev1) but rejects silent drift.
+    If popoto is not installed from this source tree, the fallback
+    "0.0.0+unknown" is acceptable — we only enforce agreement when the
+    installed distribution is clearly this project.
+    """
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+    match = re.search(r'^\s*version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    assert match, "Could not parse version from pyproject.toml"
+    project_version = match.group(1)
+
+    # If we hit the source-tree fallback, skip the equality assertion — the
+    # package isn't installed from metadata, so importlib.metadata can't see
+    # the pyproject version.
+    if popoto.__version__ == "0.0.0+unknown":
+        return
+
+    assert popoto.__version__.startswith(project_version), (
+        f"popoto.__version__={popoto.__version__!r} does not start with "
+        f"pyproject version {project_version!r}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1792,7 +1792,7 @@ wheels = [
 
 [[package]]
 name = "popoto"
-version = "1.4.4"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "msgpack" },


### PR DESCRIPTION
## Summary

Ships the five DX gaps surfaced during the `ai` repo integration of popoto v1.5.0's agent-memory stack. Three items are pure docs, two add small additive public APIs — all backwards-compatible.

Refs #370.

## Items

- [x] **Item 1 (docs)** — Upgrade the "Effects Matrix" prose in `docs/features/observation-protocol.md` to a 5-outcome × 5-field table. Module docstring in `src/popoto/fields/observation.py` gets a "See Also" pointer (no table duplication).
- [x] **Item 2 (feat)** — `RetrievalQuality.from_records(records, query_cues=None, score_weights=None, max_items=10, surfacing_threshold=0.5)` classmethod for custom BM25/RRF/hybrid pipelines that want the metacognitive signal without adopting `ContextAssembler`. Heterogeneous record lists raise `TypeError` (C4). Existing `_compute_quality` helpers extracted to pure module-level functions with keyword-only args so the classmethod and instance methods share one numeric path (C2). Refactor safety net: hardcoded-scalar fixture test using `math.isclose(rel_tol=1e-9)` (C3).
- [x] **Item 3 (feat)** — `popoto.__version__` resolves via `importlib.metadata.version("popoto")`, falling back to `"0.0.0+unknown"` for source-tree imports. `pyproject.toml` stays the single source of truth.
- [x] **Item 4 (docs)** — `ObservationProtocol.on_context_used()` docstring explains strict `VALID_OUTCOMES` validation, says "coerce", names `ValueError`, and cross-references `observation-protocol.md` (not `metacognitive-layer.md` — fixed per critique C5).
- [x] **Item 5 (docs)** — `CHANGELOG.md` v1.5.0 entry gets a "Migration" sub-section for integrators mapping bespoke `"echoed"` outcomes into the canonical vocabulary. Mirrored as a one-line bullet in `docs/features/observation-protocol.md`.

## Testing

- [x] `tests/test_version.py` — 2 tests (attribute exists, matches pyproject)
- [x] `tests/test_observation_protocol.py::TestFeatureDocAndDocstrings` — 4 tests (effects table present, module docstring pointer, `on_context_used` coerce note, CHANGELOG migration note)
- [x] `tests/test_context_assembler.py::TestRetrievalQualityAssembler::test_assess_numeric_fixture` — C3 hardcoded-scalar regression guard (`math.isclose` tolerance)
- [x] `tests/test_context_assembler.py::TestRetrievalQualityFromRecords` — 4 tests: C1 parity (`assemble(..., assess_quality=True)` vs `from_records` on identical records/config), empty list, no-cues/no-weights, mixed-models TypeError (C4)
- [x] Full suite: `1356 passed, 14 skipped` (slow-marker tests deselected)
- [x] `black --check src/ tests/` clean; `mypy src/` shows no new errors (942 pre-existing)

## Documentation

- [x] `docs/features/metacognitive-layer.md` — new "Building RetrievalQuality from a custom pipeline" sub-section with a five-line example
- [x] `docs/api-reference.md` — new "Version introspection" section covering `popoto.__version__`

## Semver

Per plan Open Question 1: **`v1.6.0` minor bump** recommended. The `feat:` commits (`feat(recipes)`, `feat(popoto)`) trigger a minor bump under release-please's conventional-commits rules. Purely additive, no breaking changes, no deprecations.

Plan: `docs/plans/integration_feedback_dx_gaps.md`