### PR TITLE
feat(confidence): capped-evidence Bayesian update + crystallize watermark idempotence (#407)

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -7,7 +7,7 @@ Agent-memory primitives and recipes shipped in Popoto.
 | [Agent Memory](agent-memory.md) | Overview of the 14-primitive agent-memory system | Stable |
 | [CoOccurrenceField](co-occurrence-field.md) | Associative co-occurrence graph for candidate expansion | Stable |
 | [CompositeScoreQuery](composite-score-query.md) | Multi-factor ranked retrieval across sorted indexes | Stable |
-| [ConfidenceField](confidence-field.md) | Bayesian certainty tracking with corroborate/contradict updates | Stable |
+| [ConfidenceField](confidence-field.md) | Capped-evidence certainty tracking with corroborate/contradict updates | Stable |
 | [ContentField + EmbeddingField](content-and-embedding-fields.md) | Large content routing and vector embedding storage | Stable |
 | [ContextAssembler](context-assembler.md) | Retrieval-to-injection bridge orchestrating pull and push paths | Stable |
 | [CyclicDecayField](cyclic-decay-field.md) | Cyclical resonance, pressure, and proactive surfacing | Stable |

--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -468,7 +468,7 @@ See [fields.md](../fields.md#writefiltermixin) for the full field reference.
 
 ## ConfidenceField
 
-A `Field` subclass that tracks Bayesian confidence metadata per member, updated atomically via Lua script. Precision grows with `sqrt(n)` — early evidence has outsized effect while established beliefs resist change.
+A `Field` subclass that tracks confidence metadata per member, updated atomically via Lua script using a capped-evidence Bayesian rule. Within the evidence window (default cap: 20) updates form an exact running mean — order-invariant and prior-weighted. Beyond the cap, a fixed gain produces bounded exponential forgetting.
 
 Shipped in [PR #215](https://github.com/tomcounsell/popoto/pull/215).
 
@@ -498,13 +498,14 @@ data = ConfidenceField.get_confidence_data(knowledge, "certainty")
 # Returns: {confidence: 0.5, evidence_count: 2, corroborations: 1, contradictions: 1}
 ```
 
-### Bayesian update formula
+### Capped-evidence update formula
 
 ```
-new_confidence = prior + (signal - prior) / sqrt(evidence_count + 1)
+n_eff = min(evidence_count + 1, cap)   # cap default: 20
+new_confidence = confidence + (signal - confidence) / (n_eff + 1)
 ```
 
-Early updates move confidence significantly; later updates have diminishing effect as evidence accumulates. Results are clamped to `[0, 1]`.
+Within the evidence window (`evidence_count < cap`), this is an exact running mean over `{initial_confidence, s1, …, sn}` — order-invariant to ~1e-12. Beyond the cap, the gain is fixed at `1/(cap+1)`, producing bounded exponential forgetting (~15 consecutive contradictions to cross 0.5 from 0.9 at cap 20). Results are clamped to `[0, 1]`.
 
 ### Entrainment with ObservationProtocol
 

--- a/docs/features/confidence-field.md
+++ b/docs/features/confidence-field.md
@@ -1,10 +1,10 @@
 # ConfidenceField
 
-A `Field` subclass that tracks Bayesian confidence metadata per member, updated atomically via Lua script.
+A `Field` subclass that tracks confidence metadata per member, updated atomically via Lua script using a capped-evidence Bayesian rule.
 
 ## Overview
 
-`ConfidenceField` maintains a confidence score for each record, allowing the system to track how certain it should be about a given piece of information. Precision grows with `sqrt(n)`, so early evidence has outsized effect while established beliefs resist change.
+`ConfidenceField` maintains a confidence score for each record, allowing the system to track how certain it should be about a given piece of information. The update rule is a **capped-evidence Bayesian** (also called "forgetful Bayesian"): within an evidence window it is an exact running mean — order-invariant and prior-weighted; beyond the cap it is bounded exponential forgetting at a constant rate.
 
 The field stores its metadata in a companion Redis hash:
 
@@ -14,8 +14,11 @@ The field stores its metadata in a companion Redis hash:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `initial_confidence` | float | 0.5 | Starting confidence for new members (0-1) |
+| `initial_confidence` | float | 0.5 | Starting confidence for new members (0-1). Acts as one prior pseudo-observation in the running mean. |
+| `evidence_cap` | int | 20 | Maximum effective evidence count. Within this window updates are a running mean; beyond it updates apply a fixed gain of `1/(cap+1)`, producing bounded exponential forgetting. Must be an integer ≥ 1. |
 | `partition_by` | str or tuple | `()` | Field name(s) to partition the companion hash by. Splits the single Redis hash into per-partition hashes for efficient reads. |
+
+> **Warning — same cap across processes**: The `evidence_cap` is passed per-call and is NOT stored in the companion hash. All processes updating the same companion hash entry must be configured with identical `evidence_cap` values. Divergent caps produce silently inconsistent gain schedules with no runtime detection.
 
 ## Usage
 
@@ -45,24 +48,47 @@ data = ConfidenceField.get_confidence_data(memory, "certainty")
 # Returns: {confidence: 0.5, evidence_count: 2, corroborations: 1, contradictions: 1}
 ```
 
-## Bayesian Update Formula
+## Update Formula
+
+The update rule uses a capped effective-evidence count:
 
 ```
-new_confidence = prior + (signal - prior) / sqrt(evidence_count + 1)
+n_eff = min(evidence_count + 1, cap)
+new_confidence = confidence + (signal - confidence) / (n_eff + 1)
 ```
 
-- **Early updates** have large effect (small evidence_count, small denominator)
-- **Later updates** have diminishing effect (large evidence_count, large denominator)
-- Results are clamped to `[0, 1]`
+The `+1` in `evidence_count + 1` is an inlined prior pseudo-count — `initial_confidence` behaves as one real observation. Results are clamped to `[0, 1]`.
 
-### Convergence Behavior
+### Running-Mean Regime (evidence_count < cap)
 
-| Updates | Denominator | Movement per update |
-|---------|-------------|---------------------|
-| 1st | sqrt(1) = 1.0 | Full step |
-| 4th | sqrt(4) = 2.0 | Half step |
-| 9th | sqrt(9) = 3.0 | Third step |
-| 100th | sqrt(100) = 10.0 | Tenth step |
+While the real evidence count is below the cap, the formula is an exact running mean over `{prior, s1, s2, …, sn}`:
+
+```
+confidence after n updates = (initial_confidence + s1 + s2 + … + sn) / (n + 1)
+```
+
+This is order-invariant up to ~1e-12 (IEEE-754 intermediate rounding; the closed form is the oracle, not bit-identical output). The first update from `initial_confidence=0.5` with `signal=0.9` yields **0.7**, not 0.9 — the prior is never erased.
+
+### Forgetting Regime (evidence_count >= cap)
+
+Once the evidence count reaches the cap, the effective gain is fixed at `1/(cap+1)`. With `cap=20` (default), each update multiplies `(confidence - signal)` by `20/21 ≈ 0.952`.
+
+**Worked example**: a belief with `confidence=0.9` and `evidence_count=20` (at the cap) subjected to 15 consecutive contradictions at `signal=0.1`:
+
+```
+After k contradictions: confidence = 0.1 + 0.8 × (20/21)^k
+Crossing 0.5 requires:  0.8 × (20/21)^k < 0.4
+                        k > ln(0.4/0.8) / ln(20/21) ≈ 14.2 → 15 contradictions
+```
+
+This is bounded exponential forgetting — well-established beliefs take ~15 systematic contradictions to cross the midpoint at the default cap, compared to ~5 under the previous decaying-step rule.
+
+### Update Behavior Summary
+
+| Regime | Condition | Behavior |
+|--------|-----------|----------|
+| Running mean | evidence_count < cap (20) | Exact mean of {prior, all signals}; order-invariant to ~1e-12 |
+| Fixed forgetting | evidence_count >= cap | Constant gain `1/(cap+1)`; ~15 contradictions cross 0.5 from 0.9 |
 
 ## Entrainment with ObservationProtocol
 
@@ -77,17 +103,21 @@ When used with `ObservationProtocol`, confidence is automatically updated based 
 
 ### Auto-discharge
 
-When confidence drops below 0.1 due to a `contradicted` outcome, homeostatic pressure on any `CyclicDecayField` is automatically resolved (discharged). This prevents low-confidence memories from building urgency.
+When confidence drops strictly below `AUTO_DISCHARGE_CONFIDENCE_THRESHOLD` (0.1), homeostatic pressure on any `CyclicDecayField` is automatically resolved (discharged). This prevents low-confidence memories from building urgency.
+
+The comparison uses an epsilon guard: discharge fires only when `conf < 0.1 - 1e-9`. A confidence value that rounds to exactly 0.1 in display but is stored as `0.09999999999999998` (a common IEEE-754 artifact on the first contradiction from a default prior) does **not** trigger discharge. A genuine drop — one clearly below the threshold by more than epsilon — still does.
 
 ## API Reference
 
 ### `ConfidenceField.update_confidence(instance, field_name, signal)`
 
-Atomically update confidence using the Bayesian formula.
+Atomically update confidence using the capped-evidence Bayesian formula.
 
 - **signal**: Float 0-1. Values >= 0.5 corroborate, < 0.5 contradict.
 - **Returns**: The new confidence value.
 - **Raises**: `TypeError` if unsaved or wrong field type; `ValueError` if signal out of range.
+
+> **Warning**: All processes calling `update_confidence` on the same companion hash entry must use identical `evidence_cap` values. The cap is not stored in Redis and divergent values produce silently inconsistent update trajectories.
 
 ### `ConfidenceField.get_confidence(instance, field_name)`
 
@@ -101,9 +131,11 @@ Read all confidence metadata.
 
 - **Returns**: Dict with keys `confidence`, `evidence_count`, `corroborations`, `contradictions`.
 
+Note: `evidence_count` reflects real observations only — the prior pseudo-count is internal to the Lua update and does not inflate this counter.
+
 ### Inspecting Companion Hash Keys
 
-Each `ConfidenceField` stores its Bayesian metadata in a companion Redis hash alongside
+Each `ConfidenceField` stores its confidence metadata in a companion Redis hash alongside
 the main model hash. The public companion key methods let you build these Redis keys
 for debugging, monitoring, or direct Redis inspection without reverse-engineering
 suffix conventions.
@@ -199,7 +231,7 @@ report = ConfidenceField.migrate_to_partitioned(Memory, "certainty")
 
 The [Popoto Kitchen example app](https://github.com/tomcounsell/popoto/tree/main/examples)
 includes a `ReviewScore` model that demonstrates `ConfidenceField` with
-`partition_by="restaurant"`. Run the operations demo to see Bayesian updates,
+`partition_by="restaurant"`. Run the operations demo to see capped-evidence updates,
 companion hash key inspection, and partitioned confidence in action:
 
 ```bash

--- a/docs/features/kitchen-edge-case-demo.md
+++ b/docs/features/kitchen-edge-case-demo.md
@@ -109,7 +109,7 @@ via `python -m popoto_kitchen --ops` and print results to stdout.
 
 A new model using `ConfidenceField` with `partition_by="restaurant"` to
 track review confidence per restaurant. See
-[ConfidenceField docs](confidence-field.md) for the Bayesian update formula.
+[ConfidenceField docs](confidence-field.md) for the capped-evidence update formula.
 
 ```python
 class ReviewScore(Model):

--- a/docs/features/observation-protocol.md
+++ b/docs/features/observation-protocol.md
@@ -138,7 +138,7 @@ expired = RecallProposal.expire_stale(Memory, ttl=3600)
 ## See Also
 
 - [Metacognitive Layer](metacognitive-layer.md) — full `"used"` outcome documentation, `error_summary`, and `AdaptiveAssembler`
-- [ConfidenceField](confidence-field.md) — Bayesian certainty tracking
+- [ConfidenceField](confidence-field.md) — capped-evidence certainty tracking
 - [CyclicDecayField](cyclic-decay-field.md) — cyclical resonance and pressure
 - [PredictionLedger](prediction-ledger.md) — outcome tracking
 - [Agent Memory overview](agent-memory.md) — full primitives reference

--- a/docs/features/prediction-ledger.md
+++ b/docs/features/prediction-ledger.md
@@ -124,6 +124,6 @@ Missing keys contribute `1.0` error per key.
 ## See Also
 
 - [Metacognitive Layer](metacognitive-layer.md) — `error_summary` full documentation and `"used"` outcome
-- [ConfidenceField](confidence-field.md) — Bayesian certainty tracking (receives error feedback)
+- [ConfidenceField](confidence-field.md) — capped-evidence certainty tracking (receives error feedback)
 - [ObservationProtocol](observation-protocol.md) — auto-resolution via outcome hooks
 - [Agent Memory overview](agent-memory.md) — full primitives reference

--- a/docs/guides/agent-memory-quickstart.md
+++ b/docs/guides/agent-memory-quickstart.md
@@ -75,7 +75,7 @@ results[0].confirm_access()  # marks as actually used
 
 ## Level 3: Learning — Outcomes Strengthen or Weaken Beliefs
 
-Add `ConfidenceField` for Bayesian certainty tracking. Use `ObservationProtocol` to report how the agent used each memory — acted on, dismissed, or contradicted.
+Add `ConfidenceField` for certainty tracking. Use `ObservationProtocol` to report how the agent used each memory — acted on, dismissed, or contradicted.
 
 ```python
 from popoto import ConfidenceField, ObservationProtocol

--- a/docs/guides/policy-cache-recipe.md
+++ b/docs/guides/policy-cache-recipe.md
@@ -43,7 +43,7 @@ PolicyEntry composes these primitives:
 | `AutoKeyField` | Unique entry ID |
 | `KeyField` | Agent partitioning, state fingerprinting, action type |
 | `DecayingSortedField` | Q-value storage with temporal decay |
-| `ConfidenceField` | Bayesian confidence from outcome history |
+| `ConfidenceField` | Capped-evidence confidence from outcome history |
 | `CoOccurrenceField` | Weighted graph between related policies |
 | `ExistenceFilter` | Bloom filter for fast state lookup |
 | `EventStreamMixin` | Mutation log via Redis Streams |

--- a/docs/guides/popoto-memory-roadmap.md
+++ b/docs/guides/popoto-memory-roadmap.md
@@ -345,7 +345,7 @@ The scoring function itself is **application layer** — Popoto provides the gat
 
 ## Step 4: ConfidenceField — Bayesian Certainty Tracking + Entrainment ✅ Shipped
 
-**What it is:** A field type that maintains a Bayesian confidence score updated atomically via Lua script. Each update provides a binary signal (corroborate/contradict) with a weight. The prior becomes harder to shift as evidence accumulates (precision grows with √n).
+**What it is:** A field type that maintains a confidence score updated atomically via Lua script using a capped-evidence Bayesian rule. Each update provides a binary signal (corroborate/contradict). Within the evidence window (default cap: 20) updates are an exact running mean — order-invariant and prior-weighted. Beyond the cap, a fixed gain produces bounded exponential forgetting.
 
 ConfidenceField also serves as the **entrainment mechanism** for CyclicDecayField (Step 1). Cyclical parameters (amplitude, phase) are hypotheses about temporal relevance. The observation protocol (Step 2) generates corroborate/contradict signals for these hypotheses, and ConfidenceField applies them. When a cycle's confidence drops below a threshold, the cycle auto-disables — this is how stale recurring memories ("send that client an update") die when the underlying context has changed ("that client contract ended").
 
@@ -356,7 +356,7 @@ ConfidenceField also serves as the **entrainment mechanism** for CyclicDecayFiel
 ```python
 class ConfidenceField(Field):
     """
-    Bayesian confidence score with precision-weighted updates.
+    Capped-evidence confidence score (forgetful Bayesian).
 
     Stored as: {confidence: float, evidence_count: int,
                 corroborations: int, contradictions: int}

--- a/docs/guides/programmable-memory-systems-neuroscience-design-spec.md
+++ b/docs/guides/programmable-memory-systems-neuroscience-design-spec.md
@@ -451,10 +451,13 @@ class ConsolidatedPattern(popoto.Model):
     corroborations = popoto.Field(type=int, default=0)
 ```
 
-**Bayesian confidence update** (Lua script):
+**Confidence update** (conceptual design sketch — see note):
+
+> **Note:** The shipped Popoto `ConfidenceField` uses a **capped-evidence Bayesian** rule, not the precision-weighted sqrt sketch below. The sketch is retained as a design exploration of the sqrt-precision approach; the actual implementation uses `n_eff = min(evidence_count + 1, cap)` with a fixed cap (default 20), giving an exact running mean within the window and bounded exponential forgetting beyond it. See [ConfidenceField docs](../features/confidence-field.md).
 
 ```lua
--- Precision-weighted Bayesian update for pattern confidence
+-- Conceptual sketch: precision-weighted Bayesian update
+-- NOTE: not the actual Popoto implementation (see ConfidenceField docs)
 -- KEYS[1] = pattern hash key
 -- ARGV[1] = new_evidence (0 or 1 for contradiction/corroboration), ARGV[2] = evidence_weight
 local key = KEYS[1]
@@ -464,11 +467,10 @@ local weight = tonumber(ARGV[2])    -- evidence strength [0, 1]
 local prior = tonumber(redis.call('HGET', key, 'confidence') or '0.5')
 local n = tonumber(redis.call('HGET', key, 'evidence_count') or '1')
 
--- Precision increases with evidence count (prior becomes harder to move)
-local prior_precision = math.sqrt(n)  -- Precision grows with sqrt(evidence)
+-- Precision-weighted update (design exploration)
+local prior_precision = math.sqrt(n)
 local likelihood_precision = weight
 
--- Precision-weighted update
 local posterior = (prior_precision * prior + likelihood_precision * evidence) 
                   / (prior_precision + likelihood_precision)
 posterior = math.max(0.01, math.min(0.99, posterior))

--- a/docs/guides/trajectory-memory-recipe.md
+++ b/docs/guides/trajectory-memory-recipe.md
@@ -97,7 +97,15 @@ Periodic (e.g. nightly reflection): cluster recent episodes by their fingerprint
 new_or_reinforced = tm.crystallize(partition="team-a")
 ```
 
-Crystallization is **idempotent**: re-running on an unchanged episode set produces no drift in confidence or `last_reinforced`. The recipe achieves this by observing only episodes newer than each pattern's `last_reinforced` timestamp (Risk 2 in the plan). Bayesian confidence updates are commutative — concurrent crystallizations converge.
+Crystallization is **idempotent via watermark**: re-running on an unchanged episode set produces zero drift in confidence or `last_reinforced`. After each run, `last_reinforced` is set to the maximum `recorded_at` timestamp across all observed episodes (the watermark). Subsequent runs observe only episodes strictly newer than that watermark, so the same episodes are never double-counted.
+
+**Operational constraints for idempotence:**
+
+- **One crystallizer per partition.** Concurrent crystallization of the same partition is not coordinated — two processes reading the same episode set and both calling `_observe_episodes` will double-observe episodes, inflating confidence counts. Run a single crystallizer per partition.
+- **NTP-synced writers.** The watermark guarantee assumes episode writers and the crystallizer are within ordinary NTP clock synchronization. A writer whose clock lags behind the current watermark will record episodes with `recorded_at` timestamps below the watermark; the strict `>` filter skips those episodes permanently on all subsequent runs.
+- **`last_reinforced` stores episode time, not crystallize time.** The stored score for `last_reinforced` equals the maximum observed episode `recorded_at` — which may predate the wall-clock time the crystallize call ran. An operator running `ZSCORE` on the recency index reads "newest episode processed", not "when crystallize last ran". Under batched or nightly crystallization, patterns will rank correspondingly older in recency-weighted recall (`DEFAULT_SCORE_WEIGHTS` weights `last_reinforced` at 0.4) than they would under wall-clock semantics.
+
+Note: within the evidence window, the capped-evidence update rule is order-invariant (to ~1e-12), which bounds — but does not eliminate — confidence drift if the single-crystallizer constraint is violated. Do not rely on commutativity as a substitute for the operational constraint.
 
 The canonical sequence is the **modal trajectory** across the group, with ties broken by the most recent episode. Anything fancier (edit-distance, n-gram similarity, custom aggregators) is intentionally out of scope.
 
@@ -126,7 +134,7 @@ The recipe introspects field names via `model_class._meta.fields`. Field names b
 | ---------------------- | --------------------- | ---------------------- | ----------------------------- |
 | Each fingerprint field | `KeyField`            | from `fingerprint_fields` ctor arg | Exact-match recall |
 | Partition              | `KeyField`            | `partition`            | Multi-tenant isolation        |
-| Confidence             | `ConfidenceField`     | `confidence`           | Bayesian success tracking     |
+| Confidence             | `ConfidenceField`     | `confidence`           | Capped-evidence success tracking |
 | Last reinforced        | `DecayingSortedField` | `last_reinforced`      | Recency-weighted ranking      |
 | Canonical sequence     | `ListField`           | `canonical_sequence`   | Modal trajectory              |
 
@@ -199,5 +207,5 @@ This produces deterministic 16-hex-char fingerprints suitable for use as a `KeyF
 * [ContextAssembler](../features/context-assembler.md) — retrieval-to-injection bridge for **semantic** memory
 * [SubconsciousMemory](subconscious-memory-recipe.md) — automatic inject/extract around LLM turns
 * [PolicyCache](policy-cache-recipe.md) — RL-style action selection by state fingerprint (the closest analogue: also clusters by fingerprint, also uses `ConfidenceField`)
-* [`ConfidenceField`](../features/confidence-field.md) — Bayesian confidence primitive used for pattern reinforcement
+* [`ConfidenceField`](../features/confidence-field.md) — capped-evidence confidence primitive used for pattern reinforcement
 * [`DecayingSortedField`](../features/decaying-sorted-field.md) — time-decaying score used for `last_reinforced` ranking

--- a/docs/guides/tuning-magic-numbers.md
+++ b/docs/guides/tuning-magic-numbers.md
@@ -34,6 +34,10 @@ Source: `src/popoto/fields/confidence_field.py`
 | Constant | Default | Optimal Range | Sensitivity |
 |----------|---------|--------------|-------------|
 | `initial_confidence` | 0.5 | [0.1, 0.9] | Low |
+| `evidence_cap` | 20 | — | Not swept — user-facing config, not a tuning constant |
+| `CONFIDENCE_EPSILON` | 1e-9 | — | Not swept — internal float-boundary guard |
+
+`evidence_cap` (default `Defaults.CONFIDENCE_EVIDENCE_CAP = 20`) is the capped-evidence Bayesian rule's memory-window length — an epistemics knob deliberately exposed as per-field user config per the [issue #407](https://github.com/tomcounsell/popoto/issues/407) decision, so it is excluded from experimental sweeps. `CONFIDENCE_EPSILON` is the float tolerance applied to the `AUTO_DISCHARGE_CONFIDENCE_THRESHOLD` comparison in `observation.py` (values within epsilon of the threshold do not discharge); it guards a boundary condition and is not user config. See [ConfidenceField](../features/confidence-field.md) for the update-rule semantics.
 
 ### WriteFilterMixin
 

--- a/docs/plans/confidence_field_capped_bayesian.md
+++ b/docs/plans/confidence_field_capped_bayesian.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: docs_complete
 type: bug
 appetite: Medium
 owner: valorengels

--- a/src/popoto/fields/confidence_field.py
+++ b/src/popoto/fields/confidence_field.py
@@ -1,8 +1,14 @@
-"""ConfidenceField — Bayesian certainty tracking with entrainment.
+"""ConfidenceField — capped-evidence confidence tracking with entrainment.
 
-Maintains a Bayesian confidence score per member, updated atomically via
-Lua script. Precision grows with sqrt(n), so early evidence has outsized
-effect while established beliefs resist change.
+Maintains a confidence score per member, updated atomically via Lua script
+using a capped-evidence update rule (issue #407). While effective evidence
+(real observations plus a prior pseudo-count of 1) is at or below the
+``evidence_cap``, each update computes the exact running mean over
+{prior, signals...} — the result is order-invariant. Once effective
+evidence reaches the cap, the gain freezes at 1/(cap+1), giving
+fixed-gain exponential forgetting with an effective memory window of
+cap+1 observations: new evidence keeps a constant influence instead of
+vanishing as history grows.
 
 Companion Redis hash stores per-member confidence metadata:
     - $ConfidencF:{Model}:{field}:data — msgpack {confidence, evidence_count,
@@ -43,12 +49,17 @@ from .field import Field
 
 logger = logging.getLogger("POPOTO.ConfidenceField")
 
-# Lua script: atomic Bayesian update of confidence companion hash.
+# Lua script: atomic capped-evidence update of the confidence companion hash.
+# While n_eff = min(evidence_count + prior_weight, cap) is below the cap, the
+# update is an exact running mean over {prior, signals...} (order-invariant).
+# At the cap, the gain freezes at 1/(cap+1): fixed-gain exponential
+# forgetting with an effective memory window of cap+1 observations.
 # KEYS[1] = companion hash key
 # ARGV[1] = member key (redis_key of the model instance)
 # ARGV[2] = signal (float 0-1)
 # ARGV[3] = initial_confidence (default for missing data)
-BAYESIAN_UPDATE_LUA = """
+# ARGV[4] = evidence_cap
+CAPPED_BAYESIAN_UPDATE_LUA = """
 local hash_key = KEYS[1]
 local member = ARGV[1]
 local signal = tonumber(ARGV[2])
@@ -71,8 +82,13 @@ if raw then
     end
 end
 
--- Bayesian update: precision grows with sqrt(n)
-local new_confidence = confidence + (signal - confidence) / math.sqrt(evidence_count + 1)
+-- Capped-evidence update: running mean while effective evidence <= cap,
+-- fixed-gain exponential forgetting (window cap+1) beyond it.
+-- ARGV[4] = evidence_cap (the only new ARGV)
+local prior_weight = 1  -- internal constant; not user config (issue #407 decision Q2)
+local cap = tonumber(ARGV[4])
+local n_eff = math.min(evidence_count + prior_weight, cap)
+local new_confidence = confidence + (signal - confidence) / (n_eff + 1)
 
 -- Clamp to [0, 1]
 new_confidence = math.max(0, math.min(1, new_confidence))
@@ -100,13 +116,21 @@ return {tostring(new_confidence), tostring(evidence_count), tostring(corroborati
 
 
 class ConfidenceField(Field):
-    """A Field that tracks Bayesian confidence metadata in a companion Redis hash.
+    """A Field that tracks confidence metadata in a companion Redis hash.
 
     Not a SortedField — confidence is metadata, not a ranking dimension.
     Stores {confidence, evidence_count, corroborations, contradictions} per member.
 
+    Updates use a capped-evidence rule (issue #407): an order-invariant
+    running mean over {prior, signals...} while effective evidence is at
+    or below ``evidence_cap``, then fixed-gain exponential forgetting
+    (memory window cap+1) beyond it.
+
     Args:
         initial_confidence: Starting confidence for new members. Default 0.5.
+        evidence_cap: Cap on effective evidence (memory-window length).
+            Must be an int >= 1. Default ``Defaults.CONFIDENCE_EVIDENCE_CAP``
+            (20). Validated at model-class definition time.
         partition_by: Optional field name or tuple of field names to partition
             the companion hash. When set, each unique combination of partition
             field values gets its own Redis hash, reducing the cost of reads
@@ -147,6 +171,23 @@ class ConfidenceField(Field):
                 f"initial_confidence must be between 0 and 1 "
                 f"(got {self.initial_confidence})"
             )
+
+        # evidence_cap: memory-window length / epistemics knob (issue #407).
+        # Validated here so misconfiguration fails at model-class definition
+        # time (field construction), not at first update.
+        evidence_cap = kwargs.pop("evidence_cap", None)
+        if evidence_cap is None:
+            evidence_cap = Defaults.CONFIDENCE_EVIDENCE_CAP
+        # bool is a subclass of int — reject it explicitly
+        if isinstance(evidence_cap, bool) or not isinstance(evidence_cap, int):
+            raise ModelException(
+                f"evidence_cap must be an int >= 1 (got {evidence_cap!r})"
+            )
+        if evidence_cap < 1:
+            raise ModelException(
+                f"evidence_cap must be an int >= 1 (got {evidence_cap})"
+            )
+        self.evidence_cap = evidence_cap
 
         # Handle partition_by parameter
         partition_by = kwargs.pop("partition_by", tuple())
@@ -366,7 +407,23 @@ class ConfidenceField(Field):
 
     @classmethod
     def update_confidence(cls, model_instance, field_name, signal, pipeline=None):
-        """Update confidence for a member using Bayesian formula.
+        """Update confidence for a member using the capped-evidence rule.
+
+        While effective evidence (real observations plus a prior
+        pseudo-count of 1) is at or below the field's ``evidence_cap``,
+        the update computes the exact running mean over
+        {prior, signals...} — order-invariant, converging on the mean of
+        the observed signals. Once effective evidence reaches the cap,
+        the gain freezes at 1/(cap+1): fixed-gain exponential forgetting
+        with an effective memory window of cap+1 observations, so new
+        evidence keeps a constant influence.
+
+        Warning:
+            All processes updating the same companion hash entry must
+            configure identical ``evidence_cap`` values. The cap is
+            passed per-call, not stored in the hash, so divergent caps
+            across processes produce silently inconsistent gain
+            schedules with no runtime detection.
 
         Note: Always executes immediately via Lua EVAL (not batched into
         pipeline) because the Lua script needs to read-modify-write atomically.
@@ -408,12 +465,13 @@ class ConfidenceField(Field):
         data_hash_key = field.get_data_hash_key(model_instance, field_name)
 
         result = POPOTO_REDIS_DB.eval(
-            BAYESIAN_UPDATE_LUA,
+            CAPPED_BAYESIAN_UPDATE_LUA,
             1,  # number of KEYS
             data_hash_key,
             member_key,
             str(signal),
             str(field.initial_confidence),
+            str(field.evidence_cap),
         )
 
         new_confidence = float(result[0])

--- a/src/popoto/fields/constants.py
+++ b/src/popoto/fields/constants.py
@@ -53,6 +53,8 @@ class Defaults:
 
     # -- ConfidenceField ------------------------------------------------------
     INITIAL_CONFIDENCE = 0.5  # empirically inert (sweep 2026-04-20, variance=0.0011)
+    CONFIDENCE_EVIDENCE_CAP = 20  # deliberate user-facing config exception per issue #407 decision — a memory-window length / epistemics knob (how much history a belief retains), not an experimental tuning constant
+    CONFIDENCE_EPSILON = 1e-9  # internal float-boundary tolerance for threshold comparisons, not user config
 
     # -- ObservationProtocol (fields/observation.py) --------------------------
     ACTED_CONFIDENCE_SIGNAL = 0.9  # sweep 2026-04-20 variance=0.030 (borderline); best in-range was 0.1 but 0.9 better reflects the "strong positive" semantics and per-scenario effect is small

--- a/src/popoto/fields/observation.py
+++ b/src/popoto/fields/observation.py
@@ -91,6 +91,11 @@ AUTO_DISCHARGE_CONFIDENCE_THRESHOLD = Defaults.AUTO_DISCHARGE_CONFIDENCE_THRESHO
 outcome. Very low confidence records should not continue building pressure.
 Optimal range: [0.05, 0.3]. Insensitive within this range."""
 
+CONFIDENCE_EPSILON = Defaults.CONFIDENCE_EPSILON
+"""Internal float-boundary tolerance for the auto-discharge comparison.
+Confidence values within this epsilon of the threshold are NOT below it.
+Not user config."""
+
 
 class ObservationProtocol:
     """Lifecycle hooks for passive behavioral inference on memory models.
@@ -364,12 +369,15 @@ def _apply_contradicted(instance, pipeline):
         except (TypeError, ValueError):
             pass  # Graceful degradation
 
-    # Auto-discharge: when confidence < 0.1, resolve pressure on CyclicDecayFields
+    # Auto-discharge: when confidence is clearly below the threshold, resolve
+    # pressure on CyclicDecayFields. Values within float epsilon of the
+    # threshold are NOT below it (fixes the 0.09999999999999998 artifact
+    # that auto-discharged on the first contradiction).
     for field_name, field in instance._meta.fields.items():
         if isinstance(field, ConfidenceField):
             try:
                 conf = ConfidenceField.get_confidence(instance, field_name)
-                if conf < AUTO_DISCHARGE_CONFIDENCE_THRESHOLD:
+                if conf < AUTO_DISCHARGE_CONFIDENCE_THRESHOLD - CONFIDENCE_EPSILON:
                     for cdf_name, cdf_field in instance._meta.fields.items():
                         if (
                             isinstance(cdf_field, CyclicDecayField)

--- a/src/popoto/recipes/trajectory_memory.py
+++ b/src/popoto/recipes/trajectory_memory.py
@@ -388,7 +388,7 @@ class TrajectoryMemory:
         return episode
 
     def crystallize(self, partition):
-        """Cluster recent episodes into canonical patterns (idempotent).
+        """Cluster recent episodes into canonical patterns.
 
         Loads every episode in ``partition``, groups them by their
         fingerprint tuple, and for each group at least
@@ -396,11 +396,48 @@ class TrajectoryMemory:
 
         * Upserts a ``pattern_model`` record keyed by ``(partition,
           *fingerprint_values)``.
-        * On existing patterns, observes only episodes newer than
-          ``pattern.last_reinforced`` (so re-running on an unchanged
-          episode set does not drift confidence — see plan Risk 2).
+        * On existing patterns, observes only episodes strictly newer
+          than the pattern's recency score (the watermark filter below).
         * Recomputes the canonical sequence as the modal trajectory
           across the group, ties broken by the most recent episode.
+        * Advances the pattern's recency field (``last_reinforced``) to
+          the **max observed episode timestamp** (the watermark), saved
+          with ``skip_auto_now=True`` — never to the wall-clock time of
+          the save.
+
+        Idempotence guarantee (and its limits):
+
+        * **Sequential re-run idempotence** via watermark filtering:
+          because the stored watermark equals the max *observed* episode
+          timestamp and the filter is strict ``>``, re-running
+          crystallize on an unchanged episode set observes nothing and
+          produces zero confidence drift. An episode recorded between
+          the episode query and the save (i.e. with a timestamp above
+          the watermark but below wall-clock save time) is picked up by
+          the *next* run rather than lost. No commutativity of the
+          underlying confidence update is assumed or claimed.
+        * **Concurrent crystallization of the same partition is NOT
+          coordinated.** The recipe performs a read-modify-write with no
+          locking, so two crystallizers racing on one partition can
+          double-observe the same episodes. Run one crystallizer per
+          partition.
+
+        Watermark semantics to be aware of:
+
+        * The recency field's stored score equals the max **observed
+          episode** ``recorded_at``, which may predate the wall-clock
+          crystallize call. A ZSCORE read of the recency index therefore
+          means "newest episode processed", not "when crystallize last
+          ran", and recency-weighted recall ranks patterns by *episode*
+          time — batched/nightly crystallization makes patterns appear
+          correspondingly older.
+        * **Clock-sync assumption:** episode writers and the
+          crystallizer are assumed to be within ordinary NTP sync. A
+          writer whose clock lags the watermark can record an episode
+          *below* it, which the strict ``>`` filter then skips forever.
+        * Crystallize-triggered saves use ``skip_auto_now=True``, so any
+          **other** ``auto_now`` field on ``pattern_model`` is frozen by
+          (and never populated by) crystallize-triggered saves.
 
         Args:
             partition: Partition value to crystallize. Crystallization is
@@ -437,7 +474,7 @@ class TrajectoryMemory:
             canonical = self._canonical_sequence(group)
 
             if not existing:
-                # New pattern: observe every episode in the group
+                # New pattern (unsaved): observe every episode in the group
                 pattern = self._create_pattern(
                     partition=partition,
                     fingerprint=fingerprint,
@@ -446,8 +483,9 @@ class TrajectoryMemory:
                 observed_episodes = group
             else:
                 pattern = existing[0]
-                # Re-running idempotence: only observe episodes newer than
-                # the pattern's last_reinforced timestamp.
+                # Re-running idempotence: only observe episodes strictly
+                # newer than the stored watermark (max observed episode
+                # timestamp from the previous run).
                 last_reinforced = self._episode_score(pattern, self.recency_field)
                 observed_episodes = [
                     e
@@ -462,10 +500,31 @@ class TrajectoryMemory:
                 # Recompute canonical sequence on the full group (deterministic).
                 setattr(pattern, self.canonical_sequence_field, canonical)
 
+            # Watermark: the max OBSERVED episode timestamp, not the
+            # wall-clock save time. Saving the wall clock would let an
+            # episode recorded between the query above and the save fall
+            # below the stored score and be filtered out forever.
+            watermark = max(
+                self._episode_score(e, self.episode_recency_field)
+                for e in observed_episodes
+            )
+            setattr(pattern, self.recency_field, watermark)
+
+            if not existing:
+                # Bootstrap save: ConfidenceField.update_confidence is an
+                # atomic Lua read-modify-write keyed on the member's redis
+                # key, and requires the instance to already exist in Redis.
+                # skip_auto_now keeps the explicit watermark here too, so
+                # the new-pattern path never carries wall-clock semantics.
+                pattern.save(skip_auto_now=True)
+
             self._observe_episodes(pattern, observed_episodes)
-            # Save advances DecayingSortedField (auto_now=True) and writes
-            # the canonical_sequence update.
-            pattern.save()
+            # Single authoritative save for both branches: persists the
+            # watermark (skip_auto_now suppresses the DecayingSortedField's
+            # auto_now wall-clock overwrite) and the canonical_sequence
+            # update. Note: skip_auto_now also freezes any OTHER auto_now
+            # field on pattern_model for crystallize-triggered saves.
+            pattern.save(skip_auto_now=True)
 
             affected.append(pattern)
 
@@ -586,16 +645,19 @@ class TrajectoryMemory:
         return list(winner)
 
     def _create_pattern(self, partition, fingerprint, canonical):
-        """Instantiate and save a new pattern record."""
+        """Instantiate a new pattern record WITHOUT saving it.
+
+        :meth:`crystallize` owns the save: it sets the recency watermark
+        first and persists with ``save(skip_auto_now=True)``, so no
+        auto_now wall-clock score is ever written for a new pattern.
+        """
         kwargs = {
             self.partition_field: partition,
             self.canonical_sequence_field: list(canonical),
         }
         for k, v in fingerprint.items():
             kwargs[k] = v
-        pattern = self.pattern_model(**kwargs)
-        pattern.save()
-        return pattern
+        return self.pattern_model(**kwargs)
 
     def _observe_episodes(self, pattern, episodes):
         """Bayesian-update the pattern's confidence using each episode's

--- a/tests/benchmarks/overrides.py
+++ b/tests/benchmarks/overrides.py
@@ -57,6 +57,10 @@ MODULE_CONSTANTS = {
         observation_mod,
         "AUTO_DISCHARGE_CONFIDENCE_THRESHOLD",
     ),
+    # Float-boundary tolerance for the auto-discharge comparison (#407).
+    # Internal constant, but it has a module-level alias in observation.py,
+    # so it is registered here for sync-test coverage and restore symmetry.
+    "CONFIDENCE_EPSILON": (observation_mod, "CONFIDENCE_EPSILON"),
     # PolicyCache (policy_cache.py)
     "MIN_EVENTS_FOR_CRYSTALLIZATION": (
         policy_cache_mod,

--- a/tests/benchmarks/test_defaults_sync.py
+++ b/tests/benchmarks/test_defaults_sync.py
@@ -51,6 +51,9 @@ class TestDefaultsSync:
         field_kwargs_and_class_attrs = {
             "DECAY_RATE",
             "INITIAL_CONFIDENCE",
+            # ConfidenceField constructor kwarg default (evidence_cap, #407);
+            # no module-level alias exists, so not in MODULE_CONSTANTS.
+            "CONFIDENCE_EVIDENCE_CAP",
             "WF_MIN_THRESHOLD",
             "WF_PRIORITY_THRESHOLD",
             "CO_OCCURRENCE_DECAY_FACTOR",

--- a/tests/benchmarks/test_factory.py
+++ b/tests/benchmarks/test_factory.py
@@ -631,7 +631,14 @@ class TestFamilyGroundTruthDecoupling:
         ndcg_high = ndcg_at_k(high_res.retrieved_ids, high_res.relevance_scores, 5)
 
         diff = abs(ndcg_low - ndcg_high)
-        assert diff > 0.03, (
+        # Sensitivity bound recomputed for the capped Bayesian rule (#407):
+        # each non-selected candidate receives ONE suppression update from a
+        # fresh state (evidence_count=0), where the update gain fell from
+        # 1/sqrt(0+1) = 1.0 (full overwrite) to 1/(min(0+1, 20)+1) = 1/2.
+        # The certainty perturbation driving the ranking divergence is
+        # exactly halved, so the nDCG sensitivity threshold is halved
+        # proportionally: 0.03 -> 0.015.
+        assert diff > 0.015, (
             f"ContextAssemblerFamilyScenario nDCG@5 barely moves between "
             f"COMPETITIVE_SUPPRESSION_SIGNAL 0.1 ({ndcg_low:.4f}) and 0.7 "
             f"({ndcg_high:.4f}), diff={diff:.4f}. Check that both "

--- a/tests/test_agent_memory_e2e.py
+++ b/tests/test_agent_memory_e2e.py
@@ -30,7 +30,7 @@ from src.popoto.fields.access_tracker import AccessTrackerMixin
 from src.popoto.fields.co_occurrence_field import CoOccurrenceField
 from src.popoto.fields.confidence_field import ConfidenceField
 from src.popoto.fields.cyclic_decay_field import CyclicDecayField
-from src.popoto.fields.constants import TemporalPeriod
+from src.popoto.fields.constants import Defaults, TemporalPeriod
 from src.popoto.fields.decaying_sorted_field import DecayingSortedField
 from src.popoto.fields.event_stream import EventStreamMixin
 from src.popoto.fields.existence_filter import ExistenceFilter, FrequencySketch
@@ -669,12 +669,17 @@ class TestTemporalDynamics:
         )
         m.save()
 
-        # Drive confidence very low first
+        # Drive confidence below the discharge threshold. Capped Bayesian
+        # oracle: from initial 0.5, after n <= cap updates at signal s the
+        # confidence is the running mean (0.5 + s*n) / (n + 1). At s = 0.05,
+        # (0.5 + 0.05n)/(n+1) < 0.1 requires n > 8, so at least 9 updates;
+        # use 10: (0.5 + 10*0.05) / 11 = 1.0/11 = 0.0909...
         for _ in range(10):
             ConfidenceField.update_confidence(m, "confidence", signal=0.05)
 
         conf = ConfidenceField.get_confidence(m, "confidence")
-        assert conf < 0.2
+        # (0.5 + 10*0.05) / 11 = 1.0/11
+        assert abs(conf - 1.0 / 11) < 1e-12
 
         # Set up old pressure
         field = m._meta.fields["relevance"]
@@ -690,15 +695,21 @@ class TestTemporalDynamics:
             msgpack.packb(pressure_data),
         )
 
-        # Contradict — should auto-discharge since confidence < 0.1
+        # Contradict — auto-discharges because the post-update confidence is
+        # strictly below threshold - epsilon (a value float-equal-ish to the
+        # threshold would NOT discharge under the epsilon guard, #407).
         ObservationProtocol.on_context_used(
             [m],
             {m.db_key.redis_key: "contradicted"},
         )
 
-        # Check confidence is very low
+        # Post-contradiction oracle: contradicted applies one more update at
+        # signal 0.1, so (0.5 + 10*0.05 + 0.1) / 12 = 1.1/12 = 0.091666...
         final_conf = ConfidenceField.get_confidence(m, "confidence")
-        assert final_conf < 0.15
+        assert abs(final_conf - 1.1 / 12) < 1e-12
+        assert final_conf < (
+            Defaults.AUTO_DISCHARGE_CONFIDENCE_THRESHOLD - Defaults.CONFIDENCE_EPSILON
+        )
 
     def test_cycle_amplitude_strengthens_on_acted(self):
         """Acted outcome strengthens cycle amplitudes via ObservationProtocol."""

--- a/tests/test_confidence_field.py
+++ b/tests/test_confidence_field.py
@@ -1,16 +1,24 @@
-"""Tests for ConfidenceField — Bayesian certainty tracking with entrainment.
+"""Tests for ConfidenceField — capped-evidence confidence tracking with entrainment.
 
 Tests cover:
-- Field initialization (initial_confidence, validation)
+- Field initialization (initial_confidence, evidence_cap, validation)
 - on_save() initializes companion hash with initial_confidence
 - on_delete() cleans up companion hash entries
-- update_confidence() with Bayesian formula
-- Precision growth: 10th update moves score less than 1st
+- update_confidence() with the capped-evidence update rule:
+  order-invariant running mean over {prior, signals...} while effective
+  evidence <= cap; fixed-gain exponential forgetting (window cap+1) beyond it
+- Gain shrinkage: 10th update moves score less than 1st (within the window)
 - Corroboration increases confidence, contradiction decreases
 - get_confidence() and get_confidence_data() read current values
 - Error cases: unsaved model, invalid signal, wrong field type
 - Entrainment: ObservationProtocol outcome handlers update confidence
-- Auto-discharge: confidence < 0.1 resolves pressure on CyclicDecayFields
+- Auto-discharge: confidence < threshold - epsilon resolves pressure on
+  CyclicDecayFields (values within float epsilon of 0.1 do NOT discharge)
+
+FLOAT-TOLERANCE CONVENTION: the incremental Lua update is algebraically
+order-invariant but NOT IEEE-754 bit-identical across orderings. Every
+closed-form assertion compares against the oracle with
+abs(actual - oracle) < 1e-12 — never ==.
 """
 
 import math
@@ -50,6 +58,46 @@ class ConfidenceWithCyclic(popoto.Model):
     )
 
 
+class ConfidenceCapped(popoto.Model):
+    """Model with a custom (small) evidence_cap for forgetting-rate tests."""
+
+    name = popoto.UniqueKeyField()
+    certainty = ConfidenceField(evidence_cap=5)
+
+
+class ConfidenceLowPrior(popoto.Model):
+    """Model with a low initial_confidence for prior-weight tests."""
+
+    name = popoto.UniqueKeyField()
+    certainty = ConfidenceField(initial_confidence=0.01)
+
+
+# --- Helpers ---
+
+
+def _seed_confidence_data(
+    item, field_name, confidence, evidence_count, corroborations=0, contradictions=0
+):
+    """Write companion-hash state directly (bypasses the update rule)."""
+    import msgpack
+
+    field = item._meta.fields[field_name]
+    data_hash_key = field.get_data_hash_key(item, field_name)
+    member_key = item.db_key.redis_key
+    POPOTO_REDIS_DB.hset(
+        data_hash_key,
+        member_key,
+        msgpack.packb(
+            {
+                "confidence": confidence,
+                "evidence_count": evidence_count,
+                "corroborations": corroborations,
+                "contradictions": contradictions,
+            }
+        ),
+    )
+
+
 # --- Fixtures ---
 
 
@@ -57,7 +105,13 @@ class ConfidenceWithCyclic(popoto.Model):
 def cleanup():
     """Clean up Redis keys after each test."""
     yield
-    for model_class in [ConfidenceItem, ConfidenceCustom, ConfidenceWithCyclic]:
+    for model_class in [
+        ConfidenceItem,
+        ConfidenceCustom,
+        ConfidenceWithCyclic,
+        ConfidenceCapped,
+        ConfidenceLowPrior,
+    ]:
         for key in POPOTO_REDIS_DB.keys(f"{model_class.__name__}:*"):
             POPOTO_REDIS_DB.delete(key)
         for key in POPOTO_REDIS_DB.keys(f"$Confidenc*"):
@@ -175,27 +229,32 @@ class TestUpdateConfidence:
         new_conf = ConfidenceField.update_confidence(item, "certainty", signal=0.1)
         assert new_conf < 0.5
 
-    def test_bayesian_formula_first_update(self):
-        """First update: new = 0.5 + (signal - 0.5) / sqrt(0 + 1) = signal."""
+    def test_capped_formula_first_update(self):
+        """First update is the running mean of {prior, signal}.
+
+        Closed form: n=0, prior_weight=1, n_eff = min(0+1, 20) = 1,
+        new = 0.5 + (0.9 - 0.5) / (1 + 1) = (0.5 + 0.9) / 2 = 0.7
+        """
         item = ConfidenceItem.create(name="formula1")
         new_conf = ConfidenceField.update_confidence(item, "certainty", signal=0.9)
-        # sqrt(1) = 1, so new = 0.5 + (0.9 - 0.5) / 1 = 0.9
-        assert abs(new_conf - 0.9) < 1e-6
+        assert abs(new_conf - 0.7) < 1e-12
 
-    def test_bayesian_formula_second_update(self):
-        """Second update uses sqrt(2) denominator."""
+    def test_capped_formula_second_update(self):
+        """Second update extends the running mean over {prior, s1, s2}.
+
+        Closed form: (c0 + s1 + s2) / 3 = (0.5 + 0.9 + 0.9) / 3 = 2.3 / 3
+        """
         item = ConfidenceItem.create(name="formula2")
         ConfidenceField.update_confidence(item, "certainty", signal=0.9)
-        # After first: confidence = 0.9, evidence_count = 1
+        # After first: confidence = 0.7, evidence_count = 1
         new_conf = ConfidenceField.update_confidence(item, "certainty", signal=0.9)
-        # new = 0.9 + (0.9 - 0.9) / sqrt(2) = 0.9
-        assert abs(new_conf - 0.9) < 1e-6
+        assert abs(new_conf - (0.5 + 0.9 + 0.9) / 3) < 1e-12
 
-    def test_precision_growth(self):
-        """10th update moves score less than 1st update."""
+    def test_gain_shrinks_within_window(self):
+        """10th update moves score less than 1st update (gain 1/(n_eff+1))."""
         item = ConfidenceItem.create(name="precision1")
 
-        # First update: delta = (0.8 - 0.5) / sqrt(1) = 0.3
+        # First update: delta = (0.8 - 0.5) / 2 = 0.15
         first_conf = ConfidenceField.update_confidence(item, "certainty", signal=0.8)
         first_delta = abs(first_conf - 0.5)
 
@@ -240,6 +299,230 @@ class TestUpdateConfidence:
         assert 0 <= conf <= 1
 
 
+# --- Capped-Evidence Update Rule (issue #407) ---
+
+
+class TestCappedBayesianUpdate:
+    """Tests for the capped-evidence update rule.
+
+    Within the window (effective evidence <= cap) the rule is an exact
+    running mean over {prior, signals...}:
+        c_n = (c0 + sum(signals)) / (n + 1)
+    At the cap the gain freezes at 1/(cap+1) — exponential forgetting.
+    """
+
+    def test_order_invariance(self):
+        """A fixed multiset of signals lands on the same value in any order.
+
+        Closed-form oracle for n <= cap signals from c0 = 0.5:
+            oracle = (0.5 + sum(signals)) / (len(signals) + 1)
+                   = (0.5 + 4.05) / 9
+        Incremental float evaluation is order-invariant algebraically but
+        not bit-identical, hence 1e-12 tolerance (never ==).
+        """
+        signals = [0.9, 0.1, 0.8, 0.2, 0.7, 0.6, 0.45, 0.3]
+        oracle = (0.5 + sum(signals)) / (len(signals) + 1)
+
+        permutations = [
+            signals,
+            list(reversed(signals)),
+            sorted(signals),
+            sorted(signals, reverse=True),
+            signals[4:] + signals[:4],
+        ]
+        for i, perm in enumerate(permutations):
+            item = ConfidenceItem.create(name=f"perm{i}")
+            for s in perm:
+                ConfidenceField.update_confidence(item, "certainty", signal=s)
+            final = ConfidenceField.get_confidence(item, "certainty")
+            assert abs(final - oracle) < 1e-12, f"permutation {i}: {perm}"
+
+    def test_prior_weight_first_update_from_default(self):
+        """One update with signal 0.9 from initial 0.5 lands on 0.7.
+
+        Closed form: (c0 + s) / 2 = (0.5 + 0.9) / 2 = 0.7 — the prior
+        counts as exactly one pseudo-observation.
+        """
+        item = ConfidenceItem.create(name="prior1")
+        new_conf = ConfidenceField.update_confidence(item, "certainty", signal=0.9)
+        assert abs(new_conf - 0.7) < 1e-12
+
+    def test_prior_weight_first_update_from_low_initial(self):
+        """One update with signal 0.9 from initial 0.01 lands on 0.455.
+
+        Closed form: (c0 + s) / 2 = (0.01 + 0.9) / 2 = 0.455
+        """
+        item = ConfidenceLowPrior.create(name="prior2")
+        new_conf = ConfidenceField.update_confidence(item, "certainty", signal=0.9)
+        assert abs(new_conf - 0.455) < 1e-12
+
+    def test_running_mean_equivalence(self):
+        """n <= cap updates equal the running mean (c0 + sum(signals)) / (n+1)."""
+        signals = [0.85, 0.15, 0.6, 0.4, 0.95, 0.05, 0.7, 0.25, 0.5, 0.8]
+        item = ConfidenceItem.create(name="runmean1")
+        for s in signals:
+            conf = ConfidenceField.update_confidence(item, "certainty", signal=s)
+        # Closed form: (0.5 + sum) / 11
+        oracle = (0.5 + sum(signals)) / (len(signals) + 1)
+        assert abs(conf - oracle) < 1e-12
+
+    def test_cap_forgetting_crosses_half_on_15th_contradiction(self):
+        """At the cap, contradictions decay confidence geometrically.
+
+        Seed the companion hash DIRECTLY with confidence=0.9,
+        evidence_count=20 (driving 20 updates would land near 0.8810, not
+        0.9 — the oracle below assumes the seeded state).
+
+        At the cap: n_eff = min(20 + 1, 20) = 20, gain = 1/21, so each
+        0.1-signal contradiction gives c' = c + (0.1 - c)/21, a geometric
+        approach to the 0.1 fixed point:
+            c_k = 0.1 + (0.9 - 0.1) * (20/21)^k = 0.1 + 0.8 * (20/21)^k
+        First k with c_k < 0.5: 0.8*(20/21)^k < 0.4 -> k > ln 2 / ln(21/20)
+        = 14.2 -> k = 15. So it stays >= 0.5 through k=14 and crosses on
+        the 15th contradiction.
+        """
+        item = ConfidenceItem.create(name="capforget1")
+        _seed_confidence_data(
+            item, "certainty", confidence=0.9, evidence_count=20, corroborations=20
+        )
+
+        for k in range(1, 15):
+            conf = ConfidenceField.update_confidence(item, "certainty", signal=0.1)
+            expected = 0.1 + 0.8 * (20 / 21) ** k
+            assert abs(conf - expected) < 1e-12, f"k={k}"
+            assert conf >= 0.5, f"crossed below 0.5 too early at k={k}"
+
+        # 15th contradiction: c_15 = 0.1 + 0.8*(20/21)^15 = 0.4848... < 0.5
+        conf = ConfidenceField.update_confidence(item, "certainty", signal=0.1)
+        expected = 0.1 + 0.8 * (20 / 21) ** 15
+        assert abs(conf - expected) < 1e-12
+        assert conf < 0.5
+
+    def test_custom_evidence_cap_changes_forgetting_rate(self):
+        """A smaller evidence_cap forgets faster once at the cap.
+
+        Both seeded with confidence=0.9, evidence_count=20, then one
+        0.1-signal contradiction:
+          default cap=20: n_eff = min(21, 20) = 20, gain 1/21:
+              c' = 0.9 + (0.1 - 0.9)/21 = 0.9 - 0.8/21
+          cap=5:          n_eff = min(21, 5)  = 5,  gain 1/6:
+              c' = 0.9 + (0.1 - 0.9)/6  = 0.9 - 0.8/6
+        """
+        default_item = ConfidenceItem.create(name="capdefault1")
+        capped_item = ConfidenceCapped.create(name="capcustom1")
+        for item in (default_item, capped_item):
+            _seed_confidence_data(
+                item, "certainty", confidence=0.9, evidence_count=20, corroborations=20
+            )
+
+        default_conf = ConfidenceField.update_confidence(
+            default_item, "certainty", signal=0.1
+        )
+        capped_conf = ConfidenceField.update_confidence(
+            capped_item, "certainty", signal=0.1
+        )
+
+        assert abs(default_conf - (0.9 - 0.8 / 21)) < 1e-12
+        assert abs(capped_conf - (0.9 - 0.8 / 6)) < 1e-12
+        assert capped_conf < default_conf  # smaller cap forgets faster
+
+    def test_concurrent_updates_within_window_match_oracle(self):
+        """Concurrent updates within the window land on the running mean.
+
+        The Lua script is atomic, so concurrent updates serialize in SOME
+        order; order-invariance within the window means the final value
+        matches the closed-form oracle (0.5 + sum(signals)) / (n+1)
+        regardless of interleaving. NOT exact equality — 1e-12 tolerance.
+        """
+        import threading
+
+        item = ConfidenceItem.create(name="concurrent1")
+        signals = [0.9, 0.1, 0.8, 0.2, 0.7, 0.3, 0.6, 0.4, 0.95, 0.05]
+
+        errors = []
+
+        def _update(sig):
+            try:
+                ConfidenceField.update_confidence(item, "certainty", signal=sig)
+            except Exception as e:  # pragma: no cover - failure diagnostics
+                errors.append(e)
+
+        threads = [threading.Thread(target=_update, args=(s,)) for s in signals]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        data = ConfidenceField.get_confidence_data(item, "certainty")
+        assert data["evidence_count"] == len(signals)
+        # Closed form: (0.5 + sum(signals)) / 11
+        oracle = (0.5 + sum(signals)) / (len(signals) + 1)
+        assert abs(data["confidence"] - oracle) < 1e-12
+
+    def test_corrupt_companion_data_recovers(self):
+        """Corrupt companion-hash bytes re-init from defaults on update.
+
+        0xc1 is an invalid msgpack type byte, so cmsgpack.unpack fails and
+        the Lua script falls back to {initial_confidence, 0, 0, 0}.
+        Closed form after recovery + one 0.9 signal: (0.5 + 0.9)/2 = 0.7.
+        """
+        item = ConfidenceItem.create(name="corrupt1")
+        field = item._meta.fields["certainty"]
+        data_hash_key = field.get_data_hash_key(item, "certainty")
+        POPOTO_REDIS_DB.hset(data_hash_key, item.db_key.redis_key, b"\xc1garbage")
+
+        new_conf = ConfidenceField.update_confidence(item, "certainty", signal=0.9)
+        assert abs(new_conf - 0.7) < 1e-12
+
+        data = ConfidenceField.get_confidence_data(item, "certainty")
+        assert data["evidence_count"] == 1
+        assert data["corroborations"] == 1
+        assert data["contradictions"] == 0
+
+
+# --- evidence_cap Configuration (issue #407) ---
+
+
+class TestEvidenceCapConfig:
+    def test_default_evidence_cap_is_20(self):
+        """Default evidence_cap comes from Defaults.CONFIDENCE_EVIDENCE_CAP."""
+        from src.popoto.fields.constants import Defaults
+
+        assert Defaults.CONFIDENCE_EVIDENCE_CAP == 20
+        field = ConfidenceField()
+        assert field.evidence_cap == 20
+
+    def test_none_falls_back_to_default(self):
+        """evidence_cap=None resolves to the Defaults value."""
+        field = ConfidenceField(evidence_cap=None)
+        assert field.evidence_cap == 20
+
+    def test_custom_evidence_cap_stored(self):
+        """A custom integer evidence_cap is honored."""
+        field = ConfidenceField(evidence_cap=5)
+        assert field.evidence_cap == 5
+        assert ConfidenceCapped._meta.fields["certainty"].evidence_cap == 5
+
+    @pytest.mark.parametrize(
+        "bad_cap",
+        ["20", 20.0, True, False, 0, -1],
+        ids=["str", "float", "bool_true", "bool_false", "zero", "negative"],
+    )
+    def test_invalid_evidence_cap_raises(self, bad_cap):
+        """Non-int (incl. bool) or < 1 evidence_cap raises ModelException."""
+        with pytest.raises(popoto.ModelException):
+            ConfidenceField(evidence_cap=bad_cap)
+
+    def test_invalid_evidence_cap_raises_at_class_definition(self):
+        """Validation fires at model-class definition time, not at use time."""
+        with pytest.raises(popoto.ModelException):
+
+            class BadCapModel(popoto.Model):
+                name = popoto.UniqueKeyField()
+                certainty = ConfidenceField(evidence_cap=0)
+
+
 # --- get_confidence / get_confidence_data Tests ---
 
 
@@ -251,11 +534,14 @@ class TestGetConfidence:
         assert conf == 0.5
 
     def test_get_confidence_after_update(self):
-        """get_confidence reflects updates."""
+        """get_confidence reflects updates.
+
+        Closed form: first update = (c0 + s) / 2 = (0.5 + 0.9) / 2 = 0.7
+        """
         item = ConfidenceItem.create(name="get2")
         ConfidenceField.update_confidence(item, "certainty", signal=0.9)
         conf = ConfidenceField.get_confidence(item, "certainty")
-        assert abs(conf - 0.9) < 1e-6
+        assert abs(conf - 0.7) < 1e-12
 
     def test_get_confidence_data_structure(self):
         """get_confidence_data returns complete metadata dict."""
@@ -292,10 +578,13 @@ class TestAttributeAccess:
         assert item.certainty == 0.5
 
     def test_attribute_returns_updated_value_after_update(self):
-        """instance.certainty reflects updated confidence after update_confidence."""
+        """instance.certainty reflects updated confidence after update_confidence.
+
+        Closed form: first update = (c0 + s) / 2 = (0.5 + 0.9) / 2 = 0.7
+        """
         item = ConfidenceItem.create(name="attr4")
         ConfidenceField.update_confidence(item, "certainty", signal=0.9)
-        assert abs(item.certainty - 0.9) < 1e-6
+        assert abs(item.certainty - 0.7) < 1e-12
 
     def test_attribute_not_none(self):
         """instance.certainty is never None with default config (issue #281)."""
@@ -399,39 +688,51 @@ class TestEntrainment:
         new_conf = ConfidenceField.get_confidence(item, "certainty")
         assert new_conf == initial_conf
 
+    def _seed_pressure(self, item, last_resolved):
+        """Seed pressure state on the relevance CyclicDecayField."""
+        import msgpack
+
+        rel_field = item._meta.fields["relevance"]
+        pressure_hash_key = rel_field.get_pressure_hash_key(item, "relevance")
+        member_key = item.db_key.redis_key
+        pressure_data = {"rate": 0.1, "last_resolved": last_resolved}
+        POPOTO_REDIS_DB.hset(
+            pressure_hash_key, member_key, msgpack.packb(pressure_data)
+        )
+        return pressure_hash_key, member_key
+
     def test_auto_discharge_on_low_confidence(self):
-        """When confidence drops below 0.1, pressure is auto-discharged."""
+        """Confidence clearly below threshold - epsilon auto-discharges pressure."""
         import msgpack
         import time
+
+        from src.popoto.fields.constants import Defaults
 
         item = ConfidenceWithCyclic.create(name="ent5", content="test")
 
         # Build up some pressure by setting last_resolved to far in the past
-        rel_field = item._meta.fields["relevance"]
-        pressure_hash_key = rel_field.get_pressure_hash_key(item, "relevance")
-        member_key = item.db_key.redis_key
-        pressure_data = {
-            "rate": 0.1,
-            "last_resolved": time.time() - 86400 * 30,  # 30 days ago
-        }
-        POPOTO_REDIS_DB.hset(
-            pressure_hash_key, member_key, msgpack.packb(pressure_data)
+        pressure_hash_key, member_key = self._seed_pressure(
+            item, time.time() - 86400 * 30  # 30 days ago
         )
 
-        # Manually set confidence below 0.1 to trigger auto-discharge
-        conf_field = item._meta.fields["certainty"]
-        data_hash_key = conf_field.get_data_hash_key(item, "certainty")
-        low_conf_data = {
-            "confidence": 0.05,
-            "evidence_count": 20,
-            "corroborations": 0,
-            "contradictions": 20,
-        }
-        POPOTO_REDIS_DB.hset(data_hash_key, member_key, msgpack.packb(low_conf_data))
+        # Manually seed confidence at 0.05 — clearly below threshold - epsilon
+        _seed_confidence_data(
+            item, "certainty", confidence=0.05, evidence_count=20, contradictions=20
+        )
 
-        # Now trigger contradicted outcome — auto-discharge should fire
+        # Now trigger contradicted outcome — auto-discharge should fire.
+        # The contradicted update itself moves confidence toward 0.1:
+        # at the cap, c' = 0.05 + (0.1 - 0.05)/21 = 0.0524, still clearly
+        # below 0.1 - 1e-9.
         outcome_map = {item.db_key.redis_key: "contradicted"}
         popoto.ObservationProtocol.on_context_used([item], outcome_map)
+
+        # Epsilon boundary, explicitly: post-update confidence must sit
+        # below threshold - epsilon for the discharge to have been correct.
+        conf = ConfidenceField.get_confidence(item, "certainty")
+        assert conf < (
+            Defaults.AUTO_DISCHARGE_CONFIDENCE_THRESHOLD - Defaults.CONFIDENCE_EPSILON
+        )
 
         # Verify pressure was resolved (last_resolved should be recent)
         raw = POPOTO_REDIS_DB.hget(pressure_hash_key, member_key)
@@ -439,6 +740,45 @@ class TestEntrainment:
         pdata = msgpack.unpackb(raw, raw=False)
         # last_resolved should be within the last minute (was 30 days ago)
         assert time.time() - pdata["last_resolved"] < 60
+
+    def test_no_auto_discharge_within_epsilon_of_threshold(self):
+        """The float predecessor of 0.1 does NOT trigger auto-discharge.
+
+        0.09999999999999998 < 0.1 in IEEE-754, but it is within
+        CONFIDENCE_EPSILON (1e-9) of the threshold — the strict
+        `conf < threshold` comparison wrongly auto-discharged on the
+        first contradiction for such float artifacts. With the epsilon
+        guard, values within epsilon of the threshold are NOT below it.
+
+        The contradicted update moves the seeded value toward the 0.1
+        fixed point (at the cap: c' = c + (0.1 - c)/21), so it stays
+        within epsilon of 0.1 — no discharge.
+        """
+        import msgpack
+        import time
+
+        item = ConfidenceWithCyclic.create(name="ent5eps", content="test")
+
+        thirty_days_ago = time.time() - 86400 * 30
+        pressure_hash_key, member_key = self._seed_pressure(item, thirty_days_ago)
+
+        # Float predecessor of 0.1 — the artifact value from issue #407
+        _seed_confidence_data(
+            item,
+            "certainty",
+            confidence=0.09999999999999998,
+            evidence_count=20,
+            contradictions=20,
+        )
+
+        outcome_map = {item.db_key.redis_key: "contradicted"}
+        popoto.ObservationProtocol.on_context_used([item], outcome_map)
+
+        # Pressure must NOT have been resolved — last_resolved unchanged
+        raw = POPOTO_REDIS_DB.hget(pressure_hash_key, member_key)
+        assert raw is not None
+        pdata = msgpack.unpackb(raw, raw=False)
+        assert abs(pdata["last_resolved"] - thirty_days_ago) < 1.0
 
     def test_entrainment_without_cyclic_field_is_safe(self):
         """Entrainment on model without CyclicDecayField is a no-op for cycles."""

--- a/tests/test_context_assembler.py
+++ b/tests/test_context_assembler.py
@@ -683,7 +683,9 @@ class TestRetrievalQualityAssembler:
 
         Fixture:
             * 3 FixtureMemory instances (topics: alpha, beta, gamma),
-              confidences post-update: 0.9 signal, 0.5 signal, 0.3 signal
+              one update each from initial 0.5 at signals 0.9, 0.5, 0.3;
+              capped Bayesian oracle (c0 + s) / 2 gives post-update
+              confidences 0.7, 0.5, 0.4
             * score_weights={"relevance": 1.0}, max_items=5,
               surfacing_threshold=0.5
             * query_cues={"topic": "alpha", "other": "beta"}
@@ -716,7 +718,10 @@ class TestRetrievalQualityAssembler:
         # Hardcoded expected scalars captured against the pre-refactor
         # implementation. DO NOT tweak these to paper over a refactor —
         # any divergence means the refactor changed numeric behavior.
-        assert self._isclose(quality.avg_confidence, 0.5666666666666667)
+        # avg_confidence recomputed for the capped Bayesian rule (#407):
+        # ((0.5+0.9)/2 + (0.5+0.5)/2 + (0.5+0.3)/2) / 3
+        #   = (0.7 + 0.5 + 0.4) / 3 = 1.6 / 3 = 0.5333...
+        assert self._isclose(quality.avg_confidence, 1.6 / 3)
         assert self._isclose(quality.score_spread, 0.0)
         assert self._isclose(quality.fok_score, 0.64)
         assert self._isclose(quality.staleness_ratio, 1.0)

--- a/tests/test_observation_protocol.py
+++ b/tests/test_observation_protocol.py
@@ -1097,3 +1097,129 @@ class TestFeatureDocAndDocstrings:
         assert (
             "echoed" in section
         ), "Expected 'echoed' migration guidance in v1.5.0 CHANGELOG entry"
+
+
+# =========================================================================
+# Auto-discharge epsilon boundary (issue #407)
+# =========================================================================
+
+
+class EpsilonBoundaryMemory(popoto.Model):
+    """Model with ConfidenceField + pressured CyclicDecayField for the
+    auto-discharge epsilon-boundary tests."""
+
+    name = popoto.UniqueKeyField()
+    certainty = ConfidenceField(initial_confidence=0.5)
+    relevance = CyclicDecayField(
+        decay_rate=0.5,
+        cycles=[(TemporalPeriod.YEARLY, 5.0, 0)],
+        pressure_rate=0.1,
+    )
+
+
+class TestAutoDischargeEpsilonBoundary:
+    """Auto-discharge fires only for conf < threshold - CONFIDENCE_EPSILON.
+
+    Values within float epsilon of the 0.1 threshold (e.g. the IEEE-754
+    predecessor 0.09999999999999998) are NOT below it — fixes the float
+    artifact that auto-discharged on the first contradiction.
+    """
+
+    def _cleanup(self):
+        EpsilonBoundaryMemory.delete_all()
+        for pattern in (
+            "$ConfidencF:EpsilonBoundaryMemory:*",
+            "$CyclicDecayF:EpsilonBoundaryMemory:*",
+        ):
+            for key in POPOTO_REDIS_DB.keys(pattern):
+                POPOTO_REDIS_DB.delete(key)
+
+    def _seed(self, m, confidence, last_resolved):
+        """Seed companion-hash confidence and pressure state directly.
+
+        Companion hashes are field metadata (not Popoto model hashes), so
+        direct writes are the established seeding pattern in these tests.
+        """
+        member_key = m.db_key.redis_key
+
+        conf_field = m._meta.fields["certainty"]
+        data_hash_key = conf_field.get_data_hash_key(m, "certainty")
+        POPOTO_REDIS_DB.hset(
+            data_hash_key,
+            member_key,
+            msgpack.packb(
+                {
+                    "confidence": confidence,
+                    "evidence_count": 20,
+                    "corroborations": 0,
+                    "contradictions": 20,
+                }
+            ),
+        )
+
+        rel_field = m._meta.fields["relevance"]
+        pressure_hash_key = rel_field.get_pressure_hash_key(m, "relevance")
+        POPOTO_REDIS_DB.hset(
+            pressure_hash_key,
+            member_key,
+            msgpack.packb({"rate": 0.1, "last_resolved": last_resolved}),
+        )
+        return pressure_hash_key, member_key
+
+    def test_float_predecessor_of_threshold_does_not_discharge(self):
+        """conf seeded at the float predecessor of 0.1 must NOT discharge.
+
+        After the contradicted update (signal 0.1, at the evidence cap):
+        c' = c + (0.1 - c)/21, which keeps c within CONFIDENCE_EPSILON
+        (1e-9) of the 0.1 threshold — so pressure stays unresolved.
+        """
+        self._cleanup()
+        try:
+            m = EpsilonBoundaryMemory(name="eps-predecessor")
+            m.save()
+            thirty_days_ago = time.time() - 86400 * 30
+            pressure_hash_key, member_key = self._seed(
+                m, confidence=0.09999999999999998, last_resolved=thirty_days_ago
+            )
+
+            ObservationProtocol.on_context_used(
+                [m], {m.db_key.redis_key: "contradicted"}
+            )
+
+            raw = POPOTO_REDIS_DB.hget(pressure_hash_key, member_key)
+            assert raw is not None
+            pdata = msgpack.unpackb(raw, raw=False)
+            assert abs(pdata["last_resolved"] - thirty_days_ago) < 1.0, (
+                "pressure was resolved — a value within float epsilon of "
+                "the threshold must NOT auto-discharge"
+            )
+        finally:
+            self._cleanup()
+
+    def test_clearly_below_threshold_discharges(self):
+        """conf clearly below threshold - epsilon DOES auto-discharge.
+
+        Seeded at 0.05; the contradicted update gives
+        c' = 0.05 + (0.1 - 0.05)/21 = 0.0524 < 0.1 - 1e-9 -> discharge.
+        """
+        self._cleanup()
+        try:
+            m = EpsilonBoundaryMemory(name="eps-below")
+            m.save()
+            thirty_days_ago = time.time() - 86400 * 30
+            pressure_hash_key, member_key = self._seed(
+                m, confidence=0.05, last_resolved=thirty_days_ago
+            )
+
+            ObservationProtocol.on_context_used(
+                [m], {m.db_key.redis_key: "contradicted"}
+            )
+
+            raw = POPOTO_REDIS_DB.hget(pressure_hash_key, member_key)
+            assert raw is not None
+            pdata = msgpack.unpackb(raw, raw=False)
+            assert (
+                time.time() - pdata["last_resolved"] < 60
+            ), "pressure should have been auto-discharged"
+        finally:
+            self._cleanup()

--- a/tests/test_partitioned_confidence.py
+++ b/tests/test_partitioned_confidence.py
@@ -26,7 +26,6 @@ from src.popoto.exceptions import ModelException
 from src.popoto.models.query import QueryException
 from src.popoto.redis_db import POPOTO_REDIS_DB
 
-
 # --- Test Models ---
 
 
@@ -171,16 +170,17 @@ class TestPartitionChange:
         ConfidenceField.update_confidence(item, "certainty", signal=0.9)
 
         # Verify data is in atlas partition
+        # Capped Bayesian oracle: (0.5 + 0.9) / 2 = 0.7
         conf_before = ConfidenceField.get_confidence(item, "certainty")
-        assert abs(conf_before - 0.9) < 1e-6
+        assert abs(conf_before - 0.7) < 1e-12
 
         # Change partition key (KeyField requires migrate_key=True)
         item.project = "bravo"
         item.save(migrate_key=True)
 
-        # Data should be in bravo partition now
+        # Data should be in bravo partition now (same value, moved hash)
         conf_after = ConfidenceField.get_confidence(item, "certainty")
-        assert abs(conf_after - 0.9) < 1e-6
+        assert abs(conf_after - 0.7) < 1e-12
 
         # Old partition hash should not have the entry
         field = item._meta.fields["certainty"]
@@ -212,7 +212,8 @@ class TestPartitionedConfidenceOps:
         ConfidenceField.update_confidence(item, "certainty", signal=0.7)
 
         conf = ConfidenceField.get_confidence(item, "certainty")
-        assert abs(conf - 0.7) < 1e-6
+        # Capped Bayesian oracle: (0.5 + 0.7) / 2 = 0.6
+        assert abs(conf - 0.6) < 1e-12
 
     def test_get_confidence_data_from_partition(self):
         """get_confidence_data reads full metadata from partition."""
@@ -248,10 +249,11 @@ class TestBackwardCompatibility:
         assert data["confidence"] == 0.5
 
         new_conf = ConfidenceField.update_confidence(item, "certainty", signal=0.9)
-        assert abs(new_conf - 0.9) < 1e-6
+        # Capped Bayesian oracle: (0.5 + 0.9) / 2 = 0.7
+        assert abs(new_conf - 0.7) < 1e-12
 
         conf = ConfidenceField.get_confidence(item, "certainty")
-        assert abs(conf - 0.9) < 1e-6
+        assert abs(conf - 0.7) < 1e-12
 
     def test_unpartitioned_hash_key_unchanged(self):
         """Unpartitioned hash key has no partition suffix."""

--- a/tests/test_trajectory_memory.py
+++ b/tests/test_trajectory_memory.py
@@ -25,6 +25,7 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 from popoto import (  # noqa: E402
     AutoKeyField,
     ConfidenceField,
+    DatetimeField,
     DecayingSortedField,
     DictField,
     KeyField,
@@ -36,7 +37,6 @@ from popoto.recipes.trajectory_memory import (  # noqa: E402
     TrajectoryMemory,
     compute_fingerprint,
 )
-
 
 # ---------------------------------------------------------------------------
 # Test Models — mirror the issue's API sketch
@@ -175,6 +175,181 @@ class TestCrystallizeIdempotent:
 
         assert pks_before == pks_after
         assert trajectories_before == trajectories_after
+
+
+# ---------------------------------------------------------------------------
+# TestCrystallizeWatermark
+#
+# crystallize stores last_reinforced as the max OBSERVED episode
+# recorded_at (a watermark), saved with skip_auto_now=True -- NOT the
+# wall-clock time of the save. This closes the query-to-save
+# evidence-loss window and makes sequential re-runs exactly idempotent.
+#
+# NOTE: timestamp comparisons use pytest.approx(..., abs=...). A relative
+# tolerance on epoch seconds (~1.7e9) would be ~1750 seconds wide and
+# pass vacuously.
+#
+# Confidence assertions here are deliberately formula-agnostic
+# (equality between runs / monotonicity), never exact values: the
+# ConfidenceField update formula is changing in the same plan.
+# ---------------------------------------------------------------------------
+
+
+class _PatternWithExtraAutoField(Model):
+    """Pattern model with an EXTRA auto_now field (Risk 2 in the plan).
+
+    crystallize saves with skip_auto_now=True, which freezes ANY other
+    auto_now field on the pattern model for crystallize-triggered saves.
+    """
+
+    pattern_id = AutoKeyField()
+    partition = KeyField()
+    problem_topology = KeyField()
+    affected_layer = KeyField()
+    canonical_sequence = ListField(default=[])
+    confidence = ConfidenceField(initial_confidence=0.5)
+    last_reinforced = DecayingSortedField(partition_by="partition")
+    touched_at = DatetimeField(auto_now=True, null=True)
+
+
+class TestCrystallizeWatermark:
+    def _pattern(self, model=ProceduralPattern, partition="t1"):
+        return list(model.query.filter(partition=partition).all())[0]
+
+    def _max_episode_ts(self, partition="t1"):
+        return max(
+            e.recorded_at for e in CyclicEpisode.query.filter(partition=partition).all()
+        )
+
+    def test_double_crystallize_second_run_observes_nothing(self, tm):
+        """Re-running crystallize on an unchanged episode set is a no-op:
+        no pattern is reinforced and confidence does not drift."""
+        for _ in range(3):
+            _record(tm, trajectory=["a", "b"], outcome={"success": True})
+        first = tm.crystallize(partition="t1")
+        assert len(first) == 1
+        conf_one = ConfidenceField.get_confidence(self._pattern(), "confidence")
+        watermark_one = self._pattern().last_reinforced
+
+        second = tm.crystallize(partition="t1")
+        assert second == []  # nothing observed, nothing reinforced
+        conf_two = ConfidenceField.get_confidence(self._pattern(), "confidence")
+        watermark_two = self._pattern().last_reinforced
+
+        assert conf_two == conf_one  # zero drift, exact
+        assert watermark_two == pytest.approx(watermark_one, abs=1e-9)
+
+    def test_watermark_equals_max_observed_episode_existing_pattern(self, tm):
+        """After reinforcing an EXISTING pattern, last_reinforced equals the
+        max observed episode recorded_at, not the wall-clock save time."""
+        for _ in range(2):
+            _record(tm, trajectory=["a"], outcome={"success": True})
+        tm.crystallize(partition="t1")
+
+        time.sleep(0.05)
+        for _ in range(2):
+            _record(tm, trajectory=["a"], outcome={"success": True})
+        # Widen the gap between the newest episode and the wall-clock save
+        # so the old (wall-clock) behavior cannot pass by accident.
+        time.sleep(0.05)
+        tm.crystallize(partition="t1")
+
+        assert self._pattern().last_reinforced == pytest.approx(
+            self._max_episode_ts(), abs=1e-3
+        )
+
+    def test_new_pattern_watermark_is_episode_time_not_wall_clock(self, tm):
+        """First crystallize of a brand-new pattern sets last_reinforced to
+        the max observed episode timestamp -- NOT time.time() at save."""
+        for _ in range(2):
+            _record(tm, trajectory=["a"], outcome={"success": True})
+        # Backdate every episode far into the past so wall-clock and
+        # watermark are unambiguously distinguishable.
+        for ep in CyclicEpisode.query.filter(partition="t1").all():
+            ep.recorded_at = ep.recorded_at - 1000.0
+            ep.save(skip_auto_now=True)
+        backdated_max = self._max_episode_ts()
+
+        wall_before_save = time.time()
+        affected = tm.crystallize(partition="t1")
+        assert len(affected) == 1
+
+        watermark = self._pattern().last_reinforced
+        assert watermark == pytest.approx(backdated_max, abs=1e-3)
+        # Differs from wall-clock at save by ~1000s.
+        assert watermark < wall_before_save - 900.0
+
+    def test_backdated_late_episode_is_picked_up_next_run(self, tm):
+        """An episode recorded between the watermark and the wall-clock save
+        time (e.g. a slightly-lagging writer) is observed by the NEXT
+        crystallize run -- the exact scenario the old wall-clock save
+        lost forever."""
+        for _ in range(2):
+            _record(tm, trajectory=["a", "b"], outcome={"success": True})
+        # Ensure a measurable query-to-save window.
+        time.sleep(0.05)
+        tm.crystallize(partition="t1")
+
+        pattern = self._pattern()
+        watermark = pattern.last_reinforced
+        evidence_one = ConfidenceField.get_confidence_data(pattern, "confidence")[
+            "evidence_count"
+        ]
+        wall_after_save = time.time()
+        assert watermark < wall_after_save  # the window exists
+
+        # Late writer: lands inside (watermark, wall_clock_save_time).
+        late = _record(tm, trajectory=["a", "b"], outcome={"success": True})
+        backdated_ts = watermark + (wall_after_save - watermark) / 2.0
+        late.recorded_at = backdated_ts
+        late.save(skip_auto_now=True)
+
+        affected = tm.crystallize(partition="t1")
+        assert len(affected) == 1  # the late episode was observed
+        pattern = self._pattern()
+        assert pattern.last_reinforced == pytest.approx(backdated_ts, abs=1e-6)
+        # Formula-agnostic observation proof: exactly one new piece of
+        # evidence was incorporated (no confidence value pinned -- the
+        # update formula is changing independently).
+        evidence_two = ConfidenceField.get_confidence_data(pattern, "confidence")[
+            "evidence_count"
+        ]
+        assert evidence_two == evidence_one + 1
+
+    def test_skip_auto_now_freezes_extra_auto_now_field(self):
+        """Risk-2 documented behavior: crystallize saves with
+        skip_auto_now=True, so any OTHER auto_now field on the pattern
+        model is frozen across crystallize-triggered saves (and never
+        populated by them)."""
+        tm = TrajectoryMemory(
+            episode_model=CyclicEpisode,
+            pattern_model=_PatternWithExtraAutoField,
+            fingerprint_fields=["problem_topology", "affected_layer"],
+            cluster_threshold=2,
+        )
+        for _ in range(2):
+            _record(tm, trajectory=["a"], outcome={"success": True})
+        tm.crystallize(partition="t1")
+
+        pattern = self._pattern(model=_PatternWithExtraAutoField)
+        # Crystallize never populates a pure auto_now field.
+        assert pattern.touched_at is None
+
+        # A consumer-triggered plain save DOES populate it (auto_now).
+        pattern.save()
+        pattern = self._pattern(model=_PatternWithExtraAutoField)
+        touched_at_before = pattern.touched_at
+        assert touched_at_before is not None
+
+        # New evidence + crystallize: touched_at is frozen, while
+        # last_reinforced advances to the new watermark.
+        time.sleep(0.05)
+        for _ in range(2):
+            _record(tm, trajectory=["a"], outcome={"success": True})
+        tm.crystallize(partition="t1")
+
+        pattern = self._pattern(model=_PatternWithExtraAutoField)
+        assert pattern.touched_at == touched_at_before
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #407

Implements `docs/plans/confidence_field_capped_bayesian.md` (planned at 68981a8, revised after war-room critique at 2118556). Maintainer decisions recorded on the issue: capped-evidence Bayesian with per-field `evidence_cap` defaulting to 20; epsilon `<=` discharge boundary.

## What changed

**ConfidenceField update rule** (`src/popoto/fields/confidence_field.py`)
- Replaced the `1/√(n+1)` decaying-step EMA with a capped-evidence Bayesian update, pure Lua (Redis/Valkey parity): `n_eff = min(evidence_count + 1, cap)`, gain `1/(n_eff + 1)`. The `+1` prior pseudo-count is inlined in Lua only — no Python constant, no kwarg.
- Within the window this is a true running mean — order-invariant (algebraically; tests assert against the closed-form oracle `(c0 + Σsi)/(n+1)` at 1e-12, never `==`). At/beyond the cap it is fixed-gain exponential forgetting (cap 20 → 20/21 decay per update): a maxed 0.9 belief crosses 0.5 on the 15th consecutive contradiction.
- `ConfidenceField(evidence_cap=N)` — validated int ≥ 1 at class-definition time; default `Defaults.CONFIDENCE_EVIDENCE_CAP = 20`. `ARGV[4]` (the cap) is the only new ARGV; companion-hash schema unchanged. Docs + docstring warn that the cap is not stored in Redis, so all processes sharing a hash must use the same value.

**Auto-discharge epsilon guard** (`src/popoto/fields/observation.py`)
- Discharge fires only when `conf < threshold − CONFIDENCE_EPSILON` (1e-9): a first contradiction landing at float-0.0999…8 no longer discharges spuriously.

**TrajectoryMemory crystallize watermark** (`src/popoto/recipes/trajectory_memory.py`)
- `last_reinforced` is now the max observed episode `recorded_at` (watermark), persisted via `save(skip_auto_now=True)` as the single authoritative save for both branches — sequential re-runs are zero-drift idempotent via the strict `>` filter, with no commutativity assumption.
- `_create_pattern` returns the unsaved pattern; the new-pattern branch bootstraps with the watermark already set (the confidence Lua script requires the hash member to exist), so wall-clock semantics never leak in.
- Docstring + recipe guide document the operational constraints: one crystallizer per partition, NTP-synced writers, and the recency-ranking impact of `last_reinforced` meaning "newest episode processed".

**Docs honesty pass** (11 files)
- `docs/features/confidence-field.md` rewritten for the capped rule with the forgetting worked example and same-cap warning; the false "concurrent crystallizations converge" claim in the trajectory recipe replaced with watermark semantics; unqualified "Bayesian"/sqrt-precision/"resists change" claims removed across features/guides. `mkdocs build --strict` passes.

**Test sweep**
- All sqrt-formula expectations recomputed from the closed-form oracles with derivation comments (`test_partitioned_confidence`, `test_context_assembler`, `test_agent_memory_e2e` discharge at n=10 with epsilon-aware assertion, benchmark registry sync for the two new constants).

## Verification

- Full suite: **1733 passed, 25 skipped, 0 failed** (live Redis, DB 15)
- Stress: 22 passed; `mkdocs build --strict` clean
- Final validator: all 10 success criteria PASS; negative checks confirm no gain-mode switch, no `prior_weight` config, no `ARGV[5]`, no Redis-module commands
- `black --check` failures are pre-existing on main (35 → 33; net improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)