### PR TITLE
fix(#416): clamp CoOccurrenceField edge weights to guarantee per-hop contraction

### DIFF
--- a/docs/features/co-occurrence-field.md
+++ b/docs/features/co-occurrence-field.md
@@ -19,6 +19,7 @@ The field supports:
 | `symmetric` | bool | `True` | If True, edges are bidirectional |
 | `max_edges` | int | `500` | Maximum edges per PK; lowest-weight edges pruned when exceeded |
 | `decay_factor` | float | `0.95` | Default multiplicative decay factor for `weaken_all()` |
+| `CO_OCCURRENCE_WEIGHT_CAP` | float | `1.0` | Upper bound on stored edge weights (experimental tuning constant in `Defaults`, not user config). Clamped on every `strengthen()` write and applied as a read-time `min(edge_weight, cap)` in the propagation BFS. Chosen with headroom below `1 / decay_per_hop = 2.0` so that `cap * decay_per_hop < 1` guarantees per-hop contraction during propagation. |
 
 ## Redis Key Pattern
 
@@ -73,14 +74,17 @@ field.link(Memory, pk_a, pk_b, initial_weight=0.2)
 
 ### `strengthen(model_class, source_pk, target_pk, delta=0.05, pipeline=None)`
 
-Increase the weight of an existing edge via atomic ZINCRBY.
+Increase the weight of an existing edge via atomic Lua script.
+
+Weights are clamped at `CO_OCCURRENCE_WEIGHT_CAP` (default 1.0) to guarantee per-hop contraction during propagation. The clamp is applied atomically via a Lua script (`STRENGTHEN_CLAMP_LUA`) that reads the current weight, adds delta, and writes back `min(old + delta, cap)` in a single `EVAL` — preventing concurrent `strengthen()` races on the same edge.
 
 ```python
 new_weight = field.strengthen(Memory, pk_a, pk_b, delta=0.1)
-# Returns the new weight after increment
+# Returns the new weight after increment and clamp
 ```
 
 - Raises `ValueError` if `delta <= 0`
+- Returned weight is the clamped value, never exceeding `CO_OCCURRENCE_WEIGHT_CAP`
 
 ### `unlink(model_class, source_pk, target_pk, pipeline=None)`
 
@@ -114,6 +118,8 @@ linked = field.get_linked(Memory, pk_a, min_weight=0.05, limit=10)
 
 BFS graph propagation with exponential weight decay per hop. Uses a server-side Lua script for efficiency.
 
+Per-hop transfer is always <= `decay_per_hop` because edge weights are clamped. The BFS threshold reliably terminates the walk. A runtime guard raises `ValueError` if `cap * decay_per_hop >= 1.0`. A read-time `min(edge_weight, cap)` in the Lua BFS handles pre-existing over-cap weights as defense-in-depth.
+
 ```python
 scores = field.propagate(Memory, [pk_a], depth=2, decay_per_hop=0.5)
 # Returns: {"pk_b": 0.4, "pk_c": 0.08, ...}
@@ -122,10 +128,44 @@ scores = field.propagate(Memory, [pk_a], depth=2, decay_per_hop=0.5)
 - When same PK reached via multiple paths, uses `max(weight)`
 - `depth=0` returns seeds only with weight 1.0
 - Seeds are excluded from results (except depth=0)
+- Raises `ValueError` if `CO_OCCURRENCE_WEIGHT_CAP * decay_per_hop >= 1.0` (contraction invariant violated; would amplify instead of decay)
 
 ## Edge Pruning
 
 When `max_edges` is exceeded during `link()`, the lowest-weight edges are atomically pruned using a Lua script. This prevents unbounded memory growth.
+
+## Contraction Guarantee
+
+`propagate()` implements spreading activation: at each BFS hop, activation is multiplied by `decay_per_hop * effective_edge_weight`. For propagation to decay (rather than amplify) with hop count, the per-hop transfer factor must be strictly less than 1:
+
+```
+decay_per_hop * effective_edge_weight < 1
+```
+
+`CO_OCCURRENCE_WEIGHT_CAP` enforces this invariant by bounding `effective_edge_weight <= cap`. The cap is chosen with intentional headroom below the theoretical maximum `1 / decay_per_hop`:
+
+- Default `decay_per_hop = 0.5` -> theoretical max cap = `1 / 0.5 = 2.0`
+- Actual `CO_OCCURRENCE_WEIGHT_CAP = 1.0` (2x headroom)
+
+At default config, `cap * decay_per_hop = 1.0 * 0.5 = 0.5 < 1`, so each hop contracts activation by at least half. The headroom means small upward adjustments to `decay_per_hop` do not silently violate the invariant.
+
+A runtime guard in `propagate()` enforces `cap * decay_per_hop < 1` at call time and raises `ValueError` if the inequality fails. This guard fires on misconfiguration (e.g. a future constants sweep raises `decay_per_hop` above `1 / cap` without a matching cap adjustment), not under current defaults. It is the runtime backstop for the invariant the cap value is designed to satisfy.
+
+The contraction invariant holds for any reachable stored weight, not just newly-written ones, because the Lua BFS applies `min(edge_weight, cap)` at read time as defense-in-depth.
+
+## Known Limitation: Neighbor Selection Bias
+
+The propagation BFS selects neighbors via `ZREVRANGE`, which ranks by the raw stored ZSET score. For pre-existing over-cap weights (edges written before the clamp was introduced, or edges above the cap from a previous lower cap value), the raw stored score may exceed `CO_OCCURRENCE_WEIGHT_CAP`.
+
+This biases *which* neighbors are visited when `max_per_node` truncation fires: an over-cap edge with stored score 2.5 ranks above a clamped edge at 1.0, even though both have the same effective weight (1.0) after the read-time `min()`. The contraction invariant is not violated — the read-time clamp guarantees `effective_weight <= cap` regardless of the stored score — but the *selection* of which neighbors to expand is distorted by the un-clamped scores.
+
+This limitation:
+
+- **Does not violate the contraction invariant** — `min(edge_weight, cap)` is applied before computing propagated weight, so per-hop transfer stays bounded.
+- **Self-corrects as over-cap edges are lazily clamped** on the next `strengthen()` call (since `min(over_cap + delta, cap) = cap`).
+- **Only affects ranking when `max_per_node` truncation fires** — if all neighbors fit within the `max_per_node` budget, no truncation occurs and the bias is invisible.
+
+The fix path, if the bias materializes as a ranking distortion in practice, is a one-time migration that clamps all existing ZSET scores in-place via a `ZADD XX` overwrite with `min(score, cap)`. This would normalize stored scores to their effective values and eliminate the ranking distortion. A follow-up issue should be filed if the bias is observed in production graphs.
 
 ## Cleanup on Delete
 

--- a/src/popoto/fields/co_occurrence_field.py
+++ b/src/popoto/fields/co_occurrence_field.py
@@ -330,7 +330,9 @@ class CoOccurrenceField(Field):
             float: The weight of the edge (existing weight if already linked).
 
         Raises:
-            ValueError: If source_pk == target_pk (no self-loops).
+            ValueError: If source_pk == target_pk (no self-loops), or if
+                ``initial_weight`` exceeds ``Defaults.CO_OCCURRENCE_WEIGHT_CAP``
+                (would violate the contraction invariant).
         """
         if initial_weight is _UNSET:
             initial_weight = Defaults.CO_OCCURRENCE_INITIAL_WEIGHT
@@ -339,6 +341,14 @@ class CoOccurrenceField(Field):
 
         if source_pk == target_pk:
             raise ValueError("Cannot link a PK to itself (no self-loops)")
+        if initial_weight > Defaults.CO_OCCURRENCE_WEIGHT_CAP:
+            raise ValueError(
+                f"initial_weight ({initial_weight}) exceeds "
+                f"CO_OCCURRENCE_WEIGHT_CAP "
+                f"({Defaults.CO_OCCURRENCE_WEIGHT_CAP}); edges above the "
+                f"cap violate the per-hop contraction invariant used by "
+                f"propagate()."
+            )
 
         source_key = self.get_edge_key(model_class, source_pk)
         result = POPOTO_REDIS_DB.eval(

--- a/src/popoto/fields/co_occurrence_field.py
+++ b/src/popoto/fields/co_occurrence_field.py
@@ -611,6 +611,18 @@ class CoOccurrenceField(Field):
         """
         if decay_per_hop is _UNSET:
             decay_per_hop = Defaults.CO_OCCURRENCE_DECAY_PER_HOP
+        # Runtime contraction guard: enforces cap * decay_per_hop < 1 so
+        # that each hop strictly decays activation. Fires on
+        # misconfiguration only (e.g. a future constants sweep raises
+        # decay_per_hop above 1/cap); under current defaults
+        # (1.0 * 0.5 = 0.5 < 1) this never raises.
+        if Defaults.CO_OCCURRENCE_WEIGHT_CAP * decay_per_hop >= 1.0:
+            raise ValueError(
+                f"Contraction invariant violated: CO_OCCURRENCE_WEIGHT_CAP "
+                f"({Defaults.CO_OCCURRENCE_WEIGHT_CAP}) * decay_per_hop "
+                f"({decay_per_hop}) >= 1.0; propagation would amplify "
+                f"instead of decay. Lower the cap or decay_per_hop."
+            )
         if not seed_pks:
             return {}
 

--- a/src/popoto/fields/co_occurrence_field.py
+++ b/src/popoto/fields/co_occurrence_field.py
@@ -228,6 +228,17 @@ class CoOccurrenceField(Field):
     Uses per-PK Redis sorted sets to store weighted edges to other PKs.
     Supports symmetric (bidirectional) and asymmetric (unidirectional) modes.
 
+    Edge weights are clamped at ``Defaults.CO_OCCURRENCE_WEIGHT_CAP``
+    (default 1.0) on every ``strengthen()`` write via an atomic Lua script,
+    and a read-time ``min(edge_weight, cap)`` in the propagation BFS
+    handles pre-existing over-cap stored weights as defense-in-depth. This
+    guarantees the per-hop contraction invariant used by ``propagate()``:
+    ``decay_per_hop * effective_edge_weight <= decay_per_hop * cap < 1``
+    (at default config, 0.5 * 1.0 = 0.5 < 1), so activation decays
+    monotonically with hop count and the BFS threshold reliably terminates
+    the walk. A runtime guard in ``propagate()`` raises ``ValueError`` if
+    ``cap * decay_per_hop >= 1.0`` to catch future misconfiguration.
+
     Args:
         symmetric: If True, edges are bidirectional. Default True.
         max_edges: Maximum edges per PK. Lowest-weight edges pruned when exceeded.

--- a/src/popoto/fields/co_occurrence_field.py
+++ b/src/popoto/fields/co_occurrence_field.py
@@ -195,6 +195,26 @@ end
 return result
 """
 
+# Lua script: atomic strengthen with upper-bound clamp.
+# Reads the current edge weight, adds delta, clamps at cap, writes back.
+# Atomic read-then-write prevents concurrent strengthen() races on the
+# same edge (Redis/Valkey single-threaded EVAL).
+# KEYS[1] = source ZSET key
+# ARGV[1] = target_pk
+# ARGV[2] = delta
+# ARGV[3] = cap
+STRENGTHEN_CLAMP_LUA = """
+local zset_key = KEYS[1]
+local target = ARGV[1]
+local existing = redis.call('ZSCORE', zset_key, target)
+local old = tonumber(existing) or 0
+local delta = tonumber(ARGV[2])
+local cap = tonumber(ARGV[3])
+local new_weight = math.min(old + delta, cap)
+redis.call('ZADD', zset_key, new_weight, target)
+return tostring(new_weight)
+"""
+
 
 class CoOccurrenceField(Field):
     """A field that maintains weighted association edges between model instances.
@@ -347,7 +367,12 @@ class CoOccurrenceField(Field):
     ):
         """Increase the weight of an existing edge.
 
-        Uses ZINCRBY to atomically increment the edge weight.
+        Uses an atomic Lua script (STRENGTHEN_CLAMP_LUA) to read the
+        current weight, add delta, and clamp at
+        ``Defaults.CO_OCCURRENCE_WEIGHT_CAP`` so stored weights can never
+        exceed the cap. This guarantees the per-hop contraction invariant
+        used by ``propagate()`` (``decay_per_hop * effective_edge_weight``
+        stays <= ``decay_per_hop * cap`` < 1 at default config).
 
         Args:
             model_class: The Model class.
@@ -357,7 +382,8 @@ class CoOccurrenceField(Field):
             pipeline: Optional Redis pipeline.
 
         Returns:
-            float: The new weight after increment.
+            float: The new (clamped) weight after increment, or None when
+                called with a pipeline (execution deferred).
 
         Raises:
             ValueError: If delta <= 0.
@@ -368,13 +394,28 @@ class CoOccurrenceField(Field):
         source_pk = str(source_pk)
         target_pk = str(target_pk)
 
+        cap = Defaults.CO_OCCURRENCE_WEIGHT_CAP
         source_key = self.get_edge_key(model_class, source_pk)
         db = pipeline if pipeline else POPOTO_REDIS_DB
-        new_weight = db.zincrby(source_key, delta, target_pk)
+        new_weight = db.eval(
+            STRENGTHEN_CLAMP_LUA,
+            1,
+            source_key,
+            target_pk,
+            str(delta),
+            str(cap),
+        )
 
         if self.symmetric:
             target_key = self.get_edge_key(model_class, target_pk)
-            db.zincrby(target_key, delta, source_pk)
+            db.eval(
+                STRENGTHEN_CLAMP_LUA,
+                1,
+                target_key,
+                source_pk,
+                str(delta),
+                str(cap),
+            )
 
         # EventStreamMixin: log strengthen event
         from .event_stream import EventStreamMixin

--- a/src/popoto/fields/co_occurrence_field.py
+++ b/src/popoto/fields/co_occurrence_field.py
@@ -110,6 +110,7 @@ return removed
 # ARGV[3] = decay per hop
 # ARGV[4] = threshold (minimum weight to continue propagation)
 # ARGV[5] = max edges per node to consider
+# ARGV[6] = weight cap (defense-in-depth: clamps pre-existing over-cap edges)
 PROPAGATE_BFS_LUA = """
 local key_prefix = KEYS[1]
 local seeds = cjson.decode(ARGV[1])
@@ -117,6 +118,7 @@ local max_depth = tonumber(ARGV[2])
 local decay_per_hop = tonumber(ARGV[3])
 local threshold = tonumber(ARGV[4])
 local max_per_node = tonumber(ARGV[5])
+local cap = tonumber(ARGV[6])
 
 -- Result table: pk -> max_weight
 local results = {}
@@ -166,7 +168,11 @@ while head <= #queue do
             for i = 1, #neighbors, 2 do
                 local neighbor_pk = neighbors[i]
                 local edge_weight = tonumber(neighbors[i + 1])
-                local propagated_weight = weight * decay_per_hop * edge_weight
+                -- Defense-in-depth: clamp pre-existing over-cap stored
+                -- weights so the contraction invariant holds for any
+                -- reachable weight, not just newly-written ones.
+                local effective_weight = math.min(edge_weight, cap)
+                local propagated_weight = weight * decay_per_hop * effective_weight
 
                 if propagated_weight >= threshold then
                     -- Update result with max weight
@@ -571,6 +577,12 @@ class CoOccurrenceField(Field):
         decay at each hop. When the same PK is reached via multiple paths,
         the maximum weight is kept.
 
+        Edge weights are clamped at ``Defaults.CO_OCCURRENCE_WEIGHT_CAP``
+        at read time (defense-in-depth) so pre-existing over-cap stored
+        weights cannot amplify propagation. A runtime guard raises
+        ``ValueError`` if ``cap * decay_per_hop >= 1.0`` (misconfiguration
+        that would amplify instead of decay).
+
         Args:
             model_class: The Model class.
             seed_pks: List of starting primary keys.
@@ -582,6 +594,10 @@ class CoOccurrenceField(Field):
         Returns:
             dict[str, float]: Mapping of discovered PKs to their propagated
                 weights. Seeds are not included in results (except for depth=0).
+
+        Raises:
+            ValueError: If ``CO_OCCURRENCE_WEIGHT_CAP * decay_per_hop >= 1.0``
+                (contraction invariant violated; propagation would amplify).
         """
         if decay_per_hop is _UNSET:
             decay_per_hop = Defaults.CO_OCCURRENCE_DECAY_PER_HOP
@@ -604,6 +620,7 @@ class CoOccurrenceField(Field):
             str(decay_per_hop),
             str(threshold),
             str(self.max_edges),
+            str(Defaults.CO_OCCURRENCE_WEIGHT_CAP),
         )
 
         # Parse flat array [pk1, weight1, pk2, weight2, ...]

--- a/src/popoto/fields/constants.py
+++ b/src/popoto/fields/constants.py
@@ -84,6 +84,14 @@ class Defaults:
     CO_OCCURRENCE_DECAY_FACTOR = 0.95  # empirically inert (sweep 2026-04-20, variance=0.0) — family scenario never calls weaken_all()
     CO_OCCURRENCE_INITIAL_WEIGHT = 0.1  # sweep 2026-04-20 variance=0.144; best 0.01 but curve has noise cliff, 0.1 is safer default for new users
     CO_OCCURRENCE_DECAY_PER_HOP = 0.5  # best from sweep 2026-04-20, variance=0.112, prior=0.5 (stable, smooth peak at 0.5)
+    # Upper bound on stored edge weights. Contraction invariant:
+    #   cap * CO_OCCURRENCE_DECAY_PER_HOP < 1  ->  per-hop transfer < 1
+    # so propagation decays rather than amplifies. The value 1.0 has
+    # intentional headroom below the theoretical maximum
+    # 1 / CO_OCCURRENCE_DECAY_PER_HOP = 2.0; a runtime guard in
+    # CoOccurrenceField.propagate() backstops the invariant if either
+    # constant is later changed.
+    CO_OCCURRENCE_WEIGHT_CAP = 1.0
 
     # -- PredictionLedgerMixin (fields/prediction_ledger.py) ------------------
     # Issue #362 added PredictionLedgerFamilyScenario. PL_AUTO_RESOLVE_
@@ -151,11 +159,15 @@ class Defaults:
     # These are tuning constants fed into the benchmarks/run_sweeps.py
     # TIER5_SWEEPS grid and tuned against the LoCoMo + LongMemEval-S harness
     # established in issue #394. Not yet swept; initial values set by design.
-    LIFECYCLE_PROMOTION_ACCESS_COUNT = 3       # accesses before episodic→semantic eligible
+    LIFECYCLE_PROMOTION_ACCESS_COUNT = 3  # accesses before episodic→semantic eligible
     LIFECYCLE_PROMOTION_CONFIDENCE_THRESHOLD = 0.6  # confidence floor for promotion
-    LIFECYCLE_PROMOTION_MIN_AGE_SECONDS = 300.0  # 5 min — prevents burst-access promotion
-    LIFECYCLE_FORGET_IMPORTANCE_FLOOR = 0.1    # importance below this → eligible for forget
-    LIFECYCLE_FORGET_IDLE_SECONDS = 86400.0    # 24 h idle → eligible for forget
+    LIFECYCLE_PROMOTION_MIN_AGE_SECONDS = (
+        300.0  # 5 min — prevents burst-access promotion
+    )
+    LIFECYCLE_FORGET_IMPORTANCE_FLOOR = (
+        0.1  # importance below this → eligible for forget
+    )
+    LIFECYCLE_FORGET_IDLE_SECONDS = 86400.0  # 24 h idle → eligible for forget
 
 
 class TemporalPeriod:

--- a/tests/benchmarks/test_defaults_sync.py
+++ b/tests/benchmarks/test_defaults_sync.py
@@ -59,6 +59,9 @@ class TestDefaultsSync:
             "CO_OCCURRENCE_DECAY_FACTOR",
             "CO_OCCURRENCE_INITIAL_WEIGHT",
             "CO_OCCURRENCE_DECAY_PER_HOP",
+            # Derived contraction-invariant cap, not a swept constant (#416);
+            # referenced only via Defaults.CO_OCCURRENCE_WEIGHT_CAP.
+            "CO_OCCURRENCE_WEIGHT_CAP",
             "PL_CONFIDENCE_ERROR_THRESHOLD",
             "PL_CONFIDENCE_LOW_SIGNAL",
             "PL_AUTO_RESOLVE_ACTED",

--- a/tests/test_co_occurrence_field.py
+++ b/tests/test_co_occurrence_field.py
@@ -37,6 +37,7 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 import pytest
 from src import popoto
 from src.popoto.fields.co_occurrence_field import CoOccurrenceField
+from src.popoto.fields.constants import Defaults
 from src.popoto.fields.decaying_sorted_field import DecayingSortedField
 from src.popoto.fields.access_tracker import AccessTrackerMixin
 from src.popoto.fields.confidence_field import ConfidenceField
@@ -201,6 +202,17 @@ class TestLink:
         # Should keep original weight (0.2), not overwrite with 0.9
         assert abs(linked[0][1] - 0.2) < 1e-9
 
+    def test_link_rejects_overcap_initial_weight(self):
+        """link() with initial_weight > CO_OCCURRENCE_WEIGHT_CAP raises ValueError."""
+        field = CoOcItem._meta.fields["associations"]
+        with pytest.raises(ValueError, match="CO_OCCURRENCE_WEIGHT_CAP"):
+            field.link(
+                CoOcItem,
+                "pk_a",
+                "pk_b",
+                initial_weight=Defaults.CO_OCCURRENCE_WEIGHT_CAP + 0.5,
+            )
+
 
 # --- Strengthen Tests ---
 
@@ -235,6 +247,56 @@ class TestStrengthen:
         field = CoOcItem._meta.fields["associations"]
         with pytest.raises(ValueError, match="delta must be > 0"):
             field.strengthen(CoOcItem, "pk_a", "pk_b", delta=0)
+
+    def test_strengthen_clamps_at_cap(self):
+        """Repeated strengthen() never lets the stored weight exceed the cap."""
+        field = CoOcItem._meta.fields["associations"]
+        field.link(CoOcItem, "pk_a", "pk_b", initial_weight=0.1)
+
+        cap = Defaults.CO_OCCURRENCE_WEIGHT_CAP
+        # 0.1 + 50 * 0.05 = 2.6 >> cap=1.0
+        last = 0.1
+        for _ in range(50):
+            last = field.strengthen(CoOcItem, "pk_a", "pk_b", delta=0.05)
+            assert last <= cap + 1e-9, f"weight {last} exceeded cap {cap}"
+
+        # At saturation the returned weight equals the cap.
+        assert abs(last - cap) < 1e-9
+
+        # Read back from the ZSET to confirm the stored score matches.
+        linked = field.get_linked(CoOcItem, "pk_a", min_weight=0.0)
+        assert abs(linked[0][1] - cap) < 1e-9
+
+    def test_strengthen_clamp_symmetric(self):
+        """Symmetric strengthen() clamps both directions at the cap."""
+        field = CoOcItem._meta.fields["associations"]
+        field.link(CoOcItem, "pk_a", "pk_b", initial_weight=0.1)
+
+        cap = Defaults.CO_OCCURRENCE_WEIGHT_CAP
+        for _ in range(50):
+            field.strengthen(CoOcItem, "pk_a", "pk_b", delta=0.05)
+
+        forward = field.get_linked(CoOcItem, "pk_a", min_weight=0.0)
+        reverse = field.get_linked(CoOcItem, "pk_b", min_weight=0.0)
+        assert abs(forward[0][1] - cap) < 1e-9
+        assert abs(reverse[0][1] - cap) < 1e-9
+
+    def test_strengthen_nonexistent_edge_clamps(self):
+        """strengthen() on a missing edge creates it at min(delta, cap)."""
+        field = CoOcItem._meta.fields["associations"]
+        cap = Defaults.CO_OCCURRENCE_WEIGHT_CAP
+
+        # delta <= cap: edge created at delta.
+        w_small = field.strengthen(CoOcItem, "pk_a", "pk_b", delta=0.05)
+        assert abs(w_small - 0.05) < 1e-9
+        linked = field.get_linked(CoOcItem, "pk_a", min_weight=0.0)
+        assert abs(linked[0][1] - 0.05) < 1e-9
+
+        # delta > cap: edge created at cap.
+        w_big = field.strengthen(CoOcItem, "pk_c", "pk_d", delta=cap + 0.5)
+        assert abs(w_big - cap) < 1e-9
+        linked_big = field.get_linked(CoOcItem, "pk_c", min_weight=0.0)
+        assert abs(linked_big[0][1] - cap) < 1e-9
 
 
 # --- Unlink Tests ---
@@ -449,6 +511,94 @@ class TestPropagate:
             CoOcItem, ["orphan"], depth=2
         )
         assert scores == {}
+
+    def test_propagate_monotonic_with_strengthened_edges(self):
+        """5-node chain a-b-c-d-e with all edges at cap: activation is
+        monotonically non-increasing in hop count and never exceeds 1.0.
+
+        This is the issue's reproduction — currently fails with
+        b:1.95, c:2.44, d:1.95, e:2.44 (non-monotonic, > 1.0).
+        """
+        field = CoOcItem._meta.fields["associations"]
+        chain = ["a", "b", "c", "d", "e"]
+        for i in range(len(chain) - 1):
+            field.link(CoOcItem, chain[i], chain[i + 1], initial_weight=0.1)
+            # Strengthen each edge to cap (1.0).
+            for _ in range(50):
+                field.strengthen(CoOcItem, chain[i], chain[i + 1], delta=0.05)
+
+        scores = field.propagate(
+            CoOcItem, ["a"], depth=4, decay_per_hop=0.5, threshold=0.01
+        )
+
+        b, c, d, e = scores["b"], scores["c"], scores["d"], scores["e"]
+        # All activations <= 1.0 (the seed weight).
+        assert b <= 1.0 + 1e-9
+        assert c <= 1.0 + 1e-9
+        assert d <= 1.0 + 1e-9
+        assert e <= 1.0 + 1e-9
+        # Monotonically non-increasing in hop count.
+        assert b >= c - 1e-9
+        assert c >= d - 1e-9
+        assert d >= e - 1e-9
+
+    def test_propagate_threshold_terminates_strengthened_graph(self):
+        """On a strengthened chain, threshold pruning fires before the
+        far end is reached, so the result set is smaller than the graph."""
+        field = CoOcItem._meta.fields["associations"]
+        chain = ["a", "b", "c", "d", "e", "f", "g"]
+        for i in range(len(chain) - 1):
+            field.link(CoOcItem, chain[i], chain[i + 1], initial_weight=0.1)
+            for _ in range(50):
+                field.strengthen(CoOcItem, chain[i], chain[i + 1], delta=0.05)
+
+        # decay 0.5 per hop, threshold 0.05:
+        #   b=0.5, c=0.25, d=0.125, e=0.0625 (>= 0.05, kept)
+        #   f=0.03125 (< 0.05, pruned), g never reached.
+        scores = field.propagate(
+            CoOcItem, ["a"], depth=6, decay_per_hop=0.5, threshold=0.05
+        )
+
+        total_non_seed = len(chain) - 1
+        assert len(scores) < total_non_seed
+        assert "f" not in scores
+        assert "g" not in scores
+        # The near end is still reached.
+        assert "b" in scores
+
+    def test_propagate_read_time_min_for_overcap_weights(self):
+        """A manually-ZADDed over-cap stored weight is clamped at read time,
+        so propagated activation <= decay_per_hop * cap (not decay_per_hop * raw)."""
+        field = CoOcItem._meta.fields["associations"]
+        # Bypass link()/strengthen() to inject a raw over-cap score.
+        source_key = field.get_edge_key(CoOcItem, "a")
+        POPOTO_REDIS_DB.zadd(source_key, {"b": 2.5})
+
+        scores = field.propagate(
+            CoOcItem, ["a"], depth=1, decay_per_hop=0.5, threshold=0.01
+        )
+
+        cap = Defaults.CO_OCCURRENCE_WEIGHT_CAP
+        # Effective weight = min(2.5, 1.0) = 1.0; propagated = 1.0 * 0.5 * 1.0 = 0.5.
+        # Without the read-time clamp it would be 1.0 * 0.5 * 2.5 = 1.25.
+        assert "b" in scores
+        assert scores["b"] <= 0.5 * cap + 1e-6
+        assert abs(scores["b"] - 0.5 * cap) < 1e-6
+
+    def test_propagate_guard_raises_on_invariant_violation(self):
+        """propagate() raises ValueError when cap * decay_per_hop >= 1.0."""
+        field = CoOcItem._meta.fields["associations"]
+        field.link(CoOcItem, "a", "b", initial_weight=0.5)
+        with pytest.raises(ValueError, match="Contraction invariant"):
+            field.propagate(CoOcItem, ["a"], depth=2, decay_per_hop=1.5)
+
+    def test_propagate_guard_passes_at_defaults(self):
+        """propagate() at default cap=1.0 and decay_per_hop=0.5 does not raise."""
+        field = CoOcItem._meta.fields["associations"]
+        field.link(CoOcItem, "a", "b", initial_weight=0.5)
+        # Should complete normally without ValueError.
+        scores = field.propagate(CoOcItem, ["a"], depth=2)
+        assert "b" in scores
 
 
 # --- On Delete Tests ---


### PR DESCRIPTION
## Summary

Fixes the unbounded edge-weight defect in `CoOccurrenceField` where repeated `strengthen()` calls could grow an edge weight above 1.0, inverting per-hop decay into amplification and defeating BFS threshold pruning (paths would *gain* score per hop instead of contracting).

This guarantees per-hop contraction by clamping edge weights to a cap (`CO_OCCURRENCE_WEIGHT_CAP`), enforced at every write and read path.

## Changes

- **Weight cap constant** — add `CO_OCCURRENCE_WEIGHT_CAP` to `fields/constants.py`, documenting that it bounds edge weights so traversal strictly contracts.
- **Write-time clamp** — `strengthen()` clamps accumulated edge weights via a `STRENGTHEN_CLAMP_LUA` script (Valkey-safe; no Redis modules), so no edge can exceed the cap atomically.
- **Read-time defense** — `PROPAGATE_BFS_LUA` applies `min(weight, cap)` when reading edges, defending against any pre-existing out-of-range data.
- **link() validation** — `link()` validates `initial_weight` against the cap.
- **Runtime contraction guard** — `propagate()` asserts per-hop contraction at runtime.
- **Tests** — add weight-cap clamp tests in `tests/test_co_occurrence_field.py`; exclude `CO_OCCURRENCE_WEIGHT_CAP` from the defaults-sync sweep coverage.
- **Docs** — document the weight cap, the contraction guarantee, and the neighbor-selection bias in `docs/features/co-occurrence-field.md`.

## Testing

- `pytest -k "co_occurrence"` — 55 passed, 6 skipped
- `pytest tests/benchmarks/test_defaults_sync.py` — 16 passed

Closes #416
