### PR TITLE
chore: sync uv.lock with v1.6.0 version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2144,7 +2144,7 @@ wheels = [
 
 [[package]]
 name = "popoto"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "msgpack" },


### PR DESCRIPTION
## Summary
The v1.6.0 release bump (#378) updated pyproject.toml but did not regenerate uv.lock, leaving the lockfile out of sync. Caught while running the do-merge gate for #381 — `uv lock --locked` fails on main, blocking downstream merges.

## Test plan
- [x] `uv lock --locked` exits 0 on this branch
- [x] No functional changes (single line: `popoto v1.5.0 -> v1.6.0` inside the editable self-entry)