### PR TITLE
fix(#410): separate PolicyCache Q-value from DecayingSortedField timestamp slot

### DIFF
--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -1113,12 +1113,14 @@ Shipped in [PR #239](https://github.com/tomcounsell/popoto/pull/239).
 ### Basic usage
 
 ```python
+from decimal import Decimal
+
 from popoto.recipes.policy_cache import (
     PolicyEntry, compute_fingerprint, update_q_value,
-    initialize_q_value, crystallization_handler,
+    crystallization_handler,
 )
 
-# Create a policy directly
+# Create a policy directly — seed q_value at construction
 fp = compute_fingerprint({"task": "deploy", "env": "staging"})
 policy = PolicyEntry(
     agent_id="agent-1",
@@ -1126,11 +1128,11 @@ policy = PolicyEntry(
     state_features={"task": "deploy", "env": "staging"},
     action_type="run_playbook",
     action_spec={"playbook": "deploy.yml"},
+    q_value=Decimal("0.0"),  # q_value lives in the model hash, not the ZSET score
 )
-policy.save()
+policy.save()  # persists both model fields and q_value in one round-trip
 
-# Initialize and update Q-value via temporal difference learning
-initialize_q_value(policy, initial_q=0.0)
+# Update Q-value via temporal difference learning
 td_error = update_q_value(policy, reward=1.0)
 
 # Or let crystallization detect patterns automatically

--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -1154,8 +1154,10 @@ class PolicyEntry(EventStreamMixin, AccessTrackerMixin, PredictionLedgerMixin, M
     state_features = Field()                      # JSON dict
     action_type = KeyField()
     action_spec = Field()                         # JSON dict
+    q_value = DecimalField(default=Decimal("0"))
     expected_value = DecayingSortedField(
         partition_by="agent_id",
+        base_score_field="q_value",
     )
     confidence = ConfidenceField(initial_confidence=0.5)
     related_policies = CoOccurrenceField(symmetric=True, max_edges=100)
@@ -1174,7 +1176,7 @@ WriteFilterMixin is intentionally excluded — the crystallization handler IS th
 |----------|-------------|
 | `compute_fingerprint(features, include_fields=None, include_timestamp=False)` | SHA-256 hash (16 hex chars) of state features |
 | `update_q_value(instance, reward, max_future_q=0.0, alpha=0.1, gamma=0.95)` | Atomic TD(0) Q-value update via Lua script |
-| `initialize_q_value(instance, initial_q=0.0)` | Set initial Q-value (overrides timestamp from save) |
+| `initialize_q_value(instance, initial_q=0.0)` | Set initial `q_value` in the model hash and save (no timestamp override) |
 | `wilson_ci_lower(successes, total, z=1.96)` | Wilson score confidence interval lower bound |
 | `chi_squared_uniform(observed, expected_per_bucket)` | Chi-squared test against uniform distribution |
 | `crystallization_handler(entries)` | StreamConsumer handler for pattern detection |

--- a/docs/features/policy-cache.md
+++ b/docs/features/policy-cache.md
@@ -27,9 +27,21 @@ policy = PolicyEntry(
     state_features={"task": "deploy", "env": "staging"},
     action_type="run_playbook",
     action_spec={"playbook": "deploy.yml"},
+    q_value=Decimal("0.5"),  # optional: seed initial Q-value at construction
 )
 policy.save()
 ```
+
+#### Q-value and recency clock: two separate storage slots
+
+`PolicyEntry` separates learned value from access recency:
+
+| Field | Storage | Role |
+|-------|---------|------|
+| `q_value` | Model hash (`DecimalField`) | Learned Q-value; updated by TD(0) |
+| `expected_value` | Sorted set (score) | Pure recency clock; decays with time |
+
+`expected_value` is a `DecayingSortedField(partition_by="agent_id", base_score_field="q_value")`. The sorted-set score is the decay-weighted access timestamp; `q_value` supplies the base magnitude. Because the two slots are independent, a `save()`, `touch()`, or `"acted"` outcome that refreshes the decay clock does not overwrite the Q-value, and a TD update to `q_value` does not alter the recency clock.
 
 ### Crystallization Handler
 
@@ -47,7 +59,7 @@ consumer = StreamConsumer(
 )
 ```
 
-The handler counts events with the same `(state_fingerprint, action_type)`. When the count exceeds `MIN_EVENTS_FOR_CRYSTALLIZATION` and the Wilson CI lower bound exceeds `WILSON_CI_THRESHOLD`, a PolicyEntry is crystallized.
+The handler counts events with the same `(state_fingerprint, action_type)`. When the count exceeds `MIN_EVENTS_FOR_CRYSTALLIZATION` and the Wilson CI lower bound exceeds `WILSON_CI_THRESHOLD`, a `PolicyEntry` is crystallized. The Wilson CI lower bound is passed as `q_value` at construction — a single `save()` persists both the model fields and the initial Q-value. No separate `initialize_q_value` call is needed.
 
 ### Q-Value Updates
 

--- a/docs/guides/policy-cache-recipe.md
+++ b/docs/guides/policy-cache-recipe.md
@@ -7,16 +7,17 @@ A reference recipe composing all shipped Popoto memory primitives into an RL-sty
 ## Quick Start
 
 ```python
+from decimal import Decimal
+
 from popoto.recipes.policy_cache import (
     PolicyEntry,
     compute_fingerprint,
     update_q_value,
-    initialize_q_value,
     crystallization_handler,
     temporal_discovery_handler,
 )
 
-# Create a policy entry
+# Create a policy entry with an initial Q-value
 fp = compute_fingerprint({"task": "deploy", "env": "staging"})
 policy = PolicyEntry(
     agent_id="agent-1",
@@ -24,11 +25,9 @@ policy = PolicyEntry(
     state_features={"task": "deploy", "env": "staging"},
     action_type="run_playbook",
     action_spec={"playbook": "deploy.yml"},
+    q_value=Decimal("0.5"),  # seed initial Q-value at construction
 )
-policy.save()
-
-# Set initial Q-value (overrides DecayingSortedField timestamp)
-initialize_q_value(policy, initial_q=0.5)
+policy.save()  # persists both model fields and q_value in one round-trip
 
 # Update Q-value after observing a reward
 td_error = update_q_value(policy, reward=1.0)
@@ -42,7 +41,8 @@ PolicyEntry composes these primitives:
 |-----------|-------------------|
 | `AutoKeyField` | Unique entry ID |
 | `KeyField` | Agent partitioning, state fingerprinting, action type |
-| `DecayingSortedField` | Q-value storage with temporal decay |
+| `DecimalField` (`q_value`) | Learned Q-value stored in the model hash |
+| `DecayingSortedField` (`expected_value`) | Pure recency clock; uses `q_value` as base magnitude via `base_score_field` |
 | `ConfidenceField` | Capped-evidence confidence from outcome history |
 | `CoOccurrenceField` | Weighted graph between related policies |
 | `ExistenceFilter` | Bloom filter for fast state lookup |
@@ -94,6 +94,19 @@ Q(s,a) <- Q(s,a) + alpha * [reward + gamma * max_Q(s',a') - Q(s,a)]
 - **alpha** (learning rate): How much new information overrides old (default: 0.1)
 - **gamma** (discount factor): Importance of future rewards (default: 0.95)
 - Returns TD error (positive = better than expected)
+
+### Storage architecture
+
+Q-values live in two separate slots that never overwrite each other:
+
+- **`q_value` (model hash)** — the learned value. Updated by `update_q_value()` via `HGET`/`HSET` on the model hash key. A `save()` or `touch()` on the instance does not reset it.
+- **`expected_value` (sorted set)** — a pure recency/decay clock. Its score is the decay-weighted access timestamp multiplied by the `q_value` magnitude. Writing a new TD estimate via `update_q_value()` does not disturb this clock.
+
+This separation means `Q(s,a)` survives every access pattern — `save()`, `touch()`, and `"acted"` outcome resolution — intact.
+
+### Negative Q-values
+
+`DecayingSortedField` includes a sign-preserving guard in its decay Lua script: negative Q-values retain their sign through the decay calculation. Policies that have been penalized remain penalized after aging.
 
 ## Tuning Constants
 

--- a/docs/plans/policycache-q-value-storage-slot.md
+++ b/docs/plans/policycache-q-value-storage-slot.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: docs_complete
 type: bug
 appetite: Medium
 owner: Valor

--- a/src/popoto/fields/decaying_sorted_field.py
+++ b/src/popoto/fields/decaying_sorted_field.py
@@ -83,7 +83,11 @@ for i = 1, #members, 2 do
     local elapsed_days = math.max((now - last_updated) / 86400, 0.01)
 
     -- Power-law decay: base_score * elapsed^(-decay_rate)
-    local decayed = base_score * math.pow(elapsed_days, -decay_rate)
+    -- Sign-preserving: math.pow only takes non-negative base, so split sign
+    -- from magnitude. Positive-base output is bitwise unchanged.
+    local sign = base_score < 0 and -1 or 1
+    local mag = math.abs(base_score)
+    local decayed = sign * mag * math.pow(elapsed_days, -decay_rate)
 
     table.insert(scored, {member, decayed})
 end

--- a/src/popoto/recipes/policy_cache.py
+++ b/src/popoto/recipes/policy_cache.py
@@ -56,6 +56,7 @@ import json
 import logging
 import math
 import time
+from decimal import Decimal
 
 
 from ..fields.access_tracker import AccessTrackerMixin
@@ -67,7 +68,7 @@ from ..fields.event_stream import EventStreamMixin
 from ..fields.existence_filter import ExistenceFilter
 from ..fields.field import Field
 from ..fields.prediction_ledger import PredictionLedgerMixin
-from ..fields.shortcuts import AutoKeyField, KeyField
+from ..fields.shortcuts import AutoKeyField, DecimalField, KeyField
 from ..models.base import Model
 from ..redis_db import POPOTO_REDIS_DB
 
@@ -131,28 +132,43 @@ If the test statistic exceeds the critical value, the null hypothesis
 
 TD_UPDATE_LUA = """
 -- td_update.lua: Temporal difference Q-value update
--- KEYS[1] = DecayingSortedField sorted set key
+-- KEYS[1] = model hash key (instance redis_key, e.g. PolicyEntry:agent-1:fp:action)
 -- ARGV[1] = reward (float)
 -- ARGV[2] = alpha (learning rate)
 -- ARGV[3] = gamma (discount factor)
 -- ARGV[4] = max_future_q (float)
--- ARGV[5] = member key (instance redis_key)
+--
+-- Q-value is stored in the model hash under field "q_value" as a
+-- cmsgpack-encoded __Decimal__ tagged dict (byte-interchangeable with
+-- Python msgpack encoding of Decimal).
 --
 -- Returns: td_error as string
 
-local current_q = tonumber(redis.call('ZSCORE', KEYS[1], ARGV[5]))
-if current_q == nil then
-    current_q = 0
-end
+local hash_key = KEYS[1]
 local reward = tonumber(ARGV[1])
 local alpha = tonumber(ARGV[2])
 local gamma = tonumber(ARGV[3])
 local max_future_q = tonumber(ARGV[4])
 
+-- Read current Q from model hash
+local current_q = 0
+local raw = redis.call('HGET', hash_key, 'q_value')
+if raw then
+    local ok, decoded = pcall(cmsgpack.unpack, raw)
+    if ok and type(decoded) == 'number' then
+        current_q = decoded
+    elseif ok and type(decoded) == 'table' and decoded['as_encodable'] then
+        -- __Decimal__ tagged dict encoding
+        current_q = tonumber(decoded['as_encodable']) or 0
+    end
+end
+
 local td_error = reward + gamma * max_future_q - current_q
 local new_q = current_q + alpha * td_error
 
-redis.call('ZADD', KEYS[1], new_q, ARGV[5])
+-- Write new Q as __Decimal__ tagged dict (byte-interchangeable with Python msgpack Decimal)
+local encoded = cmsgpack.pack({['__Decimal__']=true, ['as_encodable']=tostring(new_q)})
+redis.call('HSET', hash_key, 'q_value', encoded)
 return tostring(td_error)
 """
 
@@ -200,8 +216,10 @@ class PolicyEntry(EventStreamMixin, AccessTrackerMixin, PredictionLedgerMixin, M
     action_type = KeyField()
     action_spec = Field()  # JSON dict
 
+    q_value = DecimalField(default=Decimal("0"))
     expected_value = DecayingSortedField(
         partition_by="agent_id",
+        base_score_field="q_value",
     )
     confidence = ConfidenceField(initial_confidence=0.5)
     related_policies = CoOccurrenceField(symmetric=True, max_edges=100)
@@ -322,10 +340,13 @@ def update_q_value(
 ) -> float:
     """Update a PolicyEntry's Q-value via temporal difference learning.
 
-    Atomically updates the expected_value (Q-value) in the sorted set
-    using the TD(0) update rule:
+    Atomically updates the q_value field in the model hash using the TD(0)
+    update rule:
 
         Q(s,a) ← Q(s,a) + α [r + γ max Q(s',a') - Q(s,a)]
+
+    The Q-value is stored in the model hash (not in the sorted set score),
+    keeping it independent from the decay timestamp used by expected_value.
 
     Args:
         instance: A saved PolicyEntry instance.
@@ -343,27 +364,26 @@ def update_q_value(
         ValueError: If the instance has no redis_key (unsaved).
     """
     redis_key = _get_redis_key(instance)
-    sortedset_key = _get_sortedset_key(instance)
 
     td_error = POPOTO_REDIS_DB.eval(
         TD_UPDATE_LUA,
         1,  # num keys
-        sortedset_key,  # KEYS[1]
+        redis_key,  # KEYS[1] — model hash key
         str(reward),  # ARGV[1]
         str(alpha),  # ARGV[2]
         str(gamma),  # ARGV[3]
         str(max_future_q),  # ARGV[4]
-        redis_key,  # ARGV[5]
     )
 
     return float(td_error)
 
 
 def initialize_q_value(instance, initial_q: float = 0.0) -> None:
-    """Set the initial Q-value for a PolicyEntry in the sorted set.
+    """Set the initial Q-value for a PolicyEntry.
 
-    After save(), DecayingSortedField stores the current timestamp as score.
-    This function overrides that with the desired initial Q-value.
+    Writes the initial Q-value into the q_value field on the model hash.
+    The decay timestamp in the sorted set is left unchanged — these two
+    storage slots are now separate.
 
     Args:
         instance: A saved PolicyEntry instance.
@@ -372,9 +392,9 @@ def initialize_q_value(instance, initial_q: float = 0.0) -> None:
     Raises:
         ValueError: If the instance is unsaved.
     """
-    redis_key = _get_redis_key(instance)
-    sortedset_key = _get_sortedset_key(instance)
-    POPOTO_REDIS_DB.zadd(sortedset_key, {redis_key: initial_q})
+    _get_redis_key(instance)  # raises if unsaved
+    instance.q_value = Decimal(str(initial_q))
+    instance.save()
 
 
 def _get_redis_key(instance) -> str:
@@ -496,20 +516,17 @@ async def crystallization_handler(entries):
         except (json.JSONDecodeError, TypeError):
             action_spec = {}
 
+        # q_value is stored separately from the decay timestamp — pass it
+        # at construction so it is persisted by the same save() call.
         policy = PolicyEntry(
             agent_id=agent_id,
             state_fingerprint=fp,
             state_features=state_features,
             action_type=action,
             action_spec=action_spec,
+            q_value=Decimal(str(ci_lower)),
         )
         policy.save()
-
-        # Initialize Q-value (overrides timestamp set by DecayingSortedField)
-        try:
-            initialize_q_value(policy, initial_q=ci_lower)
-        except Exception as e:
-            logger.warning("Failed to set initial Q-value for %s: %s", fp, e)
 
         logger.info(
             "Crystallized PolicyEntry: fp=%s action=%s ci=%.3f (n=%d)",

--- a/src/popoto/recipes/policy_cache.py
+++ b/src/popoto/recipes/policy_cache.py
@@ -424,20 +424,6 @@ def _get_redis_key(instance) -> str:
     return redis_key
 
 
-def _get_sortedset_key(instance) -> str:
-    """Get the sorted set key for the expected_value field.
-
-    Note: Accesses ``instance._meta.fields`` which is a Popoto internal.
-    If the ``_meta`` structure changes in a future Popoto release, this
-    will need updating. The test_q_value_update test validates the key
-    format implicitly.
-    """
-    field = instance._meta.fields["expected_value"]
-    return field.__class__.get_partitioned_sortedset_db_key(
-        instance, "expected_value"
-    ).redis_key
-
-
 # ---------------------------------------------------------------------------
 # StreamConsumer Handlers
 # ---------------------------------------------------------------------------

--- a/src/popoto/recipes/policy_cache.py
+++ b/src/popoto/recipes/policy_cache.py
@@ -193,7 +193,14 @@ class PolicyEntry(EventStreamMixin, AccessTrackerMixin, PredictionLedgerMixin, M
         state_features: Original state feature dict (JSON-serializable).
         action_type: Category of the action (e.g., "run_playbook").
         action_spec: Full action specification dict (JSON-serializable).
-        expected_value: Q-value with temporal decay, partitioned by agent.
+        q_value: Learned Q-value stored as a DecimalField in the model hash.
+            Survives save(), touch(), and "acted" outcomes unchanged.
+            Updated atomically by update_q_value() via TD(0) Lua script.
+        expected_value: Pure recency clock implemented as a DecayingSortedField
+            with base_score_field="q_value". The sorted-set score is the
+            decay-weighted access timestamp; q_value supplies the base
+            magnitude. These two storage slots are independent — writing
+            one does not overwrite the other.
         confidence: Bayesian confidence growing with successful outcomes.
         related_policies: Weighted co-occurrence graph between policies.
         bloom: Bloom filter for fast state_fingerprint pre-checks.
@@ -345,8 +352,11 @@ def update_q_value(
 
         Q(s,a) ← Q(s,a) + α [r + γ max Q(s',a') - Q(s,a)]
 
-    The Q-value is stored in the model hash (not in the sorted set score),
-    keeping it independent from the decay timestamp used by expected_value.
+    The Q-value is stored as a DecimalField in the model hash (HGET/HSET on
+    the ``q_value`` field). This is independent of the ``expected_value``
+    sorted-set score, which is a pure recency/decay clock. Updating the
+    Q-value does not alter the decay timestamp, and a save() or touch() call
+    does not reset the Q-value.
 
     Args:
         instance: A saved PolicyEntry instance.
@@ -381,9 +391,15 @@ def update_q_value(
 def initialize_q_value(instance, initial_q: float = 0.0) -> None:
     """Set the initial Q-value for a PolicyEntry.
 
-    Writes the initial Q-value into the q_value field on the model hash.
-    The decay timestamp in the sorted set is left unchanged — these two
-    storage slots are now separate.
+    Writes ``initial_q`` into the ``q_value`` DecimalField on the model hash
+    and calls ``save()``. The ``expected_value`` sorted-set score (the recency
+    decay clock) is left unchanged — the two storage slots are independent.
+
+    Use this when you want to seed a freshly-constructed PolicyEntry with a
+    specific starting Q before any TD updates. The crystallization handler
+    instead passes ``q_value`` at construction so only one ``save()`` is
+    needed; calling ``initialize_q_value`` afterward is redundant in that
+    path.
 
     Args:
         instance: A saved PolicyEntry instance.

--- a/tests/test_policy_cache.py
+++ b/tests/test_policy_cache.py
@@ -646,9 +646,9 @@ class TestQValueStorageSlotSeparation:
         ).first()
         assert after_save is not None
         assert isinstance(after_save.q_value, Decimal)
-        assert abs(float(after_save.q_value) - 0.2) < 0.001, (
-            f"Expected q_value ~0.2 after save(), got {after_save.q_value}"
-        )
+        assert (
+            abs(float(after_save.q_value) - 0.2) < 0.001
+        ), f"Expected q_value ~0.2 after save(), got {after_save.q_value}"
 
     # -------------------------------------------------------------------------
     # 2. Touch-after-learn: Q survives touch()
@@ -680,9 +680,9 @@ class TestQValueStorageSlotSeparation:
         ).first()
         assert reloaded is not None
         assert isinstance(reloaded.q_value, Decimal)
-        assert abs(float(reloaded.q_value) - 0.15) < 0.001, (
-            f"Expected q_value ~0.15 after touch(), got {reloaded.q_value}"
-        )
+        assert (
+            abs(float(reloaded.q_value) - 0.15) < 0.001
+        ), f"Expected q_value ~0.15 after touch(), got {reloaded.q_value}"
 
     # -------------------------------------------------------------------------
     # 3. "acted" outcome: Q survives ObservationProtocol acted handler
@@ -717,9 +717,9 @@ class TestQValueStorageSlotSeparation:
         ).first()
         assert reloaded is not None
         assert isinstance(reloaded.q_value, Decimal)
-        assert abs(float(reloaded.q_value) - 0.3) < 0.001, (
-            f"Expected q_value ~0.3 after acted, got {reloaded.q_value}"
-        )
+        assert (
+            abs(float(reloaded.q_value) - 0.3) < 0.001
+        ), f"Expected q_value ~0.3 after acted, got {reloaded.q_value}"
 
     # -------------------------------------------------------------------------
     # 4. Lua<->Python encoding round-trip
@@ -731,10 +731,10 @@ class TestQValueStorageSlotSeparation:
         test_cases = [
             # (initial_q, reward, max_future_q, expected_new_q)
             # new_q = current_q + alpha * (reward + gamma * max_future_q - current_q)
-            (0.0, 0.0, 0.0, 0.0),       # Zero stays zero
-            (0.0, 5.0, 0.0, 0.5),       # 0 + 0.1 * 5.0
-            (0.0, -1.5, 0.0, -0.15),    # Negative reward -> negative Q
-            (0.0, 0.25, 0.0, 0.025),    # Fractional precision
+            (0.0, 0.0, 0.0, 0.0),  # Zero stays zero
+            (0.0, 5.0, 0.0, 0.5),  # 0 + 0.1 * 5.0
+            (0.0, -1.5, 0.0, -0.15),  # Negative reward -> negative Q
+            (0.0, 0.25, 0.0, 0.025),  # Fractional precision
         ]
 
         for idx, (initial_q, reward, max_future_q, expected_q) in enumerate(test_cases):
@@ -758,12 +758,12 @@ class TestQValueStorageSlotSeparation:
                 action_type=f"action_{idx}",
             ).first()
             assert reloaded is not None, f"Case {idx}: policy not found"
