### PR TITLE
Release v1.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "popoto"
-version = "1.6.0"
+version = "1.6.1"
 description = "A Python Redis ORM"
 readme = "README.md"
 authors = [{ name = "Tom Counsell", email = "other@tomcounsell.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -2144,7 +2144,7 @@ wheels = [
 
 [[package]]
 name = "popoto"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "msgpack" },


### PR DESCRIPTION
## Summary
Patch release for #380 — fixes lazy-loaded model instances leaking the class-level `Field` descriptor object for fields absent from the Redis hash.

## Changes since v1.6.0
- fix(encoding): initialize defaults for fields absent from lazy-loaded hash (#381 / closes #380)
- chore: sync uv.lock with v1.6.0 version bump (#383)

## Test plan
- [x] Full pytest suite: 1524 passed, 28 skipped (run locally on merged main code)
- [x] CI stress + valkey passed on #381
- [x] `uv lock --locked` passes