### PR TITLE
fix(indexes): detect partial-write orphans in clean/check_indexes (#385)

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -182,14 +182,35 @@ assert after['total'] == 0
 
 ```python
 {
-    'class_set': int,
+    'class_set': int,         # absent-hash orphans (EXISTS == 0)
+    'partial_writes': int,    # hash exists but missing the AutoKeyField value
     'key_fields': {field_name: int, ...},
     'sorted_fields': {field_name: int, ...},
     'geo_fields': {field_name: int, ...},
     'composite_indexes': {index_key: int, ...},
-    'total': int,
+    'total': int,             # sum of all the above
 }
 ```
+
+### Partial-Write Orphans
+
+For models whose primary key is a single `AutoKeyField`, `check_indexes()`
+also detects **partial-write orphans**: hashes that exist in Redis but are
+missing the auto-key field value. These appear as ghost rows in
+`query.all()` (with `id=None`, `_redis_key=None`) and `instance.delete()`
+silently no-ops on them. Common causes are crashed saves and mid-pipeline
+process exits.
+
+When `clean_indexes()` encounters a partial-write orphan it removes the
+class-set membership AND issues `DEL` on the corrupt hash — the hash is
+unrecoverable and must not linger in Redis. Models with composite
+`KeyField`s (no single `AutoKeyField`) skip this check; their behavior is
+unchanged.
+
+> **Operational guidance:** Do not run `clean_indexes()` during active
+> migrations or HDEL-based field migrations. A brief HDEL window on the
+> auto-key field can cause healthy hashes to be misclassified as
+> partial-write orphans and deleted. Run during low-traffic periods.
 
 ### When to Use `rebuild_indexes()` vs `clean_indexes()`
 

--- a/src/popoto/models/base.py
+++ b/src/popoto/models/base.py
@@ -2844,6 +2844,123 @@ class Model(metaclass=ModelBase):
         return count
 
     @classmethod
+    def _get_auto_key_field_name(cls) -> "str | None":
+        """Return the name of the model's single AutoKeyField, or None.
+
+        Used by check_indexes() and clean_indexes() to gate "partial-write
+        orphan" detection. Returns the field name only when the model has
+        EXACTLY ONE field with `auto=True` (i.e., a single AutoKeyField,
+        explicit or implicit). Returns None for:
+
+        - Models with zero AutoKeyFields (composite KeyField models).
+        - Models with multiple AutoKeyFields (ambiguous primary key).
+
+        For models defined without any explicit KeyField, popoto adds an
+        implicit `_auto_key` AutoKeyField at instance __init__ time
+        (see Model.__init__). That field is not registered on `_meta` until
+        the first instance is created. To make the helper robust for
+        classmethod use before any instance exists, this method instantiates
+        the class once if it sees zero key fields registered AND no auto
+        field — this triggers the implicit `_auto_key` registration.
+
+        Returns:
+            The name of the lone AutoKeyField, or None if the model is
+            ineligible for partial-write detection.
+        """
+        # Try to find an auto field already registered on the metaclass.
+        auto_names = [
+            name
+            for name, field in cls._meta.fields.items()
+            if getattr(field, "auto", False)
+        ]
+
+        # If no auto field is registered AND no explicit key fields exist,
+        # an implicit `_auto_key` would be added on instance init. Trigger
+        # that registration once so the introspection works classmethod-side.
+        if not auto_names and not cls._meta.key_field_names:
+            try:
+                cls()
+            except Exception:
+                # If instantiation fails (e.g., required fields), we cannot
+                # introspect further — treat as ineligible.
+                return None
+            auto_names = [
+                name
+                for name, field in cls._meta.fields.items()
+                if getattr(field, "auto", False)
+            ]
+
+        if len(auto_names) == 1:
+            return auto_names[0]
+        return None
+
+    @classmethod
+    def _classify_class_set_orphans(
+        cls,
+        members: list,
+        batch_size: int,
+        auto_key_field_name: "str | None",
+    ) -> "tuple[list, list]":
+        """Classify class-set members into (absent_orphans, partial_write_orphans).
+
+        Pipelines EXISTS for every member in batches. When `auto_key_field_name`
+        is provided, the same pipeline batch ALSO issues HGET on the auto-key
+        field for each member — interleaved one-EXISTS-one-HGET — so a single
+        ``pipe.execute()`` round-trip per batch handles both checks. The 2:1
+        result-pairing is unzipped via index arithmetic (see inline comment).
+
+        Categorization:
+        - ``EXISTS == 0`` -> "absent orphan" (existing behavior; SREM target).
+        - ``EXISTS == 1`` AND ``HGET in (None, b"", "")`` -> "partial-write
+          orphan" (new; SREM + DEL target).
+        - ``EXISTS == 1`` AND ``HGET == <value>`` -> healthy (no action).
+
+        When `auto_key_field_name is None` (composite-KeyField models, ineligible
+        for partial-write detection), the pipeline issues EXISTS only and the
+        partial-write list is always empty — preserves the original behavior.
+
+        Whitespace-only HGET values count as healthy (no whitespace stripping).
+
+        Args:
+            members: Class-set members (Redis keys) to classify.
+            batch_size: Pipeline batch size.
+            auto_key_field_name: Name of the model's AutoKeyField, or None.
+
+        Returns:
+            Tuple ``(absent_orphans, partial_write_orphans)`` of lists of keys.
+        """
+        absent_orphans: list = []
+        partial_write_orphans: list = []
+        eligible_for_partial = auto_key_field_name is not None
+
+        for i in range(0, len(members), batch_size):
+            batch = members[i : i + batch_size]
+            pipe = POPOTO_REDIS_DB.pipeline()
+            for key in batch:
+                pipe.exists(key)
+                if eligible_for_partial:
+                    # Interleaved with EXISTS so one round-trip handles both.
+                    pipe.hget(key, auto_key_field_name)
+            results = pipe.execute()
+
+            if eligible_for_partial:
+                # 2:1 result-pairing: results[2*i] == EXISTS for batch[i],
+                # results[2*i + 1] == HGET for batch[i].
+                for j, key in enumerate(batch):
+                    exists = results[2 * j]
+                    hget_value = results[2 * j + 1]
+                    if not exists:
+                        absent_orphans.append(key)
+                    elif hget_value is None or hget_value == b"" or hget_value == "":
+                        partial_write_orphans.append(key)
+            else:
+                for key, exists in zip(batch, results):
+                    if not exists:
+                        absent_orphans.append(key)
+
+        return absent_orphans, partial_write_orphans
+
+    @classmethod
     def check_indexes(cls, batch_size: int = 1000) -> dict:
         """Read-only health check that counts orphaned index entries.
 
@@ -2852,31 +2969,49 @@ class Model(metaclass=ModelBase):
         instance key still exists in Redis. Returns a structured dict with
         orphan counts per index type.
 
+        For models whose primary key is a single ``AutoKeyField``, the
+        class-set scan additionally detects **partial-write orphans**:
+        hashes that exist in Redis but are missing the auto-key field
+        (``id`` / ``uuid`` / ``_auto_key`` etc). These appear as ghost rows
+        in ``query.all()`` and are reported under the ``partial_writes`` key.
+        Models with composite KeyFields (no single AutoKeyField) skip this
+        check; their ``partial_writes`` count is always 0.
+
         This method makes zero writes to Redis. It is safe to call in
         production at any time. Note that counts are point-in-time snapshots;
-        concurrent writes may cause minor discrepancies.
+        concurrent writes may cause minor discrepancies. Avoid running during
+        active migrations or HDEL-based field migrations: a brief HDEL window
+        on the auto-key field can produce false-positive partial-write counts.
 
         Args:
             batch_size: Number of EXISTS commands per pipeline batch.
                 Default is 1000. Lower values use less memory but require
-                more round-trips.
+                more round-trips. For AutoKeyField-eligible models, the
+                class-set batch issues one EXISTS + one HGET per key in a
+                single pipeline (one network round-trip per batch).
 
         Returns:
             Dict with orphan counts per index type::
 
                 {
-                    'class_set': int,
+                    'class_set': int,         # absent-hash orphans
+                    'partial_writes': int,    # hash exists but missing auto-key
                     'key_fields': {field_name: int, ...},
                     'sorted_fields': {field_name: int, ...},
                     'geo_fields': {field_name: int, ...},
                     'composite_indexes': {index_key: int, ...},
-                    'total': int,
+                    'total': int,             # sum of all the above
                 }
 
         Example:
             result = User.check_indexes()
             if result['total'] > 0:
                 print(f"Found {result['total']} orphaned index entries")
+                if result['partial_writes'] > 0:
+                    print(
+                        f"Of those, {result['partial_writes']} are corrupt "
+                        f"hashes that will be DEL'd by clean_indexes()."
+                    )
                 User.rebuild_indexes()
         """
 
@@ -2927,6 +3062,7 @@ class Model(metaclass=ModelBase):
 
         result = {
             "class_set": 0,
+            "partial_writes": 0,
             "key_fields": {},
             "sorted_fields": {},
             "geo_fields": {},
@@ -2934,11 +3070,17 @@ class Model(metaclass=ModelBase):
             "total": 0,
         }
 
-        # 1. Check class set
+        # 1. Check class set (and detect partial-write orphans for
+        #    AutoKeyField-eligible models).
         class_set_key = cls._meta.db_class_set_key.redis_key
         members = _scan_set_members(class_set_key)
         if members:
-            result["class_set"] = _count_orphans(members)
+            auto_key_field_name = cls._get_auto_key_field_name()
+            absent, partial_writes = cls._classify_class_set_orphans(
+                members, batch_size, auto_key_field_name
+            )
+            result["class_set"] = len(absent)
+            result["partial_writes"] = len(partial_writes)
 
         # 2. Check key field sets
         for field_name in cls._meta.key_field_names:
@@ -2989,9 +3131,10 @@ class Model(metaclass=ModelBase):
                 index_orphans = _count_orphans(values)
             result["composite_indexes"][index_key] = index_orphans
 
-        # Compute total
+        # Compute total (includes partial-write orphans).
         result["total"] = (
             result["class_set"]
+            + result["partial_writes"]
             + sum(result["key_fields"].values())
             + sum(result["sorted_fields"].values())
             + sum(result["geo_fields"].values())
@@ -3009,18 +3152,36 @@ class Model(metaclass=ModelBase):
         instance keys which no longer exist in Redis. This is the write
         counterpart to check_indexes().
 
+        For models whose primary key is a single ``AutoKeyField``, the
+        class-set scan additionally detects **partial-write orphans**:
+        hashes that exist in Redis but are missing the auto-key field.
+        Such hashes are unrecoverable from the application's perspective
+        (``id`` is None, ``_redis_key`` cannot be computed, ``delete()``
+        silently no-ops). For these orphans, ``clean_indexes()`` removes
+        the class-set membership AND issues ``DEL`` on the corrupt hash —
+        no Redis memory is left behind. Models with composite KeyFields
+        (no single AutoKeyField) skip this check; their behavior is
+        identical to before.
+
         Uses SCAN-based iteration (SSCAN, ZSCAN, HSCAN) instead of the
         KEYS command, making it safe to run on production databases.
         For best results, run during low-traffic periods to minimize
-        the chance of race conditions with concurrent writes.
+        the chance of race conditions with concurrent writes. **Do not
+        run during active migrations or HDEL-based field migrations**: a
+        brief HDEL window on the auto-key field can cause healthy hashes
+        to be misclassified as partial-write orphans and deleted.
 
         Args:
             batch_size: Number of EXISTS/removal commands per pipeline
                 batch. Default is 1000. Lower values use less memory
-                but require more round-trips.
+                but require more round-trips. For AutoKeyField-eligible
+                models, the class-set batch issues one EXISTS + one HGET
+                per key in a single pipeline (one network round-trip per
+                batch).
 
         Returns:
-            Total number of orphaned index entries removed.
+            Total number of orphaned index entries removed (absent
+            orphans + partial-write orphans + per-field orphans).
 
         Example:
             # Check first, then clean
@@ -3079,17 +3240,28 @@ class Model(metaclass=ModelBase):
 
         removed = 0
 
-        # 1. Clean class set
+        # 1. Clean class set (and DEL partial-write orphans for
+        #    AutoKeyField-eligible models).
         class_set_key = cls._meta.db_class_set_key.redis_key
         members = _scan_set_members(class_set_key)
         if members:
-            orphans = _collect_orphans(members)
-            if orphans:
+            auto_key_field_name = cls._get_auto_key_field_name()
+            absent, partial_writes = cls._classify_class_set_orphans(
+                members, batch_size, auto_key_field_name
+            )
+            if absent or partial_writes:
                 pipe = POPOTO_REDIS_DB.pipeline()
-                for orphan in orphans:
+                # Absent orphans: SREM the stale class-set membership
+                # (hash is already gone — nothing to DEL).
+                for orphan in absent:
                     pipe.srem(class_set_key, orphan)
+                # Partial-write orphans: SREM AND DEL — the corrupt hash
+                # is unrecoverable and must not linger in Redis.
+                for orphan in partial_writes:
+                    pipe.srem(class_set_key, orphan)
+                    pipe.delete(orphan)
                 pipe.execute()
-                removed += len(orphans)
+                removed += len(absent) + len(partial_writes)
 
         # 2. Clean key field sets
         for field_name in cls._meta.key_field_names:

--- a/tests/test_check_indexes.py
+++ b/tests/test_check_indexes.py
@@ -13,7 +13,6 @@ import popoto
 from popoto.redis_db import POPOTO_REDIS_DB
 from popoto.fields.geo_field import GeoField
 
-
 # ---------------------------------------------------------------------------
 # Test model definitions
 # ---------------------------------------------------------------------------
@@ -217,6 +216,7 @@ class TestCheckIndexesOrphanDetection:
         result = CheckUser.check_indexes()
         expected_total = (
             result["class_set"]
+            + result["partial_writes"]
             + sum(result["key_fields"].values())
             + sum(result["sorted_fields"].values())
             + sum(result["geo_fields"].values())
@@ -306,6 +306,7 @@ class TestCheckIndexesReturnStructure:
         """Return dict contains all expected keys."""
         result = CheckUser.check_indexes()
         assert "class_set" in result
+        assert "partial_writes" in result
         assert "key_fields" in result
         assert "sorted_fields" in result
         assert "geo_fields" in result
@@ -316,11 +317,23 @@ class TestCheckIndexesReturnStructure:
         """Return dict values have correct types."""
         result = CheckUser.check_indexes()
         assert isinstance(result["class_set"], int)
+        assert isinstance(result["partial_writes"], int)
         assert isinstance(result["key_fields"], dict)
         assert isinstance(result["sorted_fields"], dict)
         assert isinstance(result["geo_fields"], dict)
         assert isinstance(result["composite_indexes"], dict)
         assert isinstance(result["total"], int)
+
+    def test_partial_writes_zero_for_composite_keyfield_model(self):
+        """Models with composite KeyField (no AutoKeyField) always report 0."""
+        result = CheckComposite.check_indexes()
+        assert result["partial_writes"] == 0
+
+    def test_partial_writes_present_for_minimal_automodel(self):
+        """AutoKeyField-eligible model exposes the partial_writes key."""
+        result = CheckMinimal.check_indexes()
+        assert result["partial_writes"] == 0
+        assert isinstance(result["partial_writes"], int)
 
     def test_batch_size_parameter(self):
         """batch_size parameter is accepted and produces same results."""
@@ -357,3 +370,128 @@ class TestAsyncCheckIndexes:
         result = asyncio.run(CheckUser.async_check_indexes())
         assert result["total"] >= 1
         assert result["class_set"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: Partial-write orphan detection
+# ---------------------------------------------------------------------------
+
+
+def _inject_partial_write_orphan(model_cls, missing_field_name: str) -> str:
+    """Manually create a partial-write orphan: a hash that exists in Redis
+    but is missing the given primary-key field, and is registered in the
+    class set.
+
+    Returns the orphan's redis_key (str).
+    """
+    class_set_key = model_cls._meta.db_class_set_key.redis_key
+    # Build a fake redis key with the right shape: ClassName:<auto_id_value>
+    # Use a placeholder value matching AutoKeyField's default uuid4 length (32).
+    fake_value = "deadbeef" * 4  # 32 chars
+    orphan_redis_key = f"{model_cls.__name__}:{fake_value}"
+
+    # Inject a hash with EVERY field EXCEPT the auto-key. This simulates
+    # a save that completed pipeline.hset for non-key fields but the
+    # auto-key field was either never set or was HDEL'd by a migration.
+    POPOTO_REDIS_DB.hset(orphan_redis_key, mapping={"data": "ghost"})
+    POPOTO_REDIS_DB.sadd(class_set_key, orphan_redis_key)
+    return orphan_redis_key
+
+
+def _inject_partial_write_orphan_with_value(
+    model_cls, missing_field_name: str, raw_value
+) -> str:
+    """Like _inject_partial_write_orphan but writes the auto-key field with
+    a specific raw value (e.g., empty bytes/string) to verify normalization.
+    """
+    class_set_key = model_cls._meta.db_class_set_key.redis_key
+    fake_value = "feedbeef" * 4
+    orphan_redis_key = f"{model_cls.__name__}:{fake_value}"
+    POPOTO_REDIS_DB.hset(
+        orphan_redis_key,
+        mapping={"data": "ghost", missing_field_name: raw_value},
+    )
+    POPOTO_REDIS_DB.sadd(class_set_key, orphan_redis_key)
+    return orphan_redis_key
+
+
+class TestCheckIndexesPartialWriteOrphans:
+    """Verify partial-write orphan detection in check_indexes()."""
+
+    def test_partial_write_orphan_counted(self):
+        """A class-set member whose hash lacks the auto-key is counted."""
+        # Create one healthy instance to make sure healthy rows aren't
+        # mis-counted as partial-writes.
+        CheckMinimal.create(data="healthy")
+
+        _inject_partial_write_orphan(CheckMinimal, "uuid")
+
+        result = CheckMinimal.check_indexes()
+        assert result["partial_writes"] == 1
+        # The hash exists, so the absent-orphan count should NOT include it.
+        assert result["class_set"] == 0
+
+    def test_partial_write_increments_total(self):
+        """The total field includes partial_writes."""
+        _inject_partial_write_orphan(CheckMinimal, "uuid")
+
+        result = CheckMinimal.check_indexes()
+        assert result["total"] >= result["partial_writes"]
+        assert result["total"] >= 1
+
+    def test_empty_bytes_value_counts_as_missing(self):
+        """An auto-key field set to b"" is treated as a partial-write orphan."""
+        _inject_partial_write_orphan_with_value(CheckMinimal, "uuid", b"")
+        result = CheckMinimal.check_indexes()
+        assert result["partial_writes"] == 1
+
+    def test_empty_str_value_counts_as_missing(self):
+        """An auto-key field set to "" is treated as a partial-write orphan."""
+        _inject_partial_write_orphan_with_value(CheckMinimal, "uuid", "")
+        result = CheckMinimal.check_indexes()
+        assert result["partial_writes"] == 1
+
+    def test_whitespace_value_counts_as_healthy(self):
+        """An auto-key field set to " " is NOT treated as missing.
+
+        Whitespace stripping is intentionally out of scope (see plan
+        Rabbit Holes). Only None / b"" / "" count as missing.
+        """
+        _inject_partial_write_orphan_with_value(CheckMinimal, "uuid", " ")
+        result = CheckMinimal.check_indexes()
+        assert result["partial_writes"] == 0
+
+    def test_composite_keyfield_model_skips_partial_write_check(self):
+        """Composite-KeyField models never report partial_writes > 0.
+
+        Even if we inject a hash that lacks every field, the model has no
+        single AutoKeyField so the eligibility gate must short-circuit.
+        """
+        # Inject a class-set member with a hash that exists but is empty
+        # of the composite key fields.
+        class_set_key = CheckComposite._meta.db_class_set_key.redis_key
+        fake_redis_key = "CheckComposite:item_x"
+        POPOTO_REDIS_DB.hset(fake_redis_key, mapping={"category": "tools"})
+        POPOTO_REDIS_DB.sadd(class_set_key, fake_redis_key)
+
+        result = CheckComposite.check_indexes()
+        # The composite-KeyField model must not classify this as a partial-write.
+        assert result["partial_writes"] == 0
+
+    def test_async_reports_partial_writes(self):
+        """async_check_indexes returns the new dict shape with partial_writes."""
+        _inject_partial_write_orphan(CheckMinimal, "uuid")
+
+        result = asyncio.run(CheckMinimal.async_check_indexes())
+        assert "partial_writes" in result
+        assert result["partial_writes"] == 1
+        assert result["total"] >= 1
+
+    def test_round_trip_with_clean(self):
+        """clean_indexes removes partial-writes; subsequent check returns 0."""
+        _inject_partial_write_orphan(CheckMinimal, "uuid")
+        assert CheckMinimal.check_indexes()["partial_writes"] == 1
+
+        CheckMinimal.clean_indexes()
+
+        assert CheckMinimal.check_indexes()["partial_writes"] == 0

--- a/tests/test_clean_indexes.py
+++ b/tests/test_clean_indexes.py
@@ -14,7 +14,6 @@ import popoto
 from popoto.redis_db import POPOTO_REDIS_DB
 from popoto.fields.geo_field import GeoField
 
-
 # ---------------------------------------------------------------------------
 # Test model definitions (reuse same patterns as test_check_indexes.py)
 # ---------------------------------------------------------------------------
@@ -326,9 +325,9 @@ class TestDeprecationWarning:
         with caplog.at_level(logging.WARNING):
             CleanUser.query.keys(clean=True)
 
-        assert any("clean_indexes()" in record.message for record in caplog.records), (
-            f"Expected warning referencing clean_indexes(), got: {[r.message for r in caplog.records]}"
-        )
+        assert any(
+            "clean_indexes()" in record.message for record in caplog.records
+        ), f"Expected warning referencing clean_indexes(), got: {[r.message for r in caplog.records]}"
 
     def test_warning_says_deprecated(self, caplog):
         """Warning message says deprecated."""
@@ -340,3 +339,126 @@ class TestDeprecationWarning:
         assert any(
             "deprecated" in record.message.lower() for record in caplog.records
         ), f"Expected deprecation warning, got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Partial-write orphan removal (DEL + SREM)
+# ---------------------------------------------------------------------------
+
+
+def _inject_partial_write_orphan(model_cls, missing_field_name: str) -> str:
+    """Manually create a partial-write orphan: a hash that exists in Redis
+    but is missing the given primary-key field, and is registered in the
+    class set.
+
+    Returns the orphan's redis_key (str).
+    """
+    class_set_key = model_cls._meta.db_class_set_key.redis_key
+    fake_value = "deadbeef" * 4  # 32 chars (matches AutoKeyField default length)
+    orphan_redis_key = f"{model_cls.__name__}:{fake_value}"
+    POPOTO_REDIS_DB.hset(orphan_redis_key, mapping={"data": "ghost"})
+    POPOTO_REDIS_DB.sadd(class_set_key, orphan_redis_key)
+    return orphan_redis_key
+
+
+class TestCleanIndexesPartialWriteOrphans:
+    """Verify partial-write orphan removal in clean_indexes()."""
+
+    def test_partial_write_orphan_removed_from_class_set(self):
+        """The orphan's class-set membership is SREM'd."""
+        orphan_key = _inject_partial_write_orphan(CleanMinimal, "uuid")
+        class_set_key = CleanMinimal._meta.db_class_set_key.redis_key
+
+        assert POPOTO_REDIS_DB.sismember(class_set_key, orphan_key) == 1
+
+        removed = CleanMinimal.clean_indexes()
+        assert removed >= 1
+        assert POPOTO_REDIS_DB.sismember(class_set_key, orphan_key) == 0
+
+    def test_partial_write_orphan_hash_deleted(self):
+        """The orphan hash itself is DEL'd from Redis (no leftover memory)."""
+        orphan_key = _inject_partial_write_orphan(CleanMinimal, "uuid")
+
+        assert POPOTO_REDIS_DB.exists(orphan_key) == 1
+
+        CleanMinimal.clean_indexes()
+        assert POPOTO_REDIS_DB.exists(orphan_key) == 0
+
+    def test_partial_write_round_trip_with_check(self):
+        """After clean_indexes, check_indexes reports partial_writes == 0."""
+        _inject_partial_write_orphan(CleanMinimal, "uuid")
+        assert CleanMinimal.check_indexes()["partial_writes"] == 1
+
+        CleanMinimal.clean_indexes()
+
+        result_after = CleanMinimal.check_indexes()
+        assert result_after["partial_writes"] == 0
+        assert result_after["total"] == 0
+
+    def test_partial_write_count_in_return(self):
+        """clean_indexes return count includes partial-write orphans."""
+        # Healthy instance — should not be touched.
+        CleanMinimal.create(data="healthy")
+        # Two partial-write orphans.
+        _inject_partial_write_orphan(CleanMinimal, "uuid")
+        # Inject a second one with a different fake key.
+        class_set_key = CleanMinimal._meta.db_class_set_key.redis_key
+        second_key = "CleanMinimal:" + ("cafebabe" * 4)
+        POPOTO_REDIS_DB.hset(second_key, mapping={"data": "ghost2"})
+        POPOTO_REDIS_DB.sadd(class_set_key, second_key)
+
+        removed = CleanMinimal.clean_indexes()
+        assert removed >= 2
+
+    def test_composite_keyfield_partial_write_not_deleted(self):
+        """Composite-KeyField model: ineligible — hash MUST NOT be deleted.
+
+        Verifies the eligibility gate: even when a hash is missing fields,
+        composite-KeyField models take the original EXISTS-only path.
+        """
+        class_set_key = CleanComposite._meta.db_class_set_key.redis_key
+        fake_key = "CleanComposite:safehash"
+        POPOTO_REDIS_DB.hset(fake_key, mapping={"category": "tools"})
+        POPOTO_REDIS_DB.sadd(class_set_key, fake_key)
+
+        CleanComposite.clean_indexes()
+
+        # Hash exists -> EXISTS == 1 -> NOT classified as absent orphan.
+        # Composite model is ineligible -> NOT classified as partial-write either.
+        # Therefore the hash and class-set membership must remain.
+        assert POPOTO_REDIS_DB.exists(fake_key) == 1
+        assert POPOTO_REDIS_DB.sismember(class_set_key, fake_key) == 1
+
+        # Cleanup so the test-isolation flushdb won't be needed for siblings.
+        POPOTO_REDIS_DB.delete(fake_key)
+        POPOTO_REDIS_DB.srem(class_set_key, fake_key)
+
+    def test_async_removes_partial_write_orphans(self):
+        """async_clean_indexes removes partial-write orphans (sync parity)."""
+        orphan_key = _inject_partial_write_orphan(CleanMinimal, "uuid")
+
+        removed = asyncio.run(CleanMinimal.async_clean_indexes())
+        assert removed >= 1
+        assert POPOTO_REDIS_DB.exists(orphan_key) == 0
+
+        # Round-trip: nothing left to flag.
+        result_after = asyncio.run(CleanMinimal.async_check_indexes())
+        assert result_after["partial_writes"] == 0
+
+    def test_healthy_instance_not_touched(self):
+        """A healthy instance alongside an orphan must survive cleanup."""
+        healthy = CleanMinimal.create(data="keep_me")
+        healthy_key = healthy.db_key.redis_key
+        orphan_key = _inject_partial_write_orphan(CleanMinimal, "uuid")
+
+        assert POPOTO_REDIS_DB.exists(healthy_key) == 1
+        assert POPOTO_REDIS_DB.exists(orphan_key) == 1
+
+        CleanMinimal.clean_indexes()
+
+        # Orphan gone, healthy survives.
+        assert POPOTO_REDIS_DB.exists(orphan_key) == 0
+        assert POPOTO_REDIS_DB.exists(healthy_key) == 1
+        # Class-set integrity preserved for the healthy row.
+        class_set_key = CleanMinimal._meta.db_class_set_key.redis_key
+        assert POPOTO_REDIS_DB.sismember(class_set_key, healthy_key) == 1


### PR DESCRIPTION
## Summary

`clean_indexes()` now detects **partial-write orphans** — hashes that exist in Redis but are missing their `AutoKeyField` primary key. This was a class of corruption invisible to the existing `EXISTS`-only orphan detection.

For these orphans, `clean_indexes()` removes the class-set membership AND issues `DEL` on the corrupt hash; `check_indexes()` reports them under a new top-level `partial_writes` key in the return dict.

Closes #385.

## Why this matters

A hash without its auto-key field is unrecoverable from the application's perspective:
- `query.all()` returns instances with `id=None` and `_redis_key=None` (ghost rows)
- `instance.delete()` silently no-ops
- The hash sits in Redis until its TTL expires

Before this fix, `clean_indexes()` could not remove these — only the application that wrote them could, but it had no way to find them either.

## Changes

**Implementation (`src/popoto/models/base.py`):**
- New helper `Model._get_auto_key_field_name()` — eligibility gate. Returns the lone AutoKeyField name, or `None` for models with zero or multiple AutoKeyFields. Composite-KeyField models take the original EXISTS-only path with no behavioral change.
- New helper `Model._classify_class_set_orphans()` — interleaves EXISTS + HGET in a single pipeline (one round-trip per batch) and returns `(absent_orphans, partial_write_orphans)`.
- `check_indexes()` — `result["partial_writes"]` initialized alongside `class_set` regardless of model eligibility (stable dict shape). `total` summation includes it.
- `clean_indexes()` — partial-write orphans get `pipeline.srem` + `pipeline.delete` in the same `.execute()`. Return count rolls them in.
- "Missing primary key" normalized as `None` / `b""` / `""`. Whitespace counts as healthy (no whitespace stripping).
- Async wrappers inherit the new behavior (they delegate via `to_thread`).

**Docs (`docs/recipes.md`):**
- New "Partial-Write Orphans" section explaining the behavior and operational guidance ("do not run during active migrations").
- Updated example return-dict shape to show `partial_writes`.

**Tests:**
- `TestCheckIndexesPartialWriteOrphans` (8 tests) in `tests/test_check_indexes.py`
- `TestCleanIndexesPartialWriteOrphans` (7 tests) in `tests/test_clean_indexes.py`
- `TestCheckIndexesReturnStructure` updated to assert `partial_writes` key/type.
- `test_total_is_sum_of_all_types` updated to include `partial_writes` in expected sum.

## Testing

- `pytest tests/test_check_indexes.py tests/test_clean_indexes.py -v` — **58 passed** (41 existing + 17 new)
- Full suite: **1550 passed, 18 skipped**, 1 unrelated preexisting failure (`test_version.py` — `popoto.__version__` is `1.5.0` but pyproject is `1.6.1`; not introduced by this PR)
- `black src/popoto/models/base.py tests/test_check_indexes.py tests/test_clean_indexes.py` — clean

## Verification (from plan)

| Check | Status |
|-------|--------|
| Targeted tests pass | PASS (58/58) |
| Full test suite | PASS (preexisting unrelated version test failure only) |
| Format clean | PASS |
| `partial_writes` key in dict | PASS (`['class_set', 'composite_indexes', 'geo_fields', 'key_fields', 'partial_writes', 'sorted_fields', 'total']`) |

## Definition of Done

- [x] Built: code implemented and working
- [x] Tested: 58 targeted tests pass; full suite green (modulo preexisting failure)
- [x] Documented: `docs/recipes.md` updated; both method docstrings expanded
- [x] Quality: black formatted

## Plan & Critique

Plan: `docs/plans/clean_indexes_partial_write_orphans.md`. All 10 critique-derived load-bearing items in the "Implementation Notes" checklist are honored:

1. Single-pipeline interleave (EXISTS + HGET) — implemented in `_classify_class_set_orphans`, with inline 2:1 unzip comment
2. Eligibility gate strict — `_get_auto_key_field_name()` returns `None` for 0 or >1 auto fields; composite test verifies negation
3. Normalize "missing" — None, `b""`, `""` all match; explicit unit tests for `b""` and `""`; whitespace-healthy test
4. Stable dict shape — `partial_writes: 0` always initialized
5. DRY helper — single `_classify_class_set_orphans` consumed by both methods
6. DEL plus SREM in same pipeline.execute()
7. Docstrings updated on both methods
8. Async parity tests included
9. No new flags / no new public methods
10. No upstream-cause investigation in this PR

Closes #385