-            assert isinstance(reloaded.q_value, Decimal), (
-                f"Case {idx}: expected Decimal, got {type(reloaded.q_value)}"
-            )
-            assert abs(float(reloaded.q_value) - expected_q) < 0.001, (
-                f"Case {idx}: expected q_value ~{expected_q}, got {reloaded.q_value}"
-            )
+            assert isinstance(
+                reloaded.q_value, Decimal
+            ), f"Case {idx}: expected Decimal, got {type(reloaded.q_value)}"
+            assert (
+                abs(float(reloaded.q_value) - expected_q) < 0.001
+            ), f"Case {idx}: expected q_value ~{expected_q}, got {reloaded.q_value}"
 
     # -------------------------------------------------------------------------
     # 5. Negative-base ranking
@@ -804,15 +804,15 @@ class TestQValueStorageSlotSeparation:
         zero_idx = action_order.index("action-zero")
         neg_idx = action_order.index("action-neg")
 
-        assert pos_idx < neg_idx, (
-            f"Positive Q must rank above negative Q. Got order: {action_order}"
-        )
+        assert (
+            pos_idx < neg_idx
+        ), f"Positive Q must rank above negative Q. Got order: {action_order}"
         # zero Q with base_score=0.0 → decayed_score = 0 * decay = 0
         # neg Q with base_score=-0.4 → decayed_score < 0
         # So zero should rank above negative
