### PR TITLE
Release v1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "popoto"
-version = "1.5.0"
+version = "1.6.0"
 description = "A Python Redis ORM"
 readme = "README.md"
 authors = [{ name = "Tom Counsell", email = "other@tomcounsell.com" }]


### PR DESCRIPTION
Bump version to 1.6.0.

## Changes since v1.5.0

- docs: nav restructure, external links, popoto.io domain (#377)
- docs: Material theme, auto-API, llms.txt, CI auto-deploy (#375)
- DX: integration feedback items from #370 (#372)
- Plan: Integration feedback DX gaps (#370) (#371)

## Release checklist

- [x] All tests pass (1566 passed, 10 skipped)
- [x] Working tree clean
- [x] Version bumped in pyproject.toml