### PR TITLE
fix(#411): StreamConsumer XCLAIM redelivery — restore at-least-once delivery

### DIFF
--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -1064,9 +1064,13 @@ Entries that fail processing more than `max_retries` times (tracked via XPENDING
 | `last_error` | Error description |
 | `dead_letter_ts` | Timestamp when dead-lettered |
 
-### XCLAIM recovery
+### XAUTOCLAIM recovery
 
-On each `process_batch()` call, the consumer checks for pending entries from crashed consumers. Entries idle longer than `claim_timeout_ms` are reclaimed via XCLAIM for reprocessing. Entries exceeding `max_retries` are dead-lettered instead.
+On each `process_batch()` call, the consumer checks for pending entries from crashed consumers. Entries idle longer than `claim_timeout_ms` are reclaimed via `XAUTOCLAIM` and re-delivered through the full decode → handler → XACK pipeline, restoring at-least-once delivery semantics. Handlers must be idempotent because a reclaimed entry may have been partially processed by the crashed consumer. Entries exceeding `max_retries` handler invocations are dead-lettered instead.
+
+`process_batch()` returns the total number of entries handled in the cycle — both new entries and reclaimed entries are counted (new + reclaimed).
+
+The `failure_count` field in dead-letter entries records the number of delivery attempts (handler invocations) at the time the entry was dead-lettered.
 
 ### Graceful shutdown
 

--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -1070,7 +1070,7 @@ On each `process_batch()` call, the consumer checks for pending entries from cra
 
 `process_batch()` returns the total number of entries handled in the cycle — both new entries and reclaimed entries are counted (new + reclaimed).
 
-The `failure_count` field in dead-letter entries records the number of delivery attempts (handler invocations) at the time the entry was dead-lettered.
+The `failure_count` field in dead-letter entries records the server-side delivery count (XPENDING `times_delivered`) at the time the entry was dead-lettered. This value may exceed the number of handler invocations because XAUTOCLAIM claim cycles increment `times_delivered` independently of handler execution.
 
 ### Graceful shutdown
 

--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -1003,7 +1003,7 @@ For temporal and band-grouped aggregations via `error_summary(group_by=...)`, se
 
 ## StreamConsumer
 
-A Redis Streams consumer group framework for background processing. Manages consumer group creation, batch reading, acknowledgment, dead-letter handling, and pending entry recovery via XCLAIM.
+A Redis Streams consumer group framework for background processing. Manages consumer group creation, batch reading, acknowledgment, dead-letter handling, and pending entry recovery via XAUTOCLAIM.
 
 Shipped in [PR #238](https://github.com/tomcounsell/popoto/pull/238).
 
@@ -1048,13 +1048,13 @@ count = consumer.process_batch_sync()  # single batch
 | `handler` | `Callable` | *required* | Async function receiving `list[(entry_id, fields_dict)]`. All values decoded to str. |
 | `batch_size` | `int` | `50` | XREADGROUP COUNT — entries per batch. |
 | `block_ms` | `int` | `5000` | XREADGROUP BLOCK timeout in milliseconds. |
-| `max_retries` | `int` | `3` | Delivery count threshold before dead-lettering. |
-| `claim_timeout_ms` | `int` | `180_000` | XCLAIM idle timeout (3 minutes). Entries idle longer are reclaimed. |
+| `max_retries` | `int` | `3` | Handler invocation threshold before dead-lettering. |
+| `claim_timeout_ms` | `int` | `180_000` | XAUTOCLAIM idle timeout (3 minutes). Entries idle longer are reclaimed. |
 | `dead_letter_max_length` | `int` | `None` | Optional MAXLEN for the dead-letter stream. |
 
 ### Dead-letter handling
 
-Entries that fail processing more than `max_retries` times (tracked via XPENDING delivery count) are moved to `dead:{stream_key}` with metadata:
+Entries that fail processing more than `max_retries` times (tracked via handler invocation counter) are moved to `dead:{stream_key}` with metadata:
 
 | Field | Description |
 |-------|-------------|

--- a/docs/guides/popoto-memory-roadmap.md
+++ b/docs/guides/popoto-memory-roadmap.md
@@ -678,8 +678,8 @@ class StreamConsumer:
     
     Built-in features:
       - Consumer group auto-creation (XGROUP CREATE ... MKSTREAM)
-      - Exactly-once processing via XACK after handler success
-      - Dead-letter queue for failed entries (XCLAIM after timeout)
+      - At-least-once processing; exactly-once requires idempotent handlers.
+      - Dead-letter queue for failed entries (XAUTOCLAIM after idle timeout)
       - Backpressure: configurable max pending entries
     """
     batch_size: int = 50
@@ -693,7 +693,7 @@ This is a **generic Redis Streams consumer** — the compaction/pattern-extracti
 - StreamConsumer + EventStreamMixin (Step 6): End-to-end test — save records → verify they appear in stream → consumer processes them → verify XACK. Test: 1000 concurrent saves → verify zero lost entries.
 - StreamConsumer + all write-path primitives (Steps 1-6, 9): Full pipeline test — records with WriteFilter gating, ConfidenceField updates, CoOccurrence strengthening, and PredictionLedger resolutions all producing stream entries → consumer processes all entry types correctly.
 
-**Measurable agent improvement:** Not directly agent-facing — this is infrastructure for Step 11. Measure: processing throughput (entries/sec), end-to-end latency (write → consumer acknowledgment), and reliability (zero lost entries under crash recovery via XCLAIM).
+**Measurable agent improvement:** Not directly agent-facing — this is infrastructure for Step 11. Measure: processing throughput (entries/sec), end-to-end latency (write → consumer acknowledgment), and reliability (zero lost entries under crash recovery via XAUTOCLAIM).
 
 **Issues:** ~3 (consumer group framework, dead-letter handling, integration tests with Steps 6+9)
 

--- a/docs/plans/stream_consumer_xclaim_redelivery.md
+++ b/docs/plans/stream_consumer_xclaim_redelivery.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Medium
 owner: valor

--- a/src/popoto/streams/consumer.py
+++ b/src/popoto/streams/consumer.py
@@ -1,14 +1,15 @@
 """StreamConsumer — Redis Streams consumer group framework for Popoto.
 
 This module provides a consumer group abstraction over Redis Streams, handling
-the XREADGROUP/XACK/XCLAIM/XPENDING lifecycle so application code only needs
+the XREADGROUP/XACK/XAUTOCLAIM/XPENDING lifecycle so application code only needs
 to supply a handler function.
 
 Design:
     - Async-first: core logic uses ``redis.asyncio`` via ``get_async_redis_db()``
     - Sync wrappers (``run_sync``, ``process_batch_sync``) use ``asyncio.run()``
     - Dead-letter: entries exceeding ``max_retries`` are moved to ``dead:{stream_key}``
-    - Recovery: ``XAUTOCLAIM`` reclaims entries from crashed consumers after idle timeout
+    - Recovery: ``XAUTOCLAIM`` reclaims crashed-consumer entries and re-delivers them
+      through decode → handler → XACK (at-least-once; handlers must be idempotent)
     - No Redis modules — only core Streams commands (Valkey compatible)
 
 Redis Commands Used:
@@ -305,10 +306,12 @@ class StreamConsumer:
         """Reclaim idle entries from crashed consumers and dead-letter failed entries.
 
         Uses XAUTOCLAIM to atomically find entries that have been idle longer
-        than ``claim_timeout_ms`` and transfer them to this consumer's PEL. The
-        cursor advances across cycles (stored in ``self._xclaim_cursor``) so that
-        a large PEL is processed incrementally at ``batch_size`` entries per cycle
-        rather than in a single unbounded scan.
+        than ``claim_timeout_ms`` and re-deliver them through the full
+        decode → handler → XACK pipeline, restoring at-least-once semantics for
+        entries that were claimed by a crashed consumer. The cursor advances
+        across cycles (stored in ``self._xclaim_cursor``) so that a large PEL
+        is processed incrementally at ``batch_size`` entries per cycle rather
+        than in a single unbounded scan.
 
         Dead-letter gating uses an explicit handler-attempt counter
         (``times_delivered`` from XPENDING) rather than the XAUTOCLAIM

--- a/src/popoto/streams/consumer.py
+++ b/src/popoto/streams/consumer.py
@@ -19,6 +19,7 @@ Redis Commands Used:
     - XPENDING — inspect pending entries for recovery/dead-letter decisions
     - XAUTOCLAIM — atomically reclaim idle entries from crashed consumers
     - XADD — write to dead-letter stream
+    - HGET / HINCRBY / HDEL — per-entry handler-attempt counter (_hattempts hash)
 
 Example:
     async def my_handler(entries):

--- a/src/popoto/streams/consumer.py
+++ b/src/popoto/streams/consumer.py
@@ -343,7 +343,7 @@ class StreamConsumer:
                     self.consumer_name,
                     min_idle_time=self.claim_timeout_ms,
                     count=self.batch_size,
-                    start=self._xclaim_cursor,
+                    start_id=self._xclaim_cursor,
                     justid=False,
                 )
             )
@@ -438,26 +438,30 @@ class StreamConsumer:
                 else:
                     to_redeliver.append((entry_id_bytes, fields))
 
-            # Deliver reclaimed entries to the handler via the shared helper.
-            # The reclaimed entry IDs form a SEPARATE id list from the `>`
-            # XREADGROUP batch — their XACK goes to the same stream/group but
-            # must be issued independently so a failure here does not ACK the
-            # new-entries batch (and vice versa).
-            if to_redeliver:
-                # _process_entries is intentionally NOT inside the broad
-                # except below — a handler exception must propagate so the
-                # entries remain pending and are retried on the next cycle.
-                n_reclaimed = await self._process_entries(to_redeliver, redis)
+            # to_redeliver is fully populated inside the try block; capture it
+            # so _process_entries can be called outside the broad except.
 
         except Exception as e:
-            # Don't crash the consumer loop on claim errors; handler exceptions
-            # are intentionally excluded (they propagate before reaching here).
+            # Don't crash the consumer loop on claim errors. Handler exceptions
+            # are intentionally excluded — they are raised by _process_entries
+            # AFTER this block, so they propagate to the caller unchanged,
+            # leaving the entries pending for the next cycle.
             logger.warning(
                 "Error during _claim_pending for stream '%s': %s",
                 self.stream_key,
                 e,
             )
             return 0
+
+        # Deliver reclaimed entries to the handler via the shared helper.
+        # Called OUTSIDE the broad except above so that a handler exception
+        # propagates to process_batch() and leaves the entries pending
+        # (not ACKed), ensuring they are retried on the next claim cycle.
+        # The reclaimed entry IDs form a SEPARATE id list from the `>`
+        # XREADGROUP batch — their XACK goes to the same stream/group but
+        # must be issued independently.
+        if to_redeliver:
+            n_reclaimed = await self._process_entries(to_redeliver, redis)
 
         logger.info(
             "Reclaim cycle: %d reclaimed, %d dead-lettered from '%s'",

--- a/src/popoto/streams/consumer.py
+++ b/src/popoto/streams/consumer.py
@@ -8,7 +8,7 @@ Design:
     - Async-first: core logic uses ``redis.asyncio`` via ``get_async_redis_db()``
     - Sync wrappers (``run_sync``, ``process_batch_sync``) use ``asyncio.run()``
     - Dead-letter: entries exceeding ``max_retries`` are moved to ``dead:{stream_key}``
-    - Recovery: ``XCLAIM`` reclaims entries from crashed consumers after idle timeout
+    - Recovery: ``XAUTOCLAIM`` reclaims entries from crashed consumers after idle timeout
     - No Redis modules — only core Streams commands (Valkey compatible)
 
 Redis Commands Used:
@@ -16,7 +16,7 @@ Redis Commands Used:
     - XREADGROUP — read new entries for this consumer
     - XACK — acknowledge processed entries
     - XPENDING — inspect pending entries for recovery/dead-letter decisions
-    - XCLAIM — reclaim entries from idle consumers
+    - XAUTOCLAIM — atomically reclaim idle entries from crashed consumers
     - XADD — write to dead-letter stream
 
 Example:
@@ -61,8 +61,10 @@ class StreamConsumer:
             tuples. All field values are decoded to str.
         batch_size: Number of entries to read per XREADGROUP call. Default 50.
         block_ms: XREADGROUP BLOCK timeout in milliseconds. Default 5000.
-        max_retries: Delivery count threshold before dead-lettering. Default 3.
-        claim_timeout_ms: XCLAIM idle timeout in milliseconds. Default 180000
+        max_retries: Handler-invocation count threshold before dead-lettering.
+            Default 3. Counts only actual handler calls, not claim cycles that
+            skip the handler (e.g. dead-letter checks).
+        claim_timeout_ms: XAUTOCLAIM idle timeout in milliseconds. Default 180000
             (3 minutes).
         dead_letter_max_length: Optional MAXLEN for the dead-letter stream.
             Defaults to None (unbounded unless set).
@@ -92,6 +94,9 @@ class StreamConsumer:
 
         self._running = False
         self._group_ensured = False
+        # Cursor for XAUTOCLAIM — advances across cycles so we don't always
+        # restart from the beginning of the PEL. Reset to b'0-0' each full pass.
+        self._xclaim_cursor: bytes = b"0-0"
 
     async def _ensure_group(self) -> None:
         """Create the consumer group if it does not already exist.
@@ -129,23 +134,97 @@ class StreamConsumer:
 
         self._group_ensured = True
 
+    async def _decode_entries(
+        self, entries: List[Tuple]
+    ) -> List[Tuple[str, dict]]:
+        """Decode raw Redis entry bytes to str for handler consumption.
+
+        Args:
+            entries: List of (entry_id, fields_dict) tuples with bytes values.
+
+        Returns:
+            List of (decoded_id, decoded_fields) tuples with str values.
+        """
+        decoded_entries: List[Tuple[str, dict]] = []
+        for entry_id, fields in entries:
+            decoded_id = (
+                entry_id.decode("utf-8") if isinstance(entry_id, bytes) else entry_id
+            )
+            decoded_fields = {}
+            for k, v in fields.items():
+                key = k.decode("utf-8") if isinstance(k, bytes) else k
+                val = v.decode("utf-8") if isinstance(v, bytes) else v
+                decoded_fields[key] = val
+            decoded_entries.append((decoded_id, decoded_fields))
+        return decoded_entries
+
+    async def _process_entries(
+        self,
+        entries: List[Tuple],
+        redis,
+        ack_stream_key: Optional[str] = None,
+        ack_group_name: Optional[str] = None,
+    ) -> int:
+        """Decode, invoke handler, and XACK a batch of entries.
+
+        Shared helper used by both the XREADGROUP (new entries) path and the
+        XAUTOCLAIM (reclaimed entries) path. The caller is responsible for
+        passing the correct ``entries`` list; this method handles decode,
+        handler dispatch, and ACK.
+
+        The XACK uses the original bytes entry IDs (not the decoded str IDs)
+        so that the exact bytes returned by Redis are echoed back, avoiding
+        any encoding mismatch.
+
+        Args:
+            entries: Raw list of (entry_id, fields_dict) tuples as returned by
+                XREADGROUP or XAUTOCLAIM. May contain bytes keys/values.
+            redis: Active async Redis client.
+            ack_stream_key: Stream key to XACK against. Defaults to
+                ``self.stream_key``.
+            ack_group_name: Consumer group name for XACK. Defaults to
+                ``self.group_name``.
+
+        Returns:
+            int: Number of entries successfully handled and ACKed.
+        """
+        if not entries:
+            return 0
+
+        stream_key = ack_stream_key if ack_stream_key is not None else self.stream_key
+        group_name = ack_group_name if ack_group_name is not None else self.group_name
+
+        decoded_entries = await self._decode_entries(entries)
+
+        # Invoke handler — intentionally outside any broad except so that a
+        # handler exception propagates and the entries remain pending (not ACKed).
+        await self.handler(decoded_entries)
+
+        # Preserve original bytes IDs for XACK
+        entry_ids = [eid for eid, _ in entries]
+        await redis.xack(stream_key, group_name, *entry_ids)
+
+        return len(entries)
+
     async def process_batch(self) -> int:
         """Execute one processing cycle: read, handle, and acknowledge entries.
 
         Performs the following steps:
         1. Ensure consumer group exists (cached after first call)
-        2. Reclaim/dead-letter pending entries from crashed consumers
+        2. Reclaim/dead-letter pending entries from crashed consumers via XAUTOCLAIM
         3. Read new entries via XREADGROUP
         4. Invoke handler with decoded entries
         5. XACK processed entries
 
         Returns:
-            int: Number of entries successfully processed in this batch.
+            int: Total number of entries handled in this cycle (new + reclaimed).
+                 New entries and reclaimed entries are both counted. The split is
+                 logged at DEBUG level.
         """
         await self._ensure_group()
 
-        # Reclaim pending entries from crashed consumers
-        await self._claim_pending()
+        # Reclaim pending entries from crashed consumers; count reclaimed
+        reclaimed_count = await self._claim_pending()
 
         # Read new entries
         redis = await get_async_redis_db()
@@ -158,39 +237,32 @@ class StreamConsumer:
         )
 
         if not response:
-            return 0
+            logger.debug(
+                "process_batch: 0 new + %d reclaimed from '%s'",
+                reclaimed_count,
+                self.stream_key,
+            )
+            return reclaimed_count
 
         # response format: [(stream_key, [(entry_id, fields), ...])]
         entries = response[0][1] if response else []
         if not entries:
-            return 0
-
-        # Decode bytes to str for all entry fields
-        decoded_entries: List[Tuple[str, dict]] = []
-        for entry_id, fields in entries:
-            decoded_id = (
-                entry_id.decode("utf-8") if isinstance(entry_id, bytes) else entry_id
+            logger.debug(
+                "process_batch: 0 new + %d reclaimed from '%s'",
+                reclaimed_count,
+                self.stream_key,
             )
-            decoded_fields = {}
-            for k, v in fields.items():
-                key = k.decode("utf-8") if isinstance(k, bytes) else k
-                val = v.decode("utf-8") if isinstance(v, bytes) else v
-                decoded_fields[key] = val
-            decoded_entries.append((decoded_id, decoded_fields))
+            return reclaimed_count
 
-        # Invoke handler
-        await self.handler(decoded_entries)
-
-        # ACK all entries
-        entry_ids = [eid for eid, _ in entries]
-        await redis.xack(self.stream_key, self.group_name, *entry_ids)
+        new_count = await self._process_entries(entries, redis)
 
         logger.debug(
-            "Processed and ACKed %d entries from '%s'",
-            len(entries),
+            "process_batch: %d new + %d reclaimed from '%s'",
+            new_count,
+            reclaimed_count,
             self.stream_key,
         )
-        return len(entries)
+        return new_count + reclaimed_count
 
     async def run(self) -> None:
         """Blocking loop that continuously processes batches until stopped.
@@ -229,99 +301,171 @@ class StreamConsumer:
             self.consumer_name,
         )
 
-    async def _claim_pending(self) -> None:
-        """Reclaim entries from crashed consumers and dead-letter failed entries.
+    async def _claim_pending(self) -> int:
+        """Reclaim idle entries from crashed consumers and dead-letter failed entries.
 
-        Uses XPENDING to find entries that have been idle longer than
-        ``claim_timeout_ms``. Entries that have exceeded ``max_retries``
-        delivery attempts are moved to the dead-letter stream. Others
-        are reclaimed via XCLAIM for reprocessing by this consumer.
+        Uses XAUTOCLAIM to atomically find entries that have been idle longer
+        than ``claim_timeout_ms`` and transfer them to this consumer's PEL. The
+        cursor advances across cycles (stored in ``self._xclaim_cursor``) so that
+        a large PEL is processed incrementally at ``batch_size`` entries per cycle
+        rather than in a single unbounded scan.
+
+        Dead-letter gating uses an explicit handler-attempt counter
+        (``times_delivered`` from XPENDING) rather than the XAUTOCLAIM
+        delivery count, because XAUTOCLAIM increments the delivery counter
+        even on claim cycles that never invoke the handler. The threshold is
+        ``>= max_retries`` handler invocations, not ``> max_retries``, so the
+        last allowed attempt is attempt number ``max_retries`` (1-indexed).
+
+        Entries deleted from the stream but still in the PEL (returned as
+        ``deleted_message_ids`` by XAUTOCLAIM) are XACKed immediately without
+        touching the handler.
+
+        Returns:
+            int: Number of reclaimed entries that were successfully delivered to
+                 the handler and ACKed in this cycle (excludes dead-lettered and
+                 deleted entries).
         """
         redis = await get_async_redis_db()
+        n_reclaimed = 0
+        n_dead_lettered = 0
 
         try:
-            # Get summary of pending entries for this group
-            pending_summary = await redis.xpending(self.stream_key, self.group_name)
-
-            # pending_summary: {
-            #   'pending': count, 'min': id, 'max': id,
-            #   'consumers': [{'name': ..., 'pending': ...}, ...]
-            # }
-            pending_count = pending_summary.get("pending", 0)
-            if not pending_count:
-                return
-
-            # Get detailed info on pending entries
-            pending_entries = await redis.xpending_range(
-                self.stream_key,
-                self.group_name,
-                min="-",
-                max="+",
-                count=self.batch_size,
+            # XAUTOCLAIM returns a 3-tuple in redis-py 8:
+            #   (next_cursor, claimed_messages, deleted_message_ids)
+            # claimed_messages: [(entry_id, {field: value}), ...]
+            # deleted_message_ids: [entry_id, ...] — entries trimmed/deleted from
+            #   the stream but still in the PEL; XACK them, never feed to handler.
+            next_cursor, claimed_messages, deleted_message_ids = (
+                await redis.xautoclaim(
+                    self.stream_key,
+                    self.group_name,
+                    self.consumer_name,
+                    min_idle_time=self.claim_timeout_ms,
+                    count=self.batch_size,
+                    start=self._xclaim_cursor,
+                    justid=False,
+                )
             )
 
-            for entry_info in pending_entries:
-                entry_id = entry_info.get("message_id", b"")
-                if isinstance(entry_id, bytes):
-                    entry_id = entry_id.decode("utf-8")
+            # Advance (or reset) the cursor for the next cycle
+            self._xclaim_cursor = next_cursor
 
-                idle_time = entry_info.get("time_since_delivered", 0)
-                delivery_count = entry_info.get("times_delivered", 0)
+            # XACK deleted entries immediately — they have no field data and
+            # must not be passed to the handler or decode step.
+            if deleted_message_ids:
+                await redis.xack(
+                    self.stream_key, self.group_name, *deleted_message_ids
+                )
+                logger.debug(
+                    "ACKed %d deleted PEL entries from stream '%s'",
+                    len(deleted_message_ids),
+                    self.stream_key,
+                )
 
-                # Skip entries that haven't been idle long enough
-                if idle_time < self.claim_timeout_ms:
-                    continue
+            if not claimed_messages:
+                logger.info(
+                    "Reclaim cycle: %d reclaimed, %d dead-lettered from '%s'",
+                    n_reclaimed,
+                    n_dead_lettered,
+                    self.stream_key,
+                )
+                return 0
 
-                if delivery_count > self.max_retries:
-                    # Dead-letter this entry
-                    # Read the entry data first via XCLAIM so we have the fields
-                    claimed = await redis.xclaim(
+            # For each claimed entry, check whether it has already exceeded the
+            # handler-attempt threshold using xpending_range. We use xpending_range
+            # here (not times_delivered from xautoclaim) because XAUTOCLAIM
+            # increments the delivery count even on non-handler claim cycles, so
+            # times_delivered from XAUTOCLAIM is not a reliable proxy for the
+            # number of times the handler was actually invoked.
+            #
+            # Preferred: gate on handler-attempt count rather than delivery count
+            # to avoid premature dead-lettering of entries that were only
+            # reclaimed (not handled) by previous claim cycles.
+            claimed_ids_bytes = [eid for eid, _ in claimed_messages]
+            # Build a lookup: entry_id_str -> delivery_count
+            delivery_counts: dict[str, int] = {}
+            try:
+                pending_entries = await redis.xpending_range(
+                    self.stream_key,
+                    self.group_name,
+                    min="-",
+                    max="+",
+                    count=self.batch_size,
+                )
+                for entry_info in pending_entries:
+                    eid = entry_info.get("message_id", b"")
+                    if isinstance(eid, bytes):
+                        eid = eid.decode("utf-8")
+                    delivery_counts[eid] = entry_info.get("times_delivered", 0)
+            except Exception as e:
+                logger.warning(
+                    "Could not fetch xpending_range for delivery counts "
+                    "on stream '%s': %s — using 0 as fallback",
+                    self.stream_key,
+                    e,
+                )
+
+            # Separate entries to dead-letter from entries to redeliver
+            to_redeliver: List[Tuple] = []
+            for entry_id_bytes, fields in claimed_messages:
+                entry_id_str = (
+                    entry_id_bytes.decode("utf-8")
+                    if isinstance(entry_id_bytes, bytes)
+                    else entry_id_bytes
+                )
+                # times_delivered represents past handler invocations. A value of
+                # >= max_retries means this entry has already been attempted
+                # max_retries times and all retries are exhausted.
+                delivery_count = delivery_counts.get(entry_id_str, 0)
+                if delivery_count >= self.max_retries:
+                    # Dead-letter this entry using actual delivery count
+                    decoded_fields: dict = {}
+                    for k, v in fields.items():
+                        key = k.decode("utf-8") if isinstance(k, bytes) else k
+                        val = v.decode("utf-8") if isinstance(v, bytes) else v
+                        decoded_fields[key] = val
+
+                    await self._dead_letter(
                         self.stream_key,
                         self.group_name,
-                        self.consumer_name,
-                        min_idle_time=0,
-                        message_ids=[entry_id],
+                        entry_id_str,
+                        decoded_fields,
+                        f"Exceeded max_retries ({self.max_retries})",
+                        actual_delivery_count=delivery_count,
                     )
-                    if claimed:
-                        claimed_id, claimed_fields = claimed[0]
-                        if isinstance(claimed_id, bytes):
-                            claimed_id = claimed_id.decode("utf-8")
-                        # Decode fields for dead-letter metadata
-                        decoded_fields = {}
-                        for k, v in claimed_fields.items():
-                            key = k.decode("utf-8") if isinstance(k, bytes) else k
-                            val = v.decode("utf-8") if isinstance(v, bytes) else v
-                            decoded_fields[key] = val
-
-                        await self._dead_letter(
-                            self.stream_key,
-                            self.group_name,
-                            claimed_id,
-                            decoded_fields,
-                            f"Exceeded max_retries ({self.max_retries})",
-                        )
+                    n_dead_lettered += 1
                 else:
-                    # Reclaim for reprocessing
-                    await redis.xclaim(
-                        self.stream_key,
-                        self.group_name,
-                        self.consumer_name,
-                        min_idle_time=self.claim_timeout_ms,
-                        message_ids=[entry_id],
-                    )
-                    logger.debug(
-                        "Claimed pending entry '%s' from stream '%s'",
-                        entry_id,
-                        self.stream_key,
-                    )
+                    to_redeliver.append((entry_id_bytes, fields))
+
+            # Deliver reclaimed entries to the handler via the shared helper.
+            # The reclaimed entry IDs form a SEPARATE id list from the `>`
+            # XREADGROUP batch — their XACK goes to the same stream/group but
+            # must be issued independently so a failure here does not ACK the
+            # new-entries batch (and vice versa).
+            if to_redeliver:
+                # _process_entries is intentionally NOT inside the broad
+                # except below — a handler exception must propagate so the
+                # entries remain pending and are retried on the next cycle.
+                n_reclaimed = await self._process_entries(to_redeliver, redis)
 
         except Exception as e:
-            # Don't crash the consumer loop on claim errors
+            # Don't crash the consumer loop on claim errors; handler exceptions
+            # are intentionally excluded (they propagate before reaching here).
             logger.warning(
                 "Error during _claim_pending for stream '%s': %s",
                 self.stream_key,
                 e,
             )
+            return 0
+
+        logger.info(
+            "Reclaim cycle: %d reclaimed, %d dead-lettered from '%s'",
+            n_reclaimed,
+            n_dead_lettered,
+            self.stream_key,
+        )
+        return n_reclaimed
 
     async def _dead_letter(
         self,
@@ -330,6 +474,7 @@ class StreamConsumer:
         entry_id: str,
         entry_data: dict,
         error_msg: str,
+        actual_delivery_count: Optional[int] = None,
     ) -> None:
         """Move a failed entry to the dead-letter stream.
 
@@ -342,15 +487,26 @@ class StreamConsumer:
             entry_id: The original entry ID.
             entry_data: The original entry fields (already decoded to str).
             error_msg: Description of why the entry was dead-lettered.
+            actual_delivery_count: The real handler-invocation count for this
+                entry at the time of dead-lettering. If None, falls back to
+                ``self.max_retries`` for backward compatibility.
         """
         redis = await get_async_redis_db()
         dead_letter_key = f"dead:{stream_key}"
+
+        # Use the actual delivery count so the metadata reflects reality,
+        # not the configured threshold.
+        failure_count = (
+            actual_delivery_count
+            if actual_delivery_count is not None
+            else self.max_retries
+        )
 
         # Build dead-letter entry with original data plus metadata
         dead_entry = dict(entry_data)
         dead_entry["original_stream"] = stream_key
         dead_entry["original_id"] = entry_id
-        dead_entry["failure_count"] = str(self.max_retries)
+        dead_entry["failure_count"] = str(failure_count)
         dead_entry["last_error"] = error_msg
         dead_entry["dead_letter_ts"] = str(time.time())
 

--- a/src/popoto/streams/consumer.py
+++ b/src/popoto/streams/consumer.py
@@ -135,9 +135,7 @@ class StreamConsumer:
 
         self._group_ensured = True
 
-    async def _decode_entries(
-        self, entries: List[Tuple]
-    ) -> List[Tuple[str, dict]]:
+    async def _decode_entries(self, entries: List[Tuple]) -> List[Tuple[str, dict]]:
         """Decode raw Redis entry bytes to str for handler consumption.
 
         Args:
@@ -313,12 +311,13 @@ class StreamConsumer:
         is processed incrementally at ``batch_size`` entries per cycle rather
         than in a single unbounded scan.
 
-        Dead-letter gating uses an explicit handler-attempt counter
-        (``times_delivered`` from XPENDING) rather than the XAUTOCLAIM
-        delivery count, because XAUTOCLAIM increments the delivery counter
-        even on claim cycles that never invoke the handler. The threshold is
-        ``>= max_retries`` handler invocations, not ``> max_retries``, so the
-        last allowed attempt is attempt number ``max_retries`` (1-indexed).
+        Dead-letter gating uses an explicit handler-attempt counter stored in a
+        Redis hash at ``_hattempts:{stream_key}:{group_name}``. The counter is
+        incremented once per actual handler invocation, NOT per XAUTOCLAIM
+        claim cycle. This decouples dead-lettering from XAUTOCLAIM delivery
+        count inflation. The threshold is ``>= max_retries`` handler
+        invocations: the entry is dead-lettered after exactly ``max_retries``
+        handler calls.
 
         Entries deleted from the stream but still in the PEL (returned as
         ``deleted_message_ids`` by XAUTOCLAIM) are XACKed immediately without
@@ -339,16 +338,14 @@ class StreamConsumer:
             # claimed_messages: [(entry_id, {field: value}), ...]
             # deleted_message_ids: [entry_id, ...] — entries trimmed/deleted from
             #   the stream but still in the PEL; XACK them, never feed to handler.
-            next_cursor, claimed_messages, deleted_message_ids = (
-                await redis.xautoclaim(
-                    self.stream_key,
-                    self.group_name,
-                    self.consumer_name,
-                    min_idle_time=self.claim_timeout_ms,
-                    count=self.batch_size,
-                    start_id=self._xclaim_cursor,
-                    justid=False,
-                )
+            next_cursor, claimed_messages, deleted_message_ids = await redis.xautoclaim(
+                self.stream_key,
+                self.group_name,
+                self.consumer_name,
+                min_idle_time=self.claim_timeout_ms,
+                count=self.batch_size,
+                start_id=self._xclaim_cursor,
+                justid=False,
             )
 
             # Advance (or reset) the cursor for the next cycle
@@ -357,14 +354,20 @@ class StreamConsumer:
             # XACK deleted entries immediately — they have no field data and
             # must not be passed to the handler or decode step.
             if deleted_message_ids:
-                await redis.xack(
-                    self.stream_key, self.group_name, *deleted_message_ids
-                )
+                await redis.xack(self.stream_key, self.group_name, *deleted_message_ids)
                 logger.debug(
                     "ACKed %d deleted PEL entries from stream '%s'",
                     len(deleted_message_ids),
                     self.stream_key,
                 )
+                # Clean up handler-attempt counters for deleted entries
+                deleted_ids_str = [
+                    eid.decode("utf-8") if isinstance(eid, bytes) else eid
+                    for eid in deleted_message_ids
+                ]
+                if deleted_ids_str:
+                    hattempts_key = f"_hattempts:{self.stream_key}:{self.group_name}"
+                    await redis.hdel(hattempts_key, *deleted_ids_str)
 
             if not claimed_messages:
                 logger.info(
@@ -375,18 +378,18 @@ class StreamConsumer:
                 )
                 return 0
 
-            # For each claimed entry, check whether it has already exceeded the
-            # handler-attempt threshold using xpending_range. We use xpending_range
-            # here (not times_delivered from xautoclaim) because XAUTOCLAIM
-            # increments the delivery count even on non-handler claim cycles, so
-            # times_delivered from XAUTOCLAIM is not a reliable proxy for the
-            # number of times the handler was actually invoked.
-            #
-            # Preferred: gate on handler-attempt count rather than delivery count
-            # to avoid premature dead-lettering of entries that were only
-            # reclaimed (not handled) by previous claim cycles.
-            claimed_ids_bytes = [eid for eid, _ in claimed_messages]
-            # Build a lookup: entry_id_str -> delivery_count
+            # Handler-attempt counter: Redis hash at _hattempts:{stream_key}:{group_name}
+            # Maps entry_id -> number of times the handler has been called for it.
+            # Incremented here (before calling the handler) so that each claim
+            # cycle that reaches the handler counts as one real attempt.
+            # The gate is: if current_attempts >= max_retries → dead-letter;
+            # else → increment counter → redeliver.
+            # This is decoupled from XAUTOCLAIM's times_delivered, which is
+            # inflated by claim cycles that never call the handler.
+            hattempts_key = f"_hattempts:{self.stream_key}:{self.group_name}"
+
+            # Fetch xpending_range for actual_delivery_count metadata in dead-letter.
+            # NOT used for the gate decision — only for failure_count metadata.
             delivery_counts: dict[str, int] = {}
             try:
                 pending_entries = await redis.xpending_range(
@@ -409,20 +412,24 @@ class StreamConsumer:
                     e,
                 )
 
-            # Separate entries to dead-letter from entries to redeliver
+            # Separate entries to dead-letter from entries to redeliver.
+            # Gate on handler-attempt counter (not times_delivered from XPENDING).
             to_redeliver: List[Tuple] = []
+            to_redeliver_ids: List[str] = []
             for entry_id_bytes, fields in claimed_messages:
                 entry_id_str = (
                     entry_id_bytes.decode("utf-8")
                     if isinstance(entry_id_bytes, bytes)
                     else entry_id_bytes
                 )
-                # times_delivered represents past handler invocations. A value of
-                # >= max_retries means this entry has already been attempted
-                # max_retries times and all retries are exhausted.
-                delivery_count = delivery_counts.get(entry_id_str, 0)
-                if delivery_count >= self.max_retries:
-                    # Dead-letter this entry using actual delivery count
+                # Read current handler-attempt count from Redis hash
+                raw_count = await redis.hget(hattempts_key, entry_id_str)
+                handler_attempts = int(raw_count) if raw_count is not None else 0
+
+                if handler_attempts >= self.max_retries:
+                    # Handler has been called max_retries times — dead-letter now.
+                    # Use times_delivered from XPENDING for failure_count metadata.
+                    actual_delivery_count = delivery_counts.get(entry_id_str, 0)
                     decoded_fields: dict = {}
                     for k, v in fields.items():
                         key = k.decode("utf-8") if isinstance(k, bytes) else k
@@ -435,11 +442,17 @@ class StreamConsumer:
                         entry_id_str,
                         decoded_fields,
                         f"Exceeded max_retries ({self.max_retries})",
-                        actual_delivery_count=delivery_count,
+                        actual_delivery_count=actual_delivery_count,
                     )
+                    # Clean up the handler-attempt counter for dead-lettered entry
+                    await redis.hdel(hattempts_key, entry_id_str)
                     n_dead_lettered += 1
                 else:
+                    # Increment handler-attempt counter before redelivery.
+                    # Counter persists across process_batch_sync() calls (Redis-backed).
+                    await redis.hincrby(hattempts_key, entry_id_str, 1)
                     to_redeliver.append((entry_id_bytes, fields))
+                    to_redeliver_ids.append(entry_id_str)
 
             # to_redeliver is fully populated inside the try block; capture it
             # so _process_entries can be called outside the broad except.
@@ -465,6 +478,13 @@ class StreamConsumer:
         # must be issued independently.
         if to_redeliver:
             n_reclaimed = await self._process_entries(to_redeliver, redis)
+            # On successful redelivery, clean up handler-attempt counters.
+            # If _process_entries raises (handler exception), the entries stay
+            # pending and the counter remains incremented — correct, because the
+            # handler was actually called and failed.
+            if to_redeliver_ids:
+                hattempts_key = f"_hattempts:{self.stream_key}:{self.group_name}"
+                await redis.hdel(hattempts_key, *to_redeliver_ids)
 
         logger.info(
             "Reclaim cycle: %d reclaimed, %d dead-lettered from '%s'",

--- a/tests/test_stream_consumer.py
+++ b/tests/test_stream_consumer.py
@@ -901,40 +901,48 @@ class TestDeadLetterThreshold:
         """Dead-letter stream respects max_length with entries from real failure cycles."""
         group = "dl_maxlen_group"
         n_entries = 5
-        max_retries = 1  # dead-letter quickly (after 1 xautoclaim)
+        max_retries = 1  # dead-letter quickly (after 1 handler attempt)
+        dead_letter_max_length = 3
 
         POPOTO_REDIS_DB.xgroup_create(STREAM_KEY, group, id="0", mkstream=True)
 
         for i in range(n_entries):
             _xadd_entries(STREAM_KEY, 1, prefix=f"maxlen_{i}")
-            # Initial delivery
+            # Initial delivery — simulate crashed consumer that never ACKs
             POPOTO_REDIS_DB.xreadgroup(group, "crashed", {STREAM_KEY: ">"}, count=1)
 
-        async def noop_handler(entries):
-            pass
+        async def always_failing_handler(entries):
+            raise RuntimeError("Always fails — drives dead-lettering")
 
         consumer = StreamConsumer(
             stream_key=STREAM_KEY,
             group_name=group,
             consumer_name="recovery",
-            handler=noop_handler,
+            handler=always_failing_handler,
             max_retries=max_retries,
             claim_timeout_ms=0,
             block_ms=100,
-            dead_letter_max_length=3,
+            dead_letter_max_length=dead_letter_max_length,
         )
 
         # Run until all entries are dead-lettered (multiple cycles needed)
-        for _ in range(n_entries + 3):
+        for _ in range(n_entries * 3 + 5):
+            dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
             pending = POPOTO_REDIS_DB.xpending(STREAM_KEY, group)
-            if pending["pending"] == 0:
+            if len(dead_entries) >= n_entries or pending["pending"] == 0:
                 break
-            consumer.process_batch_sync()
+            try:
+                consumer.process_batch_sync()
+            except RuntimeError:
+                pass
 
         dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
-        # With approximate MAXLEN trimming, length may be slightly above 3 but
-        # should be bounded well below n_entries=5 if trimming is working
-        assert len(dead_entries) <= n_entries, (
+        # Entries ARE actually dead-lettered (not vacuously zero)
+        assert len(dead_entries) >= 1, (
+            f"Expected entries to be dead-lettered, got {len(dead_entries)}"
+        )
+        # MAXLEN trimming keeps the stream bounded
+        assert len(dead_entries) <= dead_letter_max_length + 2, (
             f"Dead-letter stream has {len(dead_entries)} entries, "
-            f"expected <= {n_entries}"
+            f"expected at most {dead_letter_max_length + 2} (approximate MAXLEN)"
         )

--- a/tests/test_stream_consumer.py
+++ b/tests/test_stream_consumer.py
@@ -4,12 +4,15 @@ Tests cover:
 - Consumer group creation (idempotent, handles BUSYGROUP)
 - Batch processing — handler receives decoded entries, XACK sent after success
 - Dead-letter — entries exceeding max_retries moved to dead:{stream_key}
-- XCLAIM recovery — pending entries from crashed consumers reclaimed
+- XCLAIM recovery — pending entries from crashed consumers reclaimed and ACKed
+- Crash simulation — surviving consumer reclaims entries from crashed consumer
+- Dead-letter threshold — exactly max_retries delivery events before dead-letter
+- Deleted PEL entries — XACKed without reaching handler
 - Graceful shutdown — stop() causes run() to exit after current batch
 - Synergy: EventStreamMixin saves → StreamConsumer processes entries end-to-end
 - Empty stream — consumer blocks briefly then returns 0
 - Handler exception — entries stay pending, consumer loop continues
-- process_batch() returns int count
+- process_batch() returns int count including reclaimed entries
 """
 
 import sys
@@ -287,43 +290,40 @@ class TestHandlerException:
 
 class TestDeadLetter:
     def test_entries_exceeding_max_retries_are_dead_lettered(self):
-        """Entries that exceed max_retries are moved to the dead-letter stream."""
-        entry_ids = _xadd_entries(STREAM_KEY, 1)
+        """Entries that exceed max_retries delivery events are moved to dead-letter.
 
-        # Create consumer group and read the entry to make it pending
+        Uses the real consumer claim cycle (XAUTOCLAIM) to bump the delivery
+        counter, rather than manual XCLAIM inflation. Dead-lettering fires when
+        times_delivered >= max_retries. With max_retries=2 and claim_timeout_ms=0,
+        a single reclaim cycle (times_delivered: 1 initial + 1 xautoclaim = 2)
+        triggers dead-letter on the next cycle.
+        """
+        _xadd_entries(STREAM_KEY, 1)
         POPOTO_REDIS_DB.xgroup_create(STREAM_KEY, "dl_group", id="0", mkstream=True)
+        # Initial delivery: times_delivered = 1
+        POPOTO_REDIS_DB.xreadgroup(
+            "dl_group", "crashed-worker", {STREAM_KEY: ">"}, count=1
+        )
 
-        # Read and don't ACK — simulates failed processing
-        # We need to read multiple times to bump the delivery count
-        for _ in range(4):
-            result = POPOTO_REDIS_DB.xreadgroup(
-                "dl_group",
-                "crashed-worker",
-                {STREAM_KEY: ">"},
-                count=10,
-            )
-            if not result:
-                # Re-claim to bump delivery count
-                POPOTO_REDIS_DB.xclaim(
-                    STREAM_KEY,
-                    "dl_group",
-                    "crashed-worker",
-                    min_idle_time=0,
-                    message_ids=entry_ids,
-                )
+        async def noop_handler(entries):
+            pass
 
-        # Now run our consumer with claim_timeout_ms=0 so it picks up immediately
-        collected = []
         consumer = StreamConsumer(
             stream_key=STREAM_KEY,
             group_name="dl_group",
             consumer_name="recovery-worker",
-            handler=_make_handler(collected),
-            max_retries=3,
+            handler=noop_handler,
+            max_retries=2,
             claim_timeout_ms=0,
             block_ms=100,
         )
-        consumer.process_batch_sync()
+
+        # Run until dead-lettered (at most max_retries + 2 cycles)
+        for _ in range(5):
+            dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
+            if dead_entries:
+                break
+            consumer.process_batch_sync()
 
         # Check that the dead-letter stream has the entry
         dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
@@ -335,45 +335,46 @@ class TestDeadLetter:
         assert b"last_error" in dead_fields
         assert b"dead_letter_ts" in dead_fields
 
+        # Entry is gone from XPENDING
+        pending = POPOTO_REDIS_DB.xpending(STREAM_KEY, "dl_group")
+        assert pending["pending"] == 0
+
     def test_dead_letter_max_length(self):
-        """Dead-letter stream respects max_length parameter."""
-        # Create group and add entries
+        """Dead-letter stream respects max_length with entries from real claim cycles."""
         POPOTO_REDIS_DB.xgroup_create(STREAM_KEY, "dl_max_group", id="0", mkstream=True)
+        n_entries = 5
 
-        for i in range(5):
-            entry_id = _xadd_entries(STREAM_KEY, 1, prefix=f"dl_max_{i}")[0]
-            # Read and re-claim to bump delivery count above max_retries
-            for _ in range(5):
-                POPOTO_REDIS_DB.xreadgroup(
-                    "dl_max_group",
-                    "crashed",
-                    {STREAM_KEY: ">"},
-                    count=10,
-                )
-                POPOTO_REDIS_DB.xclaim(
-                    STREAM_KEY,
-                    "dl_max_group",
-                    "crashed",
-                    min_idle_time=0,
-                    message_ids=[entry_id],
-                )
+        for i in range(n_entries):
+            _xadd_entries(STREAM_KEY, 1, prefix=f"dl_max_{i}")
+            # Initial delivery: times_delivered = 1
+            POPOTO_REDIS_DB.xreadgroup(
+                "dl_max_group", "crashed", {STREAM_KEY: ">"}, count=1
+            )
 
-        collected = []
+        async def noop_handler(entries):
+            pass
+
         consumer = StreamConsumer(
             stream_key=STREAM_KEY,
             group_name="dl_max_group",
             consumer_name="recovery",
-            handler=_make_handler(collected),
-            max_retries=3,
+            handler=noop_handler,
+            max_retries=1,
             claim_timeout_ms=0,
             block_ms=100,
             dead_letter_max_length=3,
         )
-        consumer.process_batch_sync()
+
+        # Run until all entries are cleared from XPENDING
+        for _ in range(n_entries + 3):
+            pending = POPOTO_REDIS_DB.xpending(STREAM_KEY, "dl_max_group")
+            if pending["pending"] == 0:
+                break
+            consumer.process_batch_sync()
 
         dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
         # With approximate trimming, may be slightly over, but should be bounded
-        assert len(dead_entries) <= 5  # approximate MAXLEN allows some over
+        assert len(dead_entries) <= n_entries  # approximate MAXLEN allows some over
 
 
 # --- Tests: Graceful Shutdown ---
@@ -521,3 +522,401 @@ class TestImport:
         from src.popoto.streams import StreamConsumer as SC
 
         assert SC is StreamConsumer
+
+
+# --- Helpers for XCLAIM redelivery tests ---
+
+
+def _setup_crashed_consumer(stream_key, group_name, n_entries=1, prefix="crash"):
+    """Simulate a crashed consumer: deliver entries to a group but never ACK.
+
+    Uses the sync POPOTO_REDIS_DB directly for setup so we bypass the consumer
+    lifecycle (no _ensure_group, no _claim_pending). The caller must ensure the
+    group already exists or call XGROUP CREATE first.
+
+    Returns the list of entry IDs added.
+    """
+    entry_ids = _xadd_entries(stream_key, n_entries, prefix=prefix)
+    POPOTO_REDIS_DB.xgroup_create(stream_key, group_name, id="0", mkstream=True)
+    # Deliver but do NOT XACK — simulates the consumer crashing mid-process
+    POPOTO_REDIS_DB.xreadgroup(
+        group_name,
+        "crashed-consumer",
+        {stream_key: ">"},
+        count=n_entries,
+    )
+    return entry_ids
+
+
+# --- Tests: XCLAIM Crash Redelivery ---
+
+
+class TestXClaimRedelivery:
+    """Tests for XAUTOCLAIM-based recovery of entries from crashed consumers.
+
+    Each test simulates a crash by delivering entries to a consumer group and
+    intentionally not ACKing them. A surviving consumer with a tiny
+    claim_timeout_ms then reclaims them. Because claim_timeout_ms is
+    server-evaluated (real idle clock, not mockable), tests use a small
+    non-zero timeout (10 ms) and sleep briefly to accumulate idle time.
+    """
+
+    def test_crashed_consumer_entries_redelivered_by_surviving_consumer(self):
+        """Surviving consumer reclaims entries from a crashed consumer.
+
+        BLOCKER-1: entries that were pending under crashed-consumer appear in
+        XPENDING before recovery and disappear (pending count = 0) after the
+        surviving consumer processes them.
+        """
+        entry_ids = _setup_crashed_consumer(
+            STREAM_KEY, "crash_group", n_entries=2, prefix="blocker1"
+        )
+
+        # Confirm entries are pending before recovery
+        pending_before = POPOTO_REDIS_DB.xpending(STREAM_KEY, "crash_group")
+        assert pending_before["pending"] == 2
+
+        # Wait for idle time to accumulate beyond claim_timeout_ms
+        time.sleep(0.1)
+
+        collected = []
+        consumer = StreamConsumer(
+            stream_key=STREAM_KEY,
+            group_name="crash_group",
+            consumer_name="survivor",
+            handler=_make_handler(collected),
+            claim_timeout_ms=10,
+            block_ms=100,
+            max_retries=5,
+        )
+        count = consumer.process_batch_sync()
+
+        # Handler was called with the reclaimed entries
+        assert len(collected) == 2, (
+            f"Expected 2 reclaimed entries handled, got {len(collected)}"
+        )
+
+        # BLOCKER-1: entries are GONE from XPENDING (recurrence guard)
+        pending_after = POPOTO_REDIS_DB.xpending(STREAM_KEY, "crash_group")
+        assert pending_after["pending"] == 0, (
+            f"Entries still pending after reclaim: {pending_after['pending']}"
+        )
+
+        # process_batch return value includes the reclaimed entries
+        assert count >= 2
+
+    def test_successful_redelivery_not_dead_lettered(self):
+        """Entry reclaimed by surviving consumer and handled successfully is not dead-lettered."""
+        _setup_crashed_consumer(
+            STREAM_KEY, "success_group", n_entries=1, prefix="nodl"
+        )
+
+        time.sleep(0.1)
+
+        collected = []
+        consumer = StreamConsumer(
+            stream_key=STREAM_KEY,
+            group_name="success_group",
+            consumer_name="survivor",
+            handler=_make_handler(collected),
+            claim_timeout_ms=10,
+            block_ms=100,
+            max_retries=5,
+        )
+        consumer.process_batch_sync()
+
+        # Entry was handled
+        assert len(collected) == 1
+
+        # Entry is NOT in dead-letter stream
+        dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
+        assert len(dead_entries) == 0, (
+            f"Entry was incorrectly dead-lettered: {dead_entries}"
+        )
+
+        # Entry is gone from XPENDING
+        pending = POPOTO_REDIS_DB.xpending(STREAM_KEY, "success_group")
+        assert pending["pending"] == 0
+
+    def test_redelivery_handler_exception_leaves_entry_pending(self):
+        """When the handler raises during redelivery, the entry stays in XPENDING."""
+        _setup_crashed_consumer(
+            STREAM_KEY, "fail_redeliver_group", n_entries=1, prefix="failredeliv"
+        )
+
+        time.sleep(0.1)
+
+        async def always_failing_handler(entries):
+            raise RuntimeError("Handler fails on redelivery")
+
+        consumer = StreamConsumer(
+            stream_key=STREAM_KEY,
+            group_name="fail_redeliver_group",
+            consumer_name="survivor",
+            handler=always_failing_handler,
+            claim_timeout_ms=10,
+            block_ms=100,
+            max_retries=5,
+        )
+
+        # The handler exception propagates out of process_batch_sync
+        with pytest.raises(RuntimeError, match="Handler fails on redelivery"):
+            consumer.process_batch_sync()
+
+        # Entry remains in XPENDING — not ACKed, not dead-lettered
+        pending = POPOTO_REDIS_DB.xpending(STREAM_KEY, "fail_redeliver_group")
+        assert pending["pending"] == 1, (
+            f"Entry should still be pending after handler exception, "
+            f"got {pending['pending']}"
+        )
+
+        dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
+        assert len(dead_entries) == 0
+
+    def test_process_batch_return_count_includes_reclaimed(self):
+        """process_batch() return value counts both new entries and reclaimed entries."""
+        n_crashed = 3
+        _setup_crashed_consumer(
+            STREAM_KEY, "count_group", n_entries=n_crashed, prefix="countreclaim"
+        )
+
+        time.sleep(0.1)
+
+        # Add fresh entries that will be read via XREADGROUP ">"
+        n_fresh = 2
+        _xadd_entries(STREAM_KEY, n_fresh, prefix="fresh")
+
+        collected = []
+        consumer = StreamConsumer(
+            stream_key=STREAM_KEY,
+            group_name="count_group",
+            consumer_name="survivor",
+            handler=_make_handler(collected),
+            claim_timeout_ms=10,
+            block_ms=100,
+            max_retries=5,
+        )
+        total = consumer.process_batch_sync()
+
+        # Return value must be an int equal to reclaimed + fresh entries
+        assert isinstance(total, int), f"Expected int, got {type(total)}"
+        # Reclaimed entries (3) + fresh entries (2) = 5 total
+        assert total == n_crashed + n_fresh, (
+            f"Expected {n_crashed + n_fresh} total, got {total}"
+        )
+        assert len(collected) == n_crashed + n_fresh
+
+    def test_deleted_message_ids_xacked_without_handler_call(self):
+        """Entries deleted from the stream but still in PEL are XACKed without handler.
+
+        XAUTOCLAIM returns deleted_message_ids for entries that were XDEL-ed
+        from the stream while still pending. These must be ACKed silently —
+        they have no field data and must never reach the handler.
+        """
+        entry_ids = _setup_crashed_consumer(
+            STREAM_KEY, "del_group", n_entries=1, prefix="deleted_entry"
+        )
+
+        # Delete the entry from the stream while it's still in the PEL
+        POPOTO_REDIS_DB.xdel(STREAM_KEY, entry_ids[0])
+
+        time.sleep(0.1)
+
+        handler_call_count = {"n": 0}
+
+        async def counting_handler(entries):
+            handler_call_count["n"] += len(entries)
+
+        consumer = StreamConsumer(
+            stream_key=STREAM_KEY,
+            group_name="del_group",
+            consumer_name="survivor",
+            handler=counting_handler,
+            claim_timeout_ms=10,
+            block_ms=100,
+            max_retries=5,
+        )
+        consumer.process_batch_sync()
+
+        # Handler was NOT called for the deleted entry
+        assert handler_call_count["n"] == 0, (
+            f"Handler should not be called for deleted entries, "
+            f"got {handler_call_count['n']} calls"
+        )
+
+        # Entry is gone from XPENDING (ACKed)
+        pending = POPOTO_REDIS_DB.xpending(STREAM_KEY, "del_group")
+        assert pending["pending"] == 0, (
+            f"Deleted PEL entry should be ACKed, still pending: {pending['pending']}"
+        )
+
+
+# --- Tests: Dead-Letter Threshold ---
+
+
+class TestDeadLetterThreshold:
+    """Tests for dead-letter gating based on XPENDING times_delivered.
+
+    The dead-letter gate fires when times_delivered >= max_retries. The
+    times_delivered counter is incremented by: initial XREADGROUP delivery +
+    each XAUTOCLAIM reclaim cycle. It is NOT limited to handler invocations.
+    """
+
+    @pytest.mark.parametrize("max_retries_val", [1, 2, 3, 5])
+    def test_dead_letter_after_exactly_max_retries_delivery_events(
+        self, max_retries_val
+    ):
+        """Entry is dead-lettered after exactly max_retries total delivery events.
+
+        BLOCKER-2 verification: dead-lettering is based on times_delivered from
+        XPENDING, which counts the initial xreadgroup delivery + each xautoclaim
+        reclaim. With max_retries=N: after 1 initial delivery + (N-1) xautoclaim
+        cycles, times_delivered reaches N and the entry is dead-lettered.
+
+        This test pumps the entry through enough claim cycles to trigger
+        dead-lettering, then verifies it appears in dead:{stream_key}.
+        """
+        group = f"dl_threshold_group_{max_retries_val}"
+        _xadd_entries(STREAM_KEY, 1, prefix=f"thresh_{max_retries_val}")
+
+        # Initial delivery (times_delivered = 1)
+        POPOTO_REDIS_DB.xgroup_create(STREAM_KEY, group, id="0", mkstream=True)
+        POPOTO_REDIS_DB.xreadgroup(group, "crashed", {STREAM_KEY: ">"}, count=1)
+
+        # Run reclaim cycles until dead-lettered. Each process_batch_sync call
+        # invokes xautoclaim which bumps times_delivered by 1. We need
+        # (max_retries_val - 1) additional increments to reach the threshold.
+        # Use max_retries=max_retries_val and claim_timeout_ms=0 so xautoclaim
+        # always finds the entry eligible.
+        async def always_failing_handler(entries):
+            raise RuntimeError("Always fails")
+
+        consumer = StreamConsumer(
+            stream_key=STREAM_KEY,
+            group_name=group,
+            consumer_name="recovery",
+            handler=always_failing_handler,
+            max_retries=max_retries_val,
+            claim_timeout_ms=0,
+            block_ms=100,
+        )
+
+        # Run at most max_retries_val + 2 cycles to avoid infinite loop
+        for _ in range(max_retries_val + 2):
+            dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
+            if dead_entries:
+                break
+            try:
+                consumer.process_batch_sync()
+            except RuntimeError:
+                pass  # handler exception is expected when entry is redelivered
+
+        dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
+        assert len(dead_entries) >= 1, (
+            f"Expected entry in dead-letter after {max_retries_val} delivery "
+            f"events, but found none"
+        )
+
+        # Entry is gone from XPENDING after dead-lettering
+        pending = POPOTO_REDIS_DB.xpending(STREAM_KEY, group)
+        assert pending["pending"] == 0, (
+            f"Dead-lettered entry should be ACKed from PEL, "
+            f"still pending: {pending['pending']}"
+        )
+
+    def test_dead_letter_failure_count_equals_actual_delivery_count(self):
+        """Dead-letter metadata has failure_count equal to actual times_delivered.
+
+        The failure_count stored in dead:{stream_key} must reflect the real
+        delivery count, not the configured max_retries threshold. These differ
+        when the entry is claimed multiple times before dead-lettering.
+        """
+        group = "dl_fc_group"
+        max_retries = 2
+
+        _xadd_entries(STREAM_KEY, 1, prefix="fc_entry")
+        POPOTO_REDIS_DB.xgroup_create(STREAM_KEY, group, id="0", mkstream=True)
+        # Initial delivery: times_delivered = 1
+        POPOTO_REDIS_DB.xreadgroup(group, "crashed", {STREAM_KEY: ">"}, count=1)
+
+        async def noop_handler(entries):
+            pass
+
+        consumer = StreamConsumer(
+            stream_key=STREAM_KEY,
+            group_name=group,
+            consumer_name="recovery",
+            handler=noop_handler,
+            max_retries=max_retries,
+            claim_timeout_ms=0,
+            block_ms=100,
+        )
+
+        # Run enough cycles to trigger dead-lettering
+        for _ in range(max_retries + 2):
+            dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
+            if dead_entries:
+                break
+            consumer.process_batch_sync()
+
+        dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
+        assert len(dead_entries) >= 1
+
+        _, dead_fields = dead_entries[0]
+        stored_failure_count = int(dead_fields[b"failure_count"])
+
+        # failure_count must be >= max_retries (the actual delivery count when
+        # dead-lettered may be exactly max_retries or higher, depending on how
+        # many xautoclaim cycles ran before the threshold was reached)
+        assert stored_failure_count >= max_retries, (
+            f"failure_count {stored_failure_count} should be >= max_retries "
+            f"{max_retries}"
+        )
+
+        # Verify required dead-letter fields are present
+        assert b"original_stream" in dead_fields
+        assert dead_fields[b"original_stream"] == STREAM_KEY.encode()
+        assert b"last_error" in dead_fields
+        assert b"dead_letter_ts" in dead_fields
+
+    def test_dead_letter_max_length_with_real_failures(self):
+        """Dead-letter stream respects max_length with entries from real failure cycles."""
+        group = "dl_maxlen_group"
+        n_entries = 5
+        max_retries = 1  # dead-letter quickly (after 1 xautoclaim)
+
+        POPOTO_REDIS_DB.xgroup_create(STREAM_KEY, group, id="0", mkstream=True)
+
+        for i in range(n_entries):
+            _xadd_entries(STREAM_KEY, 1, prefix=f"maxlen_{i}")
+            # Initial delivery
+            POPOTO_REDIS_DB.xreadgroup(group, "crashed", {STREAM_KEY: ">"}, count=1)
+
+        async def noop_handler(entries):
+            pass
+
+        consumer = StreamConsumer(
+            stream_key=STREAM_KEY,
+            group_name=group,
+            consumer_name="recovery",
+            handler=noop_handler,
+            max_retries=max_retries,
+            claim_timeout_ms=0,
+            block_ms=100,
+            dead_letter_max_length=3,
+        )
+
+        # Run until all entries are dead-lettered (multiple cycles needed)
+        for _ in range(n_entries + 3):
+            pending = POPOTO_REDIS_DB.xpending(STREAM_KEY, group)
+            if pending["pending"] == 0:
+                break
+            consumer.process_batch_sync()
+
+        dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
+        # With approximate MAXLEN trimming, length may be slightly above 3 but
+        # should be bounded well below n_entries=5 if trimming is working
+        assert len(dead_entries) <= n_entries, (
+            f"Dead-letter stream has {len(dead_entries)} entries, "
+            f"expected <= {n_entries}"
+        )

--- a/tests/test_stream_consumer.py
+++ b/tests/test_stream_consumer.py
@@ -290,40 +290,42 @@ class TestHandlerException:
 
 class TestDeadLetter:
     def test_entries_exceeding_max_retries_are_dead_lettered(self):
-        """Entries that exceed max_retries delivery events are moved to dead-letter.
+        """Entries that exceed max_retries handler invocations are moved to dead-letter.
 
-        Uses the real consumer claim cycle (XAUTOCLAIM) to bump the delivery
-        counter, rather than manual XCLAIM inflation. Dead-lettering fires when
-        times_delivered >= max_retries. With max_retries=2 and claim_timeout_ms=0,
-        a single reclaim cycle (times_delivered: 1 initial + 1 xautoclaim = 2)
-        triggers dead-letter on the next cycle.
+        Uses the real consumer claim cycle (XAUTOCLAIM) to redeliver entries
+        to a failing handler. Dead-lettering fires when the handler-attempt
+        counter >= max_retries. With max_retries=2 and a handler that always
+        raises, 2 handler invocations trigger dead-lettering on the next cycle.
         """
         _xadd_entries(STREAM_KEY, 1)
         POPOTO_REDIS_DB.xgroup_create(STREAM_KEY, "dl_group", id="0", mkstream=True)
-        # Initial delivery: times_delivered = 1
+        # Initial delivery: entry enters PEL
         POPOTO_REDIS_DB.xreadgroup(
             "dl_group", "crashed-worker", {STREAM_KEY: ">"}, count=1
         )
 
-        async def noop_handler(entries):
-            pass
+        async def always_failing_handler(entries):
+            raise RuntimeError("Always fails")
 
         consumer = StreamConsumer(
             stream_key=STREAM_KEY,
             group_name="dl_group",
             consumer_name="recovery-worker",
-            handler=noop_handler,
+            handler=always_failing_handler,
             max_retries=2,
             claim_timeout_ms=0,
             block_ms=100,
         )
 
-        # Run until dead-lettered (at most max_retries + 2 cycles)
-        for _ in range(5):
+        # Run until dead-lettered (max_retries handler calls + 1 dead-letter cycle)
+        for _ in range(6):
             dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
             if dead_entries:
                 break
-            consumer.process_batch_sync()
+            try:
+                consumer.process_batch_sync()
+            except RuntimeError:
+                pass  # expected when handler fails during redelivery
 
         # Check that the dead-letter stream has the entry
         dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
@@ -346,19 +348,21 @@ class TestDeadLetter:
 
         for i in range(n_entries):
             _xadd_entries(STREAM_KEY, 1, prefix=f"dl_max_{i}")
-            # Initial delivery: times_delivered = 1
+            # Initial delivery: entry enters PEL
             POPOTO_REDIS_DB.xreadgroup(
                 "dl_max_group", "crashed", {STREAM_KEY: ">"}, count=1
             )
 
-        async def noop_handler(entries):
-            pass
+        # Must use a failing handler — successful delivery ACKs entries without
+        # dead-lettering them, so max_length would never be exercised.
+        async def always_failing_handler(entries):
+            raise RuntimeError("Always fails")
 
         consumer = StreamConsumer(
             stream_key=STREAM_KEY,
             group_name="dl_max_group",
             consumer_name="recovery",
-            handler=noop_handler,
+            handler=always_failing_handler,
             max_retries=1,
             claim_timeout_ms=0,
             block_ms=100,
@@ -366,11 +370,15 @@ class TestDeadLetter:
         )
 
         # Run until all entries are cleared from XPENDING
-        for _ in range(n_entries + 3):
+        # With max_retries=1: 1 handler call per entry, then dead-letter on next cycle
+        for _ in range(n_entries * 3 + 3):
             pending = POPOTO_REDIS_DB.xpending(STREAM_KEY, "dl_max_group")
             if pending["pending"] == 0:
                 break
-            consumer.process_batch_sync()
+            try:
+                consumer.process_batch_sync()
+            except RuntimeError:
+                pass
 
         dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
         # With approximate trimming, may be slightly over, but should be bounded
@@ -755,40 +763,38 @@ class TestXClaimRedelivery:
 
 
 class TestDeadLetterThreshold:
-    """Tests for dead-letter gating based on XPENDING times_delivered.
+    """Tests for dead-letter gating based on actual handler invocations.
 
-    The dead-letter gate fires when times_delivered >= max_retries. The
-    times_delivered counter is incremented by: initial XREADGROUP delivery +
-    each XAUTOCLAIM reclaim cycle. It is NOT limited to handler invocations.
+    The dead-letter gate fires when the handler-attempt counter >= max_retries.
+    The counter is incremented once per actual handler invocation, NOT per
+    XAUTOCLAIM claim cycle. This decouples dead-lettering from claim-cycle
+    inflation and ensures max_retries is the exact number of handler calls
+    before dead-lettering.
     """
 
     @pytest.mark.parametrize("max_retries_val", [1, 2, 3, 5])
-    def test_dead_letter_after_exactly_max_retries_delivery_events(
+    def test_dead_letter_after_exactly_max_retries_handler_invocations(
         self, max_retries_val
     ):
-        """Entry is dead-lettered after exactly max_retries total delivery events.
+        """Entry is dead-lettered after exactly max_retries handler invocations.
 
-        BLOCKER-2 verification: dead-lettering is based on times_delivered from
-        XPENDING, which counts the initial xreadgroup delivery + each xautoclaim
-        reclaim. With max_retries=N: after 1 initial delivery + (N-1) xautoclaim
-        cycles, times_delivered reaches N and the entry is dead-lettered.
-
-        This test pumps the entry through enough claim cycles to trigger
-        dead-lettering, then verifies it appears in dead:{stream_key}.
+        BLOCKER-2 verification: dead-lettering is gated on actual handler
+        invocations, not XAUTOCLAIM claim cycles. With max_retries=N:
+        exactly N handler calls occur before the entry is dead-lettered.
+        handler.call_count == max_retries is the acceptance criterion.
         """
         group = f"dl_threshold_group_{max_retries_val}"
         _xadd_entries(STREAM_KEY, 1, prefix=f"thresh_{max_retries_val}")
 
-        # Initial delivery (times_delivered = 1)
+        # Initial delivery (entry enters PEL)
         POPOTO_REDIS_DB.xgroup_create(STREAM_KEY, group, id="0", mkstream=True)
         POPOTO_REDIS_DB.xreadgroup(group, "crashed", {STREAM_KEY: ">"}, count=1)
 
-        # Run reclaim cycles until dead-lettered. Each process_batch_sync call
-        # invokes xautoclaim which bumps times_delivered by 1. We need
-        # (max_retries_val - 1) additional increments to reach the threshold.
-        # Use max_retries=max_retries_val and claim_timeout_ms=0 so xautoclaim
-        # always finds the entry eligible.
+        # Track actual handler invocations
+        handler_call_count = {"n": 0}
+
         async def always_failing_handler(entries):
+            handler_call_count["n"] += len(entries)
             raise RuntimeError("Always fails")
 
         consumer = StreamConsumer(
@@ -801,8 +807,8 @@ class TestDeadLetterThreshold:
             block_ms=100,
         )
 
-        # Run at most max_retries_val + 2 cycles to avoid infinite loop
-        for _ in range(max_retries_val + 2):
+        # Run enough cycles — need max_retries_val handler calls + 1 cycle to dead-letter
+        for _ in range(max_retries_val + 3):
             dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
             if dead_entries:
                 break
@@ -813,8 +819,14 @@ class TestDeadLetterThreshold:
 
         dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
         assert len(dead_entries) >= 1, (
-            f"Expected entry in dead-letter after {max_retries_val} delivery "
-            f"events, but found none"
+            f"Expected entry in dead-letter after {max_retries_val} handler "
+            f"invocations, but found none"
+        )
+
+        # THE KEY ASSERTION: handler was called exactly max_retries times
+        assert handler_call_count["n"] == max_retries_val, (
+            f"Expected exactly {max_retries_val} handler calls before dead-lettering, "
+            f"but got {handler_call_count['n']}"
         )
 
         # Entry is gone from XPENDING after dead-lettering
@@ -824,12 +836,14 @@ class TestDeadLetterThreshold:
             f"still pending: {pending['pending']}"
         )
 
-    def test_dead_letter_failure_count_equals_actual_delivery_count(self):
-        """Dead-letter metadata has failure_count equal to actual times_delivered.
+    def test_dead_letter_failure_count_reflects_xpending_delivery_count(self):
+        """Dead-letter metadata has failure_count from XPENDING times_delivered.
 
-        The failure_count stored in dead:{stream_key} must reflect the real
-        delivery count, not the configured max_retries threshold. These differ
-        when the entry is claimed multiple times before dead-lettering.
+        The failure_count stored in dead:{stream_key} reflects the real Redis
+        delivery count (from XPENDING), not the configured max_retries threshold
+        or the handler-attempt counter. This means failure_count >= max_retries
+        when dead-lettered (since XAUTOCLAIM may inflate times_delivered beyond
+        the handler-attempt count).
         """
         group = "dl_fc_group"
         max_retries = 2
@@ -839,25 +853,30 @@ class TestDeadLetterThreshold:
         # Initial delivery: times_delivered = 1
         POPOTO_REDIS_DB.xreadgroup(group, "crashed", {STREAM_KEY: ">"}, count=1)
 
-        async def noop_handler(entries):
-            pass
+        # Must use a failing handler — successful delivery ACKs the entry and
+        # cleans up the handler-attempt counter, so dead-lettering never triggers.
+        async def always_failing_handler(entries):
+            raise RuntimeError("Always fails")
 
         consumer = StreamConsumer(
             stream_key=STREAM_KEY,
             group_name=group,
             consumer_name="recovery",
-            handler=noop_handler,
+            handler=always_failing_handler,
             max_retries=max_retries,
             claim_timeout_ms=0,
             block_ms=100,
         )
 
         # Run enough cycles to trigger dead-lettering
-        for _ in range(max_retries + 2):
+        for _ in range(max_retries + 3):
             dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
             if dead_entries:
                 break
-            consumer.process_batch_sync()
+            try:
+                consumer.process_batch_sync()
+            except RuntimeError:
+                pass
 
         dead_entries = POPOTO_REDIS_DB.xrange(DEAD_LETTER_KEY)
         assert len(dead_entries) >= 1
@@ -865,9 +884,8 @@ class TestDeadLetterThreshold:
         _, dead_fields = dead_entries[0]
         stored_failure_count = int(dead_fields[b"failure_count"])
 
-        # failure_count must be >= max_retries (the actual delivery count when
-        # dead-lettered may be exactly max_retries or higher, depending on how
-        # many xautoclaim cycles ran before the threshold was reached)
+        # failure_count reflects XPENDING times_delivered, which is >= max_retries
+        # (XAUTOCLAIM may inflate times_delivered beyond the handler-attempt count)
         assert stored_failure_count >= max_retries, (
             f"failure_count {stored_failure_count} should be >= max_retries "
             f"{max_retries}"


### PR DESCRIPTION
## Summary
- Fixes silent message loss in `StreamConsumer`: crashed-consumer entries were never re-delivered to handlers despite `_claim_pending()` reclaiming them via XCLAIM
- Replaces XCLAIM+XPENDING loop with a single `XAUTOCLAIM` pass that atomically reclaims idle PEL entries and returns their full field data for immediate decode→handler→XACK
- Dead-lettering now gates on real handler attempts (not claim-cycle counter inflation)

## Changes
- `src/popoto/streams/consumer.py`: replace `_claim_pending()` with XAUTOCLAIM; add shared `_process_entries()` helper; fix `failure_count` to use actual delivery count; pin `process_batch()` return contract (total = new + reclaimed); per-cycle cap + monitoring log
- `tests/test_stream_consumer.py`: add `TestXClaimRedelivery` (5 tests) + `TestDeadLetterThreshold` (3 parametrized tests); update 2 existing dead-letter tests; update header comment
- `docs/features/agent-memory.md`: update XAUTOCLAIM recovery section with at-least-once semantics + handler-idempotency requirement
- `docs/guides/popoto-memory-roadmap.md`: correct "Exactly-once via XACK" to "At-least-once; exactly-once requires idempotent handlers"

## Root cause
`process_batch()` used only `XREADGROUP >` (new entries). Reclaimed entries landed in the claiming consumer's PEL but were never read back — `XREADGROUP 0` (re-read PEL) was never issued. Each claim cycle re-XCLAIMed without JUSTID, inflating `times_delivered` without any handler call; entries dead-lettered with misleading "Exceeded max_retries (3)" after 0 real handler executions.

## Testing
- [x] 27 `test_stream_consumer.py` tests pass (up from 18)
- [x] Full suite: 1768 passed, 1 pre-existing failure unrelated to this change
- [x] Crash-simulation regression test added (tiny `claim_timeout_ms` for determinism)
- [x] Parametrized dead-letter test over `max_retries` in `[1, 2, 3, 5]`
- [x] XPENDING gone-after-redelivery assertion (recurrence guard)
- [x] `deleted_message_ids` XACKed without handler call
- [x] Docs strict build (`mkdocs build --strict`) passes

## Documentation
- [x] Module docstring command list updated (XAUTOCLAIM replaces XCLAIM)
- [x] `docs/features/agent-memory.md` XAUTOCLAIM recovery section updated
- [x] `docs/guides/popoto-memory-roadmap.md` exactly-once claim corrected

## Definition of Done
- [x] Built: XAUTOCLAIM redelivery, shared helper, retry gating, failure_count, per-cycle cap
- [x] Tested: All new + existing tests pass
- [x] Documented: Docstrings, agent-memory.md, roadmap.md updated
- [x] Quality: Ruff/Black pass (pre-commit hook ran on final commits)
- [x] Valkey-safe: Core Streams commands only (no Redis modules)

Closes #411