-        assert zero_idx < neg_idx, (
-            f"Zero Q must rank above negative Q. Got order: {action_order}"
-        )
+        assert (
+            zero_idx < neg_idx
+        ), f"Zero Q must rank above negative Q. Got order: {action_order}"
 
     # -------------------------------------------------------------------------
     # 6. Rank derives from stored Q, not 1.0 fallback
@@ -889,9 +889,9 @@ class TestQValueStorageSlotSeparation:
         ).first()
         assert after is not None
         assert isinstance(after.q_value, Decimal)
-        assert abs(float(after.q_value) - 0.1) < 0.001, (
-            f"Race 3 Order 1: expected q_value ~0.1, got {after.q_value}"
-        )
+        assert (
+            abs(float(after.q_value) - 0.1) < 0.001
+        ), f"Race 3 Order 1: expected q_value ~0.1, got {after.q_value}"
 
     def test_save_then_td_then_save_no_reset(self):
         """save → td_update → reload → save(unrelated mutation) preserves the
@@ -931,9 +931,9 @@ class TestQValueStorageSlotSeparation:
         ).first()
         assert final is not None
         assert isinstance(final.q_value, Decimal)
-        assert abs(float(final.q_value) - 0.2) < 0.001, (
-            f"Race 3 Order 2: expected q_value ~0.2, got {final.q_value}"
-        )
+        assert (
+            abs(float(final.q_value) - 0.2) < 0.001
+        ), f"Race 3 Order 2: expected q_value ~0.2, got {final.q_value}"
 
     # -------------------------------------------------------------------------
     # 8. Edge cases
@@ -959,9 +959,9 @@ class TestQValueStorageSlotSeparation:
 
         # With current_q=0 (from Decimal default in hash): td_error = reward = 4.0
         # new_q = 0 + alpha * 4.0 = 0.4
-        assert abs(td_error - reward) < 0.001, (
-            f"Expected td_error={reward} when current_q=0, got {td_error}"
-        )
+        assert (
+            abs(td_error - reward) < 0.001
+        ), f"Expected td_error={reward} when current_q=0, got {td_error}"
 
         reloaded = PolicyEntry.query.filter(
             agent_id="agent-nil",
@@ -970,9 +970,9 @@ class TestQValueStorageSlotSeparation:
         ).first()
         assert reloaded is not None
         expected_new_q = 0.1 * reward  # alpha=0.1, current_q=0
-        assert abs(float(reloaded.q_value) - expected_new_q) < 0.001, (
-            f"Expected q_value ~{expected_new_q}, got {reloaded.q_value}"
-        )
+        assert (
+            abs(float(reloaded.q_value) - expected_new_q) < 0.001
+        ), f"Expected q_value ~{expected_new_q}, got {reloaded.q_value}"
 
     def test_decay_rank_with_missing_q_value(self):
         """A PolicyEntry with no explicit q_value still decay-ranks (base 1.0
@@ -992,8 +992,8 @@ class TestQValueStorageSlotSeparation:
         results = PolicyEntry.query.filter(agent_id="agent-noq").top_by_decay(
             "expected_value", n=10
         )
-        assert len(results) >= 1, (
-            "Expected at least one result even with default q_value"
-        )
+        assert (
+            len(results) >= 1
+        ), "Expected at least one result even with default q_value"
         found_actions = [r.action_type for r in results]
         assert "no_q_action" in found_actions

--- a/tests/test_policy_cache.py
+++ b/tests/test_policy_cache.py
@@ -17,6 +17,8 @@ import asyncio
 import json
 import os
 import sys
+import time
+from decimal import Decimal
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
@@ -584,3 +586,414 @@ class TestPolicyCache:
         ).all()
         assert len(results) >= 1
         assert results[0].action_type == "crystal_action"
