### PR TITLE
fix(DatetimeField): stamp auto_now/auto_now_add in UTC (1.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The default `pubsub` mode degrades to the on-disk `_version` check (never back to the stale-cache bug) if the subscriber thread cannot start, and the listener self-heals via lazy respawn after a connection drop.
   - Single-process **results** are unchanged in all modes; the default adds one daemon listener thread, one Valkey connection, and one loopback `PUBLISH` per write per model class. Set `POPOTO_EMBEDDING_INVALIDATION=none` for zero overhead. See [EmbeddingField → Multi-Worker Deployments](https://popoto.io/fields/#embeddingfield).
 
+## [1.7.1] - 2026-06-15
+
+### Fixed
+
+- **`DatetimeField` `auto_now` / `auto_now_add` now stamp UTC** ([tomcounsell/ai#1653](https://github.com/tomcounsell/ai/issues/1653)) — `format_value_pre_save` previously returned naive `datetime.now()` (host **local** wall-clock). Since the encoder serializes wall-clock without tzinfo, every `auto_now`/`auto_now_add` timestamp on a non-UTC host was skewed by the host's UTC offset, breaking downstream "age since update" math. It now returns `datetime.now(timezone.utc)`, so timestamps are correct regardless of host timezone. Uses `timezone.utc` (valid on the `requires-python = ">=3.10"` floor), not the 3.11+ `datetime.UTC`. Write-only and non-migrating: existing rows are unchanged; UTC hosts already stamped UTC.
+
 ## [1.5.0](https://github.com/tomcounsell/popoto/compare/v1.0.3...v1.5.0) (2026-04-21)
 
 ### Popoto Agent Memory — Now in Beta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "popoto"
-version = "1.7.0"
+version = "1.7.1"
 description = "A Python Redis ORM"
 readme = "README.md"
 authors = [{ name = "Tom Counsell", email = "other@tomcounsell.com" }]

--- a/src/popoto/fields/datetime_field.py
+++ b/src/popoto/fields/datetime_field.py
@@ -22,7 +22,7 @@ wrappers, DatetimeField lives in its own module because it introduces behavioral
 """
 
 from .field import Field
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class DatetimeField(Field):
@@ -103,17 +103,25 @@ class DatetimeField(Field):
             **kwargs: Additional keyword arguments for forward compatibility.
 
         Returns:
-            datetime: The processed datetime value. Returns current time for
-                auto_now fields (unless skip_auto_now is True), current time
-                for auto_now_add when field_value is falsy, or the original
-                field_value otherwise.
+            datetime: The processed datetime value. Returns the current UTC time
+                for auto_now fields (unless skip_auto_now is True), the current
+                UTC time for auto_now_add when field_value is falsy, or the
+                original field_value otherwise.
 
         Implementation note:
+            Timestamps are stamped in UTC via ``datetime.now(timezone.utc)`` so
+            that auto_now/auto_now_add fields record correct instants regardless
+            of host timezone. (The encoder stores wall-clock without tzinfo, so
+            consumers re-attach UTC on read.) ``timezone.utc`` is used rather than
+            ``datetime.UTC`` to stay valid on Python 3.10 (the ``requires-python``
+            floor); ``datetime.UTC`` is 3.11+.
+
             auto_now takes precedence if both flags are set, as it unconditionally
-            returns datetime.now() regardless of existing value (unless skipped).
+            returns the current UTC time regardless of existing value (unless
+            skipped).
         """
         if self.auto_now_add and not field_value:
-            return datetime.now()
+            return datetime.now(timezone.utc)
         if self.auto_now and not skip_auto_now:
-            return datetime.now()
+            return datetime.now(timezone.utc)
         return field_value

--- a/tests/test_auto_timestamps.py
+++ b/tests/test_auto_timestamps.py
@@ -1,9 +1,11 @@
 """Tests for auto_now_add and auto_now on SortedField."""
 
 import time
+from datetime import datetime, timezone
+
 import pytest
 
-from popoto import Model, KeyField, Field, SortedField
+from popoto import Model, KeyField, Field, SortedField, DatetimeField
 
 
 class AutoNowAddModel(Model):
@@ -261,3 +263,85 @@ class TestAsyncAutoTimestamps:
         await instance.async_save()
 
         assert instance.updated_at > original_timestamp
+
+
+class UTCAutoNowAddModel(Model):
+    """DatetimeField model with auto_now_add timestamp."""
+
+    key = KeyField(type=str)
+    created_at = DatetimeField(auto_now_add=True)
+    name = Field(type=str, null=True)
+
+
+class UTCAutoNowModel(Model):
+    """DatetimeField model with auto_now timestamp."""
+
+    key = KeyField(type=str)
+    updated_at = DatetimeField(auto_now=True)
+    name = Field(type=str, null=True)
+
+
+def _as_naive(dt):
+    """Drop tzinfo for naive-to-naive comparison.
+
+    The encoder stores wall-clock without tzinfo, so a round-tripped value is
+    naive. A freshly-stamped in-memory value is tz-aware UTC. Comparing the two
+    directly raises TypeError, so we normalize both to naive before asserting.
+    """
+    return dt.replace(tzinfo=None) if dt.tzinfo is not None else dt
+
+
+class TestDatetimeFieldUTC:
+    """DatetimeField auto_now/auto_now_add stamp UTC wall-clock (tomcounsell/ai#1653).
+
+    Run under a non-UTC TZ (e.g. ``TZ=America/New_York pytest``) to make a naive
+    ``datetime.now()`` regression visibly diverge: the stamped wall-clock would
+    fall outside the UTC ``before``/``after`` bounds by the host's UTC offset.
+    """
+
+    def setup_method(self):
+        UTCAutoNowAddModel.delete_all()
+        UTCAutoNowModel.delete_all()
+
+    def teardown_method(self):
+        UTCAutoNowAddModel.delete_all()
+        UTCAutoNowModel.delete_all()
+
+    def test_auto_now_add_stamps_utc_wallclock(self):
+        """auto_now_add stamps the current UTC wall-clock, not host-local time."""
+        before = datetime.now(timezone.utc).replace(tzinfo=None)
+        instance = UTCAutoNowAddModel.create(key="dt-add-1")
+        after = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        assert instance.created_at is not None
+        # in-memory fresh stamp (tz-aware UTC) normalized to naive UTC wall-clock
+        assert before <= _as_naive(instance.created_at) <= after
+
+        # round-trip from Redis: decoder returns a naive datetime carrying the
+        # stored UTC wall-clock, which must still fall within the UTC bounds.
+        reloaded = UTCAutoNowAddModel.query.get(key="dt-add-1")
+        assert reloaded.created_at.tzinfo is None
+        assert before <= reloaded.created_at <= after
+
+    def test_auto_now_stamps_utc_wallclock(self):
+        """auto_now stamps the current UTC wall-clock on every save."""
+        before = datetime.now(timezone.utc).replace(tzinfo=None)
+        instance = UTCAutoNowModel.create(key="dt-now-1")
+        after = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        assert before <= _as_naive(instance.updated_at) <= after
+
+        reloaded = UTCAutoNowModel.query.get(key="dt-now-1")
+        assert reloaded.updated_at.tzinfo is None
+        assert before <= reloaded.updated_at <= after
+
+    def test_skip_auto_now_preserves_value(self):
+        """skip_auto_now=True must not re-stamp an existing auto_now value."""
+        instance = UTCAutoNowModel.create(key="dt-skip-1", name="original")
+        original = instance.updated_at
+
+        time.sleep(0.01)
+        instance.name = "updated"
+        instance.save(skip_auto_now=True)
+
+        assert instance.updated_at == original


### PR DESCRIPTION
## Problem

`DatetimeField.format_value_pre_save` returned naive `datetime.now()` (host **local** wall-clock) for both the `auto_now` and `auto_now_add` branches. The datetime encoder serializes wall-clock without tzinfo, so on any non-UTC host every `auto_now`/`auto_now_add` timestamp was skewed by the host's UTC offset — breaking downstream "age since last update" math (negative ages, masked staleness).

## Fix

`format_value_pre_save` now returns `datetime.now(timezone.utc)`, so timestamps are correct regardless of host timezone.

**Why `timezone.utc` and not `datetime.UTC`:** `datetime.UTC` is Python 3.11+, but popoto's `requires-python = ">=3.10"`. The release CI builds only on 3.12, so `datetime.UTC` would build green yet `ImportError` on any 3.10 install. `timezone.utc` is valid since Python 3.2 and functionally identical.

## Scope

Write-only and **non-migrating**: existing stored rows are unchanged. UTC hosts already stamped UTC. The encoder still stores naive wall-clock; consumers re-attach UTC on read, as before — only the wall-clock *value* of new writes changes.

## Tests

New `TestDatetimeFieldUTC` in `tests/test_auto_timestamps.py`:
- `auto_now_add` / `auto_now` stamp the current **UTC** wall-clock — asserted via **naive-to-naive** comparison (the decoder returns naive datetimes; comparing aware-vs-naive would `TypeError`) plus a Redis round-trip.
- `skip_auto_now=True` preserves the existing value.

These tests **fail against the old code and pass against the fix** when run under a non-UTC `TZ` (e.g. `TZ=America/New_York`), making them genuine regression guards. Full suite: 1774 passed, 25 skipped, version test green after the `1.7.1` bump.

## Release note

Tagged for `1.7.1`. This patch is intended to ship from a release branch cut off `v1.7.0` (cherry-picking only this commit), keeping the `[Unreleased]` feature block out of the patch release.

Downstream tracking: tomcounsell/ai#1653