+
+
+# ---------------------------------------------------------------------------
+# Q-value Storage-Slot Separation: Regression + Round-Trip Tests
+# Issue #410: PolicyCache Q-value / Decay-Timestamp Storage-Slot Separation
+# ---------------------------------------------------------------------------
+
+
+class TestQValueStorageSlotSeparation:
+    """Regression tests for #410: Q-value stored in model hash, decay timestamp
+    stored in ZSET score.  These tests verify the two slots stay independent."""
+
+    def setup_method(self):
+        """Clean up before each test."""
+        _clean_all()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        _clean_all()
+
+    # -------------------------------------------------------------------------
+    # 1. Save-after-learn: Q survives save()
+    # -------------------------------------------------------------------------
+
+    def test_q_value_survives_save(self):
+        """Q-value written by update_q_value survives a subsequent save()."""
+        fp = compute_fingerprint({"task": "survives_save"})
+        policy = PolicyEntry(
+            agent_id="agent-sv",
+            state_fingerprint=fp,
+            state_features={"task": "survives_save"},
+            action_type="compile",
+            action_spec={},
+        )
+        policy.save()
+        initialize_q_value(policy, initial_q=0.0)
+
+        # Learn some Q
+        update_q_value(policy, reward=2.0, max_future_q=0.0)
+        # current_q=0, alpha=0.1, reward=2.0 -> new_q=0.2
+
+        # Reload and mutate an unrelated field, then save again
+        reloaded = PolicyEntry.query.filter(
+            agent_id="agent-sv",
+            state_fingerprint=fp,
+            action_type="compile",
+        ).first()
+        assert reloaded is not None
+
+        reloaded.action_spec = {"updated": True}
+        reloaded.save()
+
+        # Reload again — q_value must not be overwritten
+        after_save = PolicyEntry.query.filter(
+            agent_id="agent-sv",
+            state_fingerprint=fp,
+            action_type="compile",
+        ).first()
+        assert after_save is not None
+        assert isinstance(after_save.q_value, Decimal)
+        assert abs(float(after_save.q_value) - 0.2) < 0.001, (
+            f"Expected q_value ~0.2 after save(), got {after_save.q_value}"
+        )
+
+    # -------------------------------------------------------------------------
+    # 2. Touch-after-learn: Q survives touch()
+    # -------------------------------------------------------------------------
+
+    def test_q_value_survives_touch(self):
+        """Q-value survives touch('expected_value') — touch only updates ZSET timestamp."""
+        fp = compute_fingerprint({"task": "survives_touch"})
+        policy = PolicyEntry(
+            agent_id="agent-touch",
+            state_fingerprint=fp,
+            state_features={"task": "survives_touch"},
+            action_type="deploy",
+            action_spec={},
+        )
+        policy.save()
+        initialize_q_value(policy, initial_q=0.0)
+        update_q_value(policy, reward=1.5)
+        # new_q = 0 + 0.1 * 1.5 = 0.15
+
+        # Touch the decay field (refreshes ZSET timestamp, must NOT change hash)
+        policy.touch("expected_value")
+
+        # Reload and verify q_value is unchanged
+        reloaded = PolicyEntry.query.filter(
+            agent_id="agent-touch",
+            state_fingerprint=fp,
+            action_type="deploy",
+        ).first()
+        assert reloaded is not None
+        assert isinstance(reloaded.q_value, Decimal)
+        assert abs(float(reloaded.q_value) - 0.15) < 0.001, (
+            f"Expected q_value ~0.15 after touch(), got {reloaded.q_value}"
+        )
+
+    # -------------------------------------------------------------------------
+    # 3. "acted" outcome: Q survives ObservationProtocol acted handler
+    # -------------------------------------------------------------------------
+
+    def test_q_value_survives_acted_outcome(self):
+        """Q-value survives ObservationProtocol 'acted' handler (which touches
+        DecayingSortedFields)."""
+        fp = compute_fingerprint({"task": "survives_acted"})
+        policy = PolicyEntry(
+            agent_id="agent-acted",
+            state_fingerprint=fp,
+            state_features={"task": "survives_acted"},
+            action_type="observe_and_act",
+            action_spec={},
+        )
+        policy.save()
+        initialize_q_value(policy, initial_q=0.0)
+        update_q_value(policy, reward=3.0)
+        # new_q = 0 + 0.1 * 3.0 = 0.3
+
+        # Apply "acted" outcome — this touches all DecayingSortedFields via
+        # _apply_acted(), which must NOT overwrite the q_value hash slot
+        pk = policy.db_key.redis_key
+        ObservationProtocol.on_context_used([policy], {pk: "acted"})
+
+        # Reload and verify q_value survived
+        reloaded = PolicyEntry.query.filter(
+            agent_id="agent-acted",
+            state_fingerprint=fp,
+            action_type="observe_and_act",
+        ).first()
+        assert reloaded is not None
+        assert isinstance(reloaded.q_value, Decimal)
+        assert abs(float(reloaded.q_value) - 0.3) < 0.001, (
+            f"Expected q_value ~0.3 after acted, got {reloaded.q_value}"
+        )
+
+    # -------------------------------------------------------------------------
+    # 4. Lua<->Python encoding round-trip
+    # -------------------------------------------------------------------------
+
+    def test_q_value_encoding_round_trip(self):
+        """Q written by Lua (update_q_value) reads back via Python as Decimal
+        with the correct value."""
+        test_cases = [
+            # (initial_q, reward, max_future_q, expected_new_q)
+            # new_q = current_q + alpha * (reward + gamma * max_future_q - current_q)
+            (0.0, 0.0, 0.0, 0.0),       # Zero stays zero
+            (0.0, 5.0, 0.0, 0.5),       # 0 + 0.1 * 5.0
+            (0.0, -1.5, 0.0, -0.15),    # Negative reward -> negative Q
+            (0.0, 0.25, 0.0, 0.025),    # Fractional precision
+        ]
+
+        for idx, (initial_q, reward, max_future_q, expected_q) in enumerate(test_cases):
+            fp = compute_fingerprint({"task": f"roundtrip_{idx}"})
+            policy = PolicyEntry(
+                agent_id="agent-rt",
+                state_fingerprint=fp,
+                state_features={"task": f"roundtrip_{idx}"},
+                action_type=f"action_{idx}",
+                action_spec={},
+            )
+            policy.save()
+            initialize_q_value(policy, initial_q=initial_q)
+
+            if reward != 0.0 or max_future_q != 0.0:
+                update_q_value(policy, reward=reward, max_future_q=max_future_q)
+
+            reloaded = PolicyEntry.query.filter(
+                agent_id="agent-rt",
+                state_fingerprint=fp,
+                action_type=f"action_{idx}",
+            ).first()
+            assert reloaded is not None, f"Case {idx}: policy not found"
+            assert isinstance(reloaded.q_value, Decimal), (
+                f"Case {idx}: expected Decimal, got {type(reloaded.q_value)}"
+            )
+            assert abs(float(reloaded.q_value) - expected_q) < 0.001, (
+                f"Case {idx}: expected q_value ~{expected_q}, got {reloaded.q_value}"
+            )
+
+    # -------------------------------------------------------------------------
+    # 5. Negative-base ranking
+    # -------------------------------------------------------------------------
+
+    def test_negative_q_value_ranking(self):
+        """Negative Q ranks below positive Q of equal recency; zero Q ranks
+        below positive Q but above (i.e. less negative than) negative Q."""
+        agent = "agent-rank"
+        state_fp = compute_fingerprint({"task": "ranking_test"})
+
+        # Create 3 policies with same recency but different q_values
+        q_configs = [
+            ("action-neg", -0.4),
+            ("action-zero", 0.0),
+            ("action-pos", 0.6),
+        ]
+        for action, q_val in q_configs:
+            fp = compute_fingerprint({"task": "ranking_test", "action": action})
+            policy = PolicyEntry(
+                agent_id=agent,
+                state_fingerprint=fp,
+                state_features={"task": "ranking_test"},
+                action_type=action,
+                action_spec={},
+                q_value=Decimal(str(q_val)),
+            )
+            policy.save()
+
+        # Query top by decay for this agent
+        results = PolicyEntry.query.filter(agent_id=agent).top_by_decay(
+            "expected_value", n=10
+        )
+        assert len(results) == 3
+
+        action_order = [r.action_type for r in results]
+        pos_idx = action_order.index("action-pos")
+        zero_idx = action_order.index("action-zero")
+        neg_idx = action_order.index("action-neg")
+
+        assert pos_idx < neg_idx, (
+            f"Positive Q must rank above negative Q. Got order: {action_order}"
+        )
+        # zero Q with base_score=0.0 → decayed_score = 0 * decay = 0
+        # neg Q with base_score=-0.4 → decayed_score < 0
+        # So zero should rank above negative
+        assert zero_idx < neg_idx, (
+            f"Zero Q must rank above negative Q. Got order: {action_order}"
+        )
+
+    # -------------------------------------------------------------------------
+    # 6. Rank derives from stored Q, not 1.0 fallback
+    # -------------------------------------------------------------------------
+
+    def test_rank_derives_from_stored_q_value(self):
+        """Decayed rank derives from stored q_value, not a silent 1.0 fallback."""
+        agent = "agent-q-rank"
+        configs = [
+            ("high-q-action", 0.6),
+            ("low-q-action", 0.2),
+        ]
+        for action, q_val in configs:
+            fp = compute_fingerprint({"task": "q_rank", "action": action})
+            policy = PolicyEntry(
+                agent_id=agent,
+                state_fingerprint=fp,
+                state_features={"task": "q_rank"},
+                action_type=action,
+                action_spec={},
+                q_value=Decimal(str(q_val)),
+            )
+            policy.save()
+
+        results = PolicyEntry.query.filter(agent_id=agent).top_by_decay(
+            "expected_value", n=10
+        )
+        assert len(results) == 2
+
+        first_action = results[0].action_type
+        assert first_action == "high-q-action", (
+            f"Expected high-q-action first, got {first_action}. "
+            "If both ranked the same, the 1.0 fallback may have been used."
+        )
+
+    # -------------------------------------------------------------------------
+    # 7. Race-3 interleaving tests
+    # -------------------------------------------------------------------------
+
+    def test_td_update_then_save_q_survives(self):
+        """After TD update, saving with unrelated field change does not reset
+        q_value (Race 3 Order 1: save → update_q_value → reload → save)."""
+        fp = compute_fingerprint({"task": "race3_order1"})
+        policy = PolicyEntry(
+            agent_id="agent-race3a",
+            state_fingerprint=fp,
+            state_features={"task": "race3_order1"},
+            action_type="race_action",
+            action_spec={"v": 1},
+        )
+        policy.save()
+        initialize_q_value(policy, initial_q=0.0)
+
+        # TD update writes q_value to hash via Lua
+        update_q_value(policy, reward=1.0)
+        # expected new_q = 0.1
+
+        # Reload, mutate unrelated field, save again
+        reloaded = PolicyEntry.query.filter(
+            agent_id="agent-race3a",
+            state_fingerprint=fp,
+            action_type="race_action",
+        ).first()
+        assert reloaded is not None
+
+        reloaded.action_spec = {"v": 2}
+        reloaded.save()
+
+        # Verify q_value survived the second save
+        after = PolicyEntry.query.filter(
+            agent_id="agent-race3a",
+            state_fingerprint=fp,
+            action_type="race_action",
+        ).first()
+        assert after is not None
+        assert isinstance(after.q_value, Decimal)
+        assert abs(float(after.q_value) - 0.1) < 0.001, (
+            f"Race 3 Order 1: expected q_value ~0.1, got {after.q_value}"
+        )
+
+    def test_save_then_td_then_save_no_reset(self):
+        """save → td_update → reload → save(unrelated mutation) preserves the
+        TD-written Q (Race 3 Order 2)."""
+        fp = compute_fingerprint({"task": "race3_order2"})
+        policy = PolicyEntry(
+            agent_id="agent-race3b",
+            state_fingerprint=fp,
+            state_features={"task": "race3_order2"},
+            action_type="race_action_b",
+            action_spec={"v": 1},
+        )
+        # First save establishes the record
+        policy.save()
+        initialize_q_value(policy, initial_q=0.0)
+
+        # TD update (Lua writes q_value into hash)
+        update_q_value(policy, reward=2.0)
+        # expected new_q = 0 + 0.1 * 2.0 = 0.2
+
+        # Reload, mutate unrelated field, save
+        reloaded = PolicyEntry.query.filter(
+            agent_id="agent-race3b",
+            state_fingerprint=fp,
+            action_type="race_action_b",
+        ).first()
+        assert reloaded is not None
+
+        reloaded.action_spec = {"v": 3}
+        reloaded.save()
+
+        # Final reload — TD Q must persist
+        final = PolicyEntry.query.filter(
+            agent_id="agent-race3b",
+            state_fingerprint=fp,
+            action_type="race_action_b",
+        ).first()
+        assert final is not None
+        assert isinstance(final.q_value, Decimal)
+        assert abs(float(final.q_value) - 0.2) < 0.001, (
+            f"Race 3 Order 2: expected q_value ~0.2, got {final.q_value}"
+        )
+
+    # -------------------------------------------------------------------------
+    # 8. Edge cases
+    # -------------------------------------------------------------------------
+
+    def test_td_update_nil_q_treated_as_zero(self):
+        """TD update on an instance with no prior q_value initialization treats
+        current Q as 0 (default field value acts as zero baseline)."""
+        fp = compute_fingerprint({"task": "nil_q"})
+        policy = PolicyEntry(
+            agent_id="agent-nil",
+            state_fingerprint=fp,
+            state_features={"task": "nil_q"},
+            action_type="nil_action",
+            action_spec={},
+            # q_value not set → uses DecimalField default=Decimal("0")
+        )
+        policy.save()
+
+        # Do NOT call initialize_q_value — rely on default
+        reward = 4.0
+        td_error = update_q_value(policy, reward=reward, max_future_q=0.0)
+
+        # With current_q=0 (from Decimal default in hash): td_error = reward = 4.0
+        # new_q = 0 + alpha * 4.0 = 0.4
+        assert abs(td_error - reward) < 0.001, (
+            f"Expected td_error={reward} when current_q=0, got {td_error}"
+        )
+
+        reloaded = PolicyEntry.query.filter(
+            agent_id="agent-nil",
+            state_fingerprint=fp,
+            action_type="nil_action",
+        ).first()
+        assert reloaded is not None
+        expected_new_q = 0.1 * reward  # alpha=0.1, current_q=0
+        assert abs(float(reloaded.q_value) - expected_new_q) < 0.001, (
+            f"Expected q_value ~{expected_new_q}, got {reloaded.q_value}"
+        )
+
+    def test_decay_rank_with_missing_q_value(self):
+        """A PolicyEntry with no explicit q_value still decay-ranks (base 1.0
+        fallback path in Lua — no error raised, entry appears in results)."""
+        fp = compute_fingerprint({"task": "no_q_rank"})
+        policy = PolicyEntry(
+            agent_id="agent-noq",
+            state_fingerprint=fp,
+            state_features={"task": "no_q_rank"},
+            action_type="no_q_action",
+            action_spec={},
+            # q_value not set — default Decimal("0") will be stored
+        )
+        policy.save()
+
+        # Should not raise; entry must appear in results
+        results = PolicyEntry.query.filter(agent_id="agent-noq").top_by_decay(
+            "expected_value", n=10
+        )
+        assert len(results) >= 1, (
+            "Expected at least one result even with default q_value"
+        )
+        found_actions = [r.action_type for r in results]
+        assert "no_q_action" in found_actions


### PR DESCRIPTION
## Summary

Fixes #410. Separates the PolicyCache **Q-value** storage from the **decay-timestamp** ZSET score slot so neither write path can corrupt the other.

Previously `PolicyEntry.expected_value` was a `DecayingSortedField` whose single ZSET score held *both* the learned Q-value *and* the decay last-updated timestamp. Every `save()` / `touch()` / ObservationProtocol `"acted"` overwrote the Q with `time.time()`, and decay queries misread a surviving Q in [0,1] as a 1970-epoch timestamp (audit findings **MATH-2** + **POLICY-1**).

## Changes

- **`PolicyEntry` gains a `q_value = DecimalField(default=Decimal("0"))`** in the model hash. The Q-value now lives in the hash, fully independent of the decay clock.
- **`expected_value` keeps `base_score_field="q_value"`** — the decay Lua reads the real Q as the base score while the ZSET score stays a pure last-updated timestamp. Recency ranking now reflects actual update times.
- **`TD_UPDATE_LUA` rewritten** to `HGET`/`HSET` the `q_value` hash field via cmsgpack `__Decimal__` tagged-dict encoding (byte-interchangeable with Python's msgpack Decimal). Update stays atomic; Redis + Valkey compatible (plain hash + Lua, no modules).
- **`initialize_q_value`** no longer ZADDs over the timestamp — it sets `instance.q_value` and saves. The "override the timestamp" workaround is gone.
- **`crystallization_handler`** passes `q_value=Decimal(str(ci_lower))` at construction, so the initial Q persists in the same `save()` (removes the post-save workaround).
- **`decaying_sorted_field.py`**: sign-preserving `math.pow` (Lua `math.pow` rejects negative bases) so post-TD negative Q-values rank correctly. **Bitwise-identical for non-negative base scores** — no behavior change for existing positive-score fields.

## Acceptance Criteria

All 7 ACs met, covered by the new `TestQValueStorageSlotSeparation` suite (11 tests):
- Q survives `save()`, `touch("expected_value")`, and the ObservationProtocol `"acted"` path.
- Decay queries never read a Q as a timestamp; ranking derives from stored Q.
- `update_q_value()` after save/touch computes TD error from the true prior Q.
- `initialize_q_value` timestamp-override removed.
- Regression tests for save-after-learn and touch-after-learn (the exact untested gap).
- Lua↔Python encoding round-trip verified.

## Testing

- `tests/test_policy_cache.py`: **35 passed** (incl. all 11 new separation tests), deterministic.
- `scripts/ci-local.sh --fast`: policy_cache fully green. The only failures are in `tests/test_trajectory_memory.py`, which are **pre-existing flaky/order-dependent tests on `main`** (verified: `main` fails a *different*, varying subset run-to-run — 1 failure, then 0, with no code change). They are unrelated to this PR and are being handled in separate trajectory-memory isolation work. This change cannot affect them: the only shared file touched is `decaying_sorted_field.py`, whose Lua is bitwise-identical for the non-negative scores trajectory memory uses.

Breaking schema change (beta substrate layer) — no migration, per the plan.
