### PR TITLE
fix(#433): external benchmark Recall@k as any-hit hit-rate

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -26,7 +26,7 @@ the relevant memory given a natural-language query. It supports two datasets:
 
 | Metric | Definition |
 |--------|-----------|
-| **Recall@K** | Fraction of relevant items found in top-K retrieved results. For single-relevant-item queries, this is a hit-rate: 1 if the correct session/turn appears in top-K, else 0. |
+| **Recall@K** | Any-hit hit-rate: 1.0 if **any** relevant session/turn appears in the top-K retrieved results, else 0.0. This is the definition used by the published reference numbers and preserves the invariant MRR ≤ Recall@K. (A fractional variant — proportion of multi-evidence items found — is available as `fractional_recall_at_k` for per-evidence coverage analysis, but is not the headline metric.) |
 | **MRR** | Mean Reciprocal Rank — reciprocal of the rank of the first relevant result, averaged over all questions. |
 | **p50 latency** | Median wall-clock time for one `assemble()` call (ms). |
 | **p95 latency** | 95th-percentile latency (ms). |

--- a/tests/benchmarks/metrics/retrieval.py
+++ b/tests/benchmarks/metrics/retrieval.py
@@ -108,14 +108,49 @@ def calibration_error(
 
 
 def recall_at_k(retrieved: List[str], relevant: set, k: int) -> float:
-    """Compute recall@k — fraction of relevant items found in top-k results.
+    """Compute recall@k as an any-hit hit-rate.
 
-    For queries with a single relevant item (e.g. LongMemEval-S, LoCoMo),
-    this is equivalent to a hit-rate: 1.0 if the relevant item appears in
-    top-k, 0.0 otherwise.
+    Returns 1.0 if *any* relevant item appears in the top-k results, else 0.0.
+    This is the standard hit-rate definition used by published memory
+    benchmarks (LongMemEval-S, LoCoMo) and by the external reference numbers
+    this harness compares against.
 
-    For queries with multiple relevant items, this is the fraction of
-    relevant items that appear in top-k (capped at 1.0 when |relevant| > k).
+    Any-hit recall — not fractional recall — is the correct headline metric
+    here for two reasons: (1) it is directly comparable to the external
+    reference hit-rates, and (2) it preserves the invariant
+    ``MRR <= recall_at_k`` for any single result, since a first relevant item
+    at rank r contributes 1/r <= 1 to MRR but a full 1.0 to an any-hit. The
+    datasets carry *multi-evidence* ground truth (a question may have 2-6
+    relevant sessions), so fractional recall would deflate a rank-1 hit to
+    1/|relevant| and break that invariant. Use :func:`fractional_recall_at_k`
+    when the proportion of relevant items found is genuinely wanted.
+
+    Args:
+        retrieved: Ordered list of retrieved item IDs.
+        relevant: Set of relevant item IDs (ground truth).
+        k: Number of top results to evaluate.
+
+    Returns:
+        1.0 if at least one relevant item is in the top-k, else 0.0. Returns
+        0.0 if k <= 0, retrieved is empty, or relevant is empty.
+    """
+    if k <= 0 or not retrieved or not relevant:
+        return 0.0
+    hits = sum(1 for item in retrieved[:k] if item in relevant)
+    return 1.0 if hits > 0 else 0.0
+
+
+def fractional_recall_at_k(retrieved: List[str], relevant: set, k: int) -> float:
+    """Compute fractional recall@k — proportion of relevant items in top-k.
+
+    Returns ``(# relevant items found in top-k) / (total # relevant items)``,
+    capped at 1.0. Unlike :func:`recall_at_k` (any-hit hit-rate), this rewards
+    finding *more* of a multi-evidence ground-truth set: a rank-1 hit on a
+    2-evidence question scores 0.5 here but 1.0 under :func:`recall_at_k`.
+
+    This is NOT the headline benchmark metric — it is not comparable to the
+    external any-hit reference numbers and does not preserve ``MRR <= recall``.
+    It is retained for per-evidence coverage analysis.
 
     Args:
         retrieved: Ordered list of retrieved item IDs.
@@ -128,8 +163,7 @@ def recall_at_k(retrieved: List[str], relevant: set, k: int) -> float:
     """
     if k <= 0 or not retrieved or not relevant:
         return 0.0
-    top_k = retrieved[:k]
-    hits = sum(1 for item in top_k if item in relevant)
+    hits = sum(1 for item in retrieved[:k] if item in relevant)
     return min(1.0, hits / len(relevant))
 
 

--- a/tests/benchmarks/results/external/longmemeval_s_20260629.json
+++ b/tests/benchmarks/results/external/longmemeval_s_20260629.json
@@ -1,0 +1,10029 @@
+{
+  "dataset": "longmemeval-s",
+  "run_date": "2026-06-29",
+  "run_timestamp": "2026-06-29T09:10:30.912242+00:00",
+  "machine": {
+    "python_version": "3.12.13",
+    "platform": "macOS-26.3.1-arm64-arm-64bit",
+    "cpu_count": 10
+  },
+  "summary": {
+    "n_total": 500,
+    "n_ok": 500,
+    "n_errors": 0,
+    "n_skipped": 0,
+    "recall_at_1": 0.856,
+    "recall_at_5": 0.952,
+    "recall_at_10": 0.978,
+    "mrr": 0.8987,
+    "p50_ms": 0.57,
+    "p95_ms": 1.46
+  },
+  "notes": [
+    "Baseline run: relevance-only scoring (DecayingSortedField).",
+    "No vector/embedding retrieval wired in (BM25-style baseline).",
+    "LoCoMo: image-only turns skipped (text-only evaluation)."
+  ],
+  "questions": [
+    {
+      "item_id": "e47becba",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.15,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e47becba",
+        "query": "What degree did I graduate with?",
+        "n_history_turns": 550,
+        "n_saved_records": 550,
+        "n_retrieved": 2,
+        "retrieval_ms": 0.15,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "118b2229",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.5,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "118b2229",
+        "query": "How long is my daily commute to work?",
+        "n_history_turns": 485,
+        "n_saved_records": 485,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.5,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "51a45a95",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.29,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "51a45a95",
+        "query": "Where did I redeem a $5 coupon on coffee creamer?",
+        "n_history_turns": 529,
+        "n_saved_records": 529,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.29,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "58bf7951",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.37,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "58bf7951",
+        "query": "What play did I attend at the local community theater?",
+        "n_history_turns": 616,
+        "n_saved_records": 616,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.37,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1e043500",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.24,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1e043500",
+        "query": "What is the name of the playlist I created on Spotify?",
+        "n_history_turns": 510,
+        "n_saved_records": 510,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.24,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c5e8278d",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.46,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c5e8278d",
+        "query": "What was my last name before I changed it?",
+        "n_history_turns": 469,
+        "n_saved_records": 469,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.46,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6ade9755",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.52,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6ade9755",
+        "query": "Where do I take yoga classes?",
+        "n_history_turns": 513,
+        "n_saved_records": 513,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.52,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6f9b354f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.24,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6f9b354f",
+        "query": "What color did I repaint my bedroom walls?",
+        "n_history_turns": 500,
+        "n_saved_records": 500,
+        "n_retrieved": 3,
+        "retrieval_ms": 0.24,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "58ef2f1c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "58ef2f1c",
+        "query": "When did I volunteer at the local animal shelter's fundraising dinner?",
+        "n_history_turns": 518,
+        "n_saved_records": 518,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "f8c5f88b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.43,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "f8c5f88b",
+        "query": "Where did I buy my new tennis racket from?",
+        "n_history_turns": 487,
+        "n_saved_records": 487,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.43,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "5d3d2817",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.25,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "5d3d2817",
+        "query": "What was my previous occupation?",
+        "n_history_turns": 510,
+        "n_saved_records": 510,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.25,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "7527f7e2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.32,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "7527f7e2",
+        "query": "How much did I spend on a designer handbag?",
+        "n_history_turns": 490,
+        "n_saved_records": 490,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.32,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c960da58",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.33,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c960da58",
+        "query": "How many playlists do I have on Spotify?",
+        "n_history_turns": 504,
+        "n_saved_records": 504,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.33,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "3b6f954b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.31,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "3b6f954b",
+        "query": "Where did I attend for my study abroad program?",
+        "n_history_turns": 470,
+        "n_saved_records": 470,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.31,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "726462e0",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.42,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "726462e0",
+        "query": "What was the discount I got on my first purchase from the new clothing brand?",
+        "n_history_turns": 501,
+        "n_saved_records": 501,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.42,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "94f70d80",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.5,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "94f70d80",
+        "query": "How long did it take me to assemble the IKEA bookshelf?",
+        "n_history_turns": 510,
+        "n_saved_records": 510,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.5,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "66f24dbb",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.32,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "66f24dbb",
+        "query": "What did I buy for my sister's birthday gift?",
+        "n_history_turns": 507,
+        "n_saved_records": 507,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.32,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "ad7109d1",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.24,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "ad7109d1",
+        "query": "What speed is my new internet plan?",
+        "n_history_turns": 466,
+        "n_saved_records": 466,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.24,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "af8d2e46",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.52,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "af8d2e46",
+        "query": "How many shirts did I pack for my 5-day trip to Costa Rica?",
+        "n_history_turns": 495,
+        "n_saved_records": 495,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.52,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "dccbc061",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.24,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "dccbc061",
+        "query": "What was my previous stance on spirituality?",
+        "n_history_turns": 505,
+        "n_saved_records": 505,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.24,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c8c3f81d",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.5,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c8c3f81d",
+        "query": "What brand are my favorite running shoes?",
+        "n_history_turns": 487,
+        "n_saved_records": 487,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.5,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8ebdbe50",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.43,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8ebdbe50",
+        "query": "What certification did I complete last month?",
+        "n_history_turns": 487,
+        "n_saved_records": 487,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.43,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6b168ec8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.34,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6b168ec8",
+        "query": "How many bikes do I own?",
+        "n_history_turns": 482,
+        "n_saved_records": 482,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.34,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "75499fd8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.21,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "75499fd8",
+        "query": "What breed is my dog?",
+        "n_history_turns": 491,
+        "n_saved_records": 491,
+        "n_retrieved": 1,
+        "retrieval_ms": 0.21,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "21436231",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "21436231",
+        "query": "How many largemouth bass did I catch on my fishing trip to Lake Michigan?",
+        "n_history_turns": 512,
+        "n_saved_records": 512,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "95bcc1c8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "95bcc1c8",
+        "query": "How many amateur comedians did I watch perform at the open mic night?",
+        "n_history_turns": 487,
+        "n_saved_records": 487,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0862e8bf",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.27,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0862e8bf",
+        "query": "What is the name of my cat?",
+        "n_history_turns": 490,
+        "n_saved_records": 490,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.27,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "853b0a1d",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.75,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "853b0a1d",
+        "query": "How old was I when my grandma gave me the silver necklace?",
+        "n_history_turns": 512,
+        "n_saved_records": 512,
+        "n_retrieved": 3,
+        "retrieval_ms": 1.75,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a06e4cfe",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.42,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a06e4cfe",
+        "query": "What is my preferred gin-to-vermouth ratio for a classic gin martini?",
+        "n_history_turns": 534,
+        "n_saved_records": 534,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.42,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "37d43f65",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.3,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "37d43f65",
+        "query": "How much RAM did I upgrade my laptop to?",
+        "n_history_turns": 533,
+        "n_saved_records": 533,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.3,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b86304ba",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.35,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b86304ba",
+        "query": "How much is the painting of a sunset worth in terms of the amount I paid for it?",
+        "n_history_turns": 456,
+        "n_saved_records": 456,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.35,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "d52b4f67",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.43,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "d52b4f67",
+        "query": "Where did I attend my cousin's wedding?",
+        "n_history_turns": 479,
+        "n_saved_records": 479,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.43,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "25e5aa4f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.37,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "25e5aa4f",
+        "query": "Where did I complete my Bachelor's degree in Computer Science?",
+        "n_history_turns": 506,
+        "n_saved_records": 506,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.37,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "caf9ead2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "caf9ead2",
+        "query": "How long did it take to move to the new apartment?",
+        "n_history_turns": 466,
+        "n_saved_records": 466,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8550ddae",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.66,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8550ddae",
+        "query": "What type of cocktail recipe did I try last weekend?",
+        "n_history_turns": 453,
+        "n_saved_records": 453,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.66,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "60d45044",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.37,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "60d45044",
+        "query": "What type of rice is my favorite?",
+        "n_history_turns": 541,
+        "n_saved_records": 541,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.37,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "3f1e9474",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.23,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "3f1e9474",
+        "query": "Who did I have a conversation with about destiny?",
+        "n_history_turns": 515,
+        "n_saved_records": 515,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.23,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "86b68151",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.28,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "86b68151",
+        "query": "Where did I buy my new bookshelf from?",
+        "n_history_turns": 485,
+        "n_saved_records": 485,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.28,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "577d4d32",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.73,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "577d4d32",
+        "query": "What time do I stop checking work emails and messages?",
+        "n_history_turns": 487,
+        "n_saved_records": 487,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.73,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "ec81a493",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.52,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "ec81a493",
+        "query": "How many copies of my favorite artist's debut album were released worldwide?",
+        "n_history_turns": 495,
+        "n_saved_records": 495,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.52,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "15745da0",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.32,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "15745da0",
+        "query": "How long have I been collecting vintage cameras?",
+        "n_history_turns": 474,
+        "n_saved_records": 474,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.32,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e01b8e2f",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.3333333333333333,
+      "retrieval_ms": 0.52,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e01b8e2f",
+        "query": "Where did I go on a week-long trip with my family?",
+        "n_history_turns": 523,
+        "n_saved_records": 523,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.52,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "bc8a6e93",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.53,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "bc8a6e93",
+        "query": "What did I bake for my niece's birthday party?",
+        "n_history_turns": 537,
+        "n_saved_records": 537,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.53,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "ccb36322",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.2,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "ccb36322",
+        "query": "What is the name of the music streaming service have I been using lately?",
+        "n_history_turns": 471,
+        "n_saved_records": 471,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "001be529",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.31,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "001be529",
+        "query": "How long did I wait for the decision on my asylum application?",
+        "n_history_turns": 514,
+        "n_saved_records": 514,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.31,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b320f3f8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b320f3f8",
+        "query": "What type of action figure did I buy from a thrift store?",
+        "n_history_turns": 463,
+        "n_saved_records": 463,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "19b5f2b3",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.31,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "19b5f2b3",
+        "query": "How long was I in Japan for?",
+        "n_history_turns": 482,
+        "n_saved_records": 482,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.31,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "4fd1909e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.42,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "4fd1909e",
+        "query": "Where did I attend the Imagine Dragons concert?",
+        "n_history_turns": 554,
+        "n_saved_records": 554,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.42,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "545bd2b5",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.78,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "545bd2b5",
+        "query": "How much screen time have I been averaging on Instagram per day?",
+        "n_history_turns": 461,
+        "n_saved_records": 461,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.78,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8a137a7f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.31,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8a137a7f",
+        "query": "What type of bulb did I replace in my bedside lamp?",
+        "n_history_turns": 512,
+        "n_saved_records": 512,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.31,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "76d63226",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.19,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "76d63226",
+        "query": "What size is my new Samsung TV?",
+        "n_history_turns": 489,
+        "n_saved_records": 489,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.19,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "86f00804",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.61,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "86f00804",
+        "query": "What book am I currently reading?",
+        "n_history_turns": 503,
+        "n_saved_records": 503,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.61,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8e9d538c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.77,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8e9d538c",
+        "query": "How many skeins of worsted weight yarn did I find in my stash?",
+        "n_history_turns": 486,
+        "n_saved_records": 486,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.77,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "311778f1",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "311778f1",
+        "query": "How many hours did I spend watching documentaries on Netflix last month?",
+        "n_history_turns": 500,
+        "n_saved_records": 500,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c19f7a0b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.83,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c19f7a0b",
+        "query": "What time do I usually get home from work on weeknights?",
+        "n_history_turns": 478,
+        "n_saved_records": 478,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.83,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "4100d0a0",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.2,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "4100d0a0",
+        "query": "What is my ethnicity?",
+        "n_history_turns": 523,
+        "n_saved_records": 523,
+        "n_retrieved": 2,
+        "retrieval_ms": 0.2,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "29f2956b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.57,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "29f2956b",
+        "query": "How much time do I dedicate to practicing guitar every day?",
+        "n_history_turns": 496,
+        "n_saved_records": 496,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.57,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1faac195",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.73,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1faac195",
+        "query": "Where does my sister Emily live?",
+        "n_history_turns": 494,
+        "n_saved_records": 494,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.73,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "faba32e5",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.49,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "faba32e5",
+        "query": "How long did Alex marinate the BBQ ribs in special sauce?",
+        "n_history_turns": 473,
+        "n_saved_records": 473,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.49,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "f4f1d8a4",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.24,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "f4f1d8a4",
+        "query": "Who gave me a new stand mixer as a birthday gift?",
+        "n_history_turns": 585,
+        "n_saved_records": 585,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.24,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c14c00dd",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.28,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c14c00dd",
+        "query": "What brand of shampoo do I currently use?",
+        "n_history_turns": 492,
+        "n_saved_records": 492,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.28,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "36580ce8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.07,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "36580ce8",
+        "query": "What health issue did I initially think was just a cold?",
+        "n_history_turns": 545,
+        "n_saved_records": 545,
+        "n_retrieved": 13,
+        "retrieval_ms": 1.07,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "3d86fd0a",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.49,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "3d86fd0a",
+        "query": "Where did I meet Sophia?",
+        "n_history_turns": 526,
+        "n_saved_records": 526,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.49,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a82c026e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a82c026e",
+        "query": "What game did I finally beat last weekend?",
+        "n_history_turns": 476,
+        "n_saved_records": 476,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0862e8bf_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.18,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0862e8bf_abs",
+        "query": "What is the name of my hamster?",
+        "n_history_turns": 523,
+        "n_saved_records": 523,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.18,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "15745da0_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.32,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "15745da0_abs",
+        "query": "How long have I been collecting vintage films?",
+        "n_history_turns": 547,
+        "n_saved_records": 547,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.32,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "bc8a6e93_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.25,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "bc8a6e93_abs",
+        "query": "What did I bake for my uncle's birthday party?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.25,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "19b5f2b3_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.35,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "19b5f2b3_abs",
+        "query": "How long was I in Korea for?",
+        "n_history_turns": 527,
+        "n_saved_records": 527,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.35,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "29f2956b_abs",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.1111111111111111,
+      "retrieval_ms": 0.49,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "29f2956b_abs",
+        "query": "How much time do I dedicate to practicing violin every day?",
+        "n_history_turns": 494,
+        "n_saved_records": 494,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.49,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "f4f1d8a4_abs",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.21,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "f4f1d8a4_abs",
+        "query": "What did my dad gave me as a birthday gift?",
+        "n_history_turns": 506,
+        "n_saved_records": 506,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.21,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0a995998",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.83,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0a995998",
+        "query": "How many items of clothing do I need to pick up or return from a store?",
+        "n_history_turns": 484,
+        "n_saved_records": 484,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.83,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6d550036",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.25,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6d550036",
+        "query": "How many projects have I led or am currently leading?",
+        "n_history_turns": 505,
+        "n_saved_records": 505,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_59c863d7",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.42,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_59c863d7",
+        "query": "How many model kits have I worked on or bought?",
+        "n_history_turns": 481,
+        "n_saved_records": 481,
+        "n_retrieved": 15,
+        "retrieval_ms": 0.42,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b5ef892d",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.3333333333333333,
+      "retrieval_ms": 0.52,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b5ef892d",
+        "query": "How many days did I spend on camping trips in the United States this year?",
+        "n_history_turns": 516,
+        "n_saved_records": 516,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.52,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e831120c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.84,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e831120c",
+        "query": "How many weeks did it take me to watch all the Marvel Cinematic Universe movies and the main Star Wars films?",
+        "n_history_turns": 481,
+        "n_saved_records": 481,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.84,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "3a704032",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.75,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "3a704032",
+        "query": "How many plants did I acquire in the last month?",
+        "n_history_turns": 479,
+        "n_saved_records": 479,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.75,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_d84a3211",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.59,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_d84a3211",
+        "query": "How much total money have I spent on bike-related expenses since the start of the year?",
+        "n_history_turns": 495,
+        "n_saved_records": 495,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.59,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "aae3761f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "aae3761f",
+        "query": "How many hours in total did I spend driving to my three road trip destinations combined?",
+        "n_history_turns": 485,
+        "n_saved_records": 485,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_f2262a51",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 0.0,
+      "mrr": 0.0,
+      "retrieval_ms": 0.41,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_f2262a51",
+        "query": "How many different doctors did I visit?",
+        "n_history_turns": 479,
+        "n_saved_records": 479,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.41,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "dd2973ad",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.75,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "dd2973ad",
+        "query": "What time did I go to bed on the day before I had a doctor's appointment?",
+        "n_history_turns": 516,
+        "n_saved_records": 515,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.75,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c4a1ceb8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.12,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c4a1ceb8",
+        "query": "How many different types of citrus fruits have I used in my cocktail recipes?",
+        "n_history_turns": 488,
+        "n_saved_records": 488,
+        "n_retrieved": 10,
+        "retrieval_ms": 1.12,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_a56e767c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.34,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_a56e767c",
+        "query": "How many movie festivals that I attended?",
+        "n_history_turns": 477,
+        "n_saved_records": 477,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.34,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6cb6f249",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.78,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6cb6f249",
+        "query": "How many days did I take social media breaks in total?",
+        "n_history_turns": 470,
+        "n_saved_records": 470,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.78,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "46a3abf7",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.71,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "46a3abf7",
+        "query": "How many tanks do I currently have, including the one I set up for my friend's kid?",
+        "n_history_turns": 503,
+        "n_saved_records": 503,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.71,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "36b9f61e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.51,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "36b9f61e",
+        "query": "What is the total amount I spent on luxury items in the past few months?",
+        "n_history_turns": 490,
+        "n_saved_records": 490,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.51,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "28dc39ac",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.58,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "28dc39ac",
+        "query": "How many hours have I spent playing games in total?",
+        "n_history_turns": 431,
+        "n_saved_records": 431,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.58,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_2f8be40d",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.16666666666666666,
+      "retrieval_ms": 0.37,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_2f8be40d",
+        "query": "How many weddings have I attended in this year?",
+        "n_history_turns": 474,
+        "n_saved_records": 474,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.37,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2e6d26dc",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.67,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2e6d26dc",
+        "query": "How many babies were born to friends and family members in the last few months?",
+        "n_history_turns": 494,
+        "n_saved_records": 494,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.67,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_15e38248",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_15e38248",
+        "query": "How many pieces of furniture did I buy, assemble, sell, or fix in the past few months?",
+        "n_history_turns": 470,
+        "n_saved_records": 470,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "88432d0a",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.16666666666666666,
+      "retrieval_ms": 0.77,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "88432d0a",
+        "query": "How many times did I bake something in the past two weeks?",
+        "n_history_turns": 479,
+        "n_saved_records": 479,
+        "n_retrieved": 15,
+        "retrieval_ms": 0.77,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "80ec1f4f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.74,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "80ec1f4f",
+        "query": "How many different museums or galleries did I visit in the month of February?",
+        "n_history_turns": 487,
+        "n_saved_records": 487,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.74,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "d23cf73b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.01,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "d23cf73b",
+        "query": "How many different cuisines have I learned to cook or tried out in the past few months?",
+        "n_history_turns": 512,
+        "n_saved_records": 512,
+        "n_retrieved": 14,
+        "retrieval_ms": 1.01,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_7fce9456",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.99,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_7fce9456",
+        "query": "How many properties did I view before making an offer on the townhouse in the Brookside neighborhood?",
+        "n_history_turns": 497,
+        "n_saved_records": 493,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.99,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "d682f1a2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.93,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "d682f1a2",
+        "query": "How many different types of food delivery services have I used recently?",
+        "n_history_turns": 469,
+        "n_saved_records": 469,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.93,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "7024f17c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.66,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "7024f17c",
+        "query": "How many hours of jogging and yoga did I do last week?",
+        "n_history_turns": 483,
+        "n_saved_records": 483,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.66,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_5501fe77",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.06,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_5501fe77",
+        "query": "Which social media platform did I gain the most followers on over the past month?",
+        "n_history_turns": 516,
+        "n_saved_records": 516,
+        "n_retrieved": 8,
+        "retrieval_ms": 1.06,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_2ba83207",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.44,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_2ba83207",
+        "query": "Which grocery store did I spend the most money at in the past month?",
+        "n_history_turns": 502,
+        "n_saved_records": 502,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.44,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2318644b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.72,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2318644b",
+        "query": "How much more did I spend on accommodations per night in Hawaii compared to Tokyo?",
+        "n_history_turns": 523,
+        "n_saved_records": 523,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.72,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2ce6a0f2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.92,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2ce6a0f2",
+        "query": "How many different art-related events did I attend in the past month?",
+        "n_history_turns": 480,
+        "n_saved_records": 480,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.92,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_d12ceb0e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.39,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_d12ceb0e",
+        "query": "What is the average age of me, my parents, and my grandparents?",
+        "n_history_turns": 477,
+        "n_saved_records": 477,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.39,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "00ca467f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.4,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "00ca467f",
+        "query": "How many doctor's appointments did I go to in March?",
+        "n_history_turns": 486,
+        "n_saved_records": 486,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.4,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b3c15d39",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b3c15d39",
+        "query": "How many days did it take for me to receive the new remote shutter release after I ordered it?",
+        "n_history_turns": 502,
+        "n_saved_records": 502,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_31ff4165",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_31ff4165",
+        "query": "How many health-related devices do I use in a day?",
+        "n_history_turns": 457,
+        "n_saved_records": 457,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "eeda8a6d",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "eeda8a6d",
+        "query": "How many fish are there in total in both of my aquariums?",
+        "n_history_turns": 513,
+        "n_saved_records": 513,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2788b940",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.84,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2788b940",
+        "query": "How many fitness classes do I attend in a typical week?",
+        "n_history_turns": 475,
+        "n_saved_records": 475,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.84,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "60bf93ed",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.61,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "60bf93ed",
+        "query": "How many days did it take for my laptop backpack to arrive after I bought it?",
+        "n_history_turns": 494,
+        "n_saved_records": 494,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.61,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "9d25d4e0",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.54,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "9d25d4e0",
+        "query": "How many pieces of jewelry did I acquire in the last two months?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.54,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "129d1232",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.76,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "129d1232",
+        "query": "How much money did I raise in total through all the charity events I participated in?",
+        "n_history_turns": 451,
+        "n_saved_records": 451,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.76,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "60472f9c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "60472f9c",
+        "query": "How many projects have I been working on simultaneously, excluding my thesis?",
+        "n_history_turns": 454,
+        "n_saved_records": 454,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_194be4b3",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_194be4b3",
+        "query": "How many musical instruments do I currently own?",
+        "n_history_turns": 474,
+        "n_saved_records": 474,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a9f6b44c",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.6,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a9f6b44c",
+        "query": "How many bikes did I service or plan to service in March?",
+        "n_history_turns": 476,
+        "n_saved_records": 476,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.6,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "d851d5ba",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.39,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "d851d5ba",
+        "query": "How much money did I raise for charity in total?",
+        "n_history_turns": 533,
+        "n_saved_records": 533,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.39,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "5a7937c8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.58,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "5a7937c8",
+        "query": "How many days did I spend participating in faith-related activities in December?",
+        "n_history_turns": 419,
+        "n_saved_records": 419,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.58,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_ab202e7f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.43,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_ab202e7f",
+        "query": "How many kitchen items did I replace or fix?",
+        "n_history_turns": 481,
+        "n_saved_records": 481,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.43,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_e05b82a6",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.02,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_e05b82a6",
+        "query": "How many times did I ride rollercoasters across all the events I attended from July to October?",
+        "n_history_turns": 497,
+        "n_saved_records": 497,
+        "n_retrieved": 12,
+        "retrieval_ms": 1.02,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_731e37d7",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.47,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_731e37d7",
+        "query": "How much total money did I spend on attending workshops in the last four months?",
+        "n_history_turns": 525,
+        "n_saved_records": 525,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.47,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "edced276",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.47,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "edced276",
+        "query": "How many days did I spend in total traveling in Hawaii and in New York City?",
+        "n_history_turns": 482,
+        "n_saved_records": 482,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.47,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "10d9b85a",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 1.13,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "10d9b85a",
+        "query": "How many days did I spend attending workshops, lectures, and conferences in April?",
+        "n_history_turns": 466,
+        "n_saved_records": 466,
+        "n_retrieved": 16,
+        "retrieval_ms": 1.13,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e3038f8c",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.7,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e3038f8c",
+        "query": "How many rare items do I have in total?",
+        "n_history_turns": 458,
+        "n_saved_records": 458,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.7,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2b8f3739",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.49,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2b8f3739",
+        "query": "What is the total amount of money I earned from selling my products at the markets?",
+        "n_history_turns": 491,
+        "n_saved_records": 491,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.49,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1a8a66a6",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.35,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1a8a66a6",
+        "query": "How many magazine subscriptions do I currently have?",
+        "n_history_turns": 501,
+        "n_saved_records": 501,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.35,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c2ac3c61",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c2ac3c61",
+        "query": "How many online courses have I completed in total?",
+        "n_history_turns": 528,
+        "n_saved_records": 528,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "bf659f65",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.8,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "bf659f65",
+        "query": "How many music albums or EPs have I purchased or downloaded?",
+        "n_history_turns": 516,
+        "n_saved_records": 516,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.8,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_372c3eed",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.65,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_372c3eed",
+        "query": "How many years in total did I spend in formal education from high school to the completion of my Bachelor's degree?",
+        "n_history_turns": 465,
+        "n_saved_records": 465,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.65,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_2f91af09",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.97,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_2f91af09",
+        "query": "How many total pieces of writing have I completed since I started writing again three weeks ago, including short stories, poems, and pieces for the writing challenge?",
+        "n_history_turns": 515,
+        "n_saved_records": 515,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.97,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "81507db6",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.61,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "81507db6",
+        "query": "How many graduation ceremonies have I attended in the past three months?",
+        "n_history_turns": 510,
+        "n_saved_records": 510,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.61,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "88432d0a_abs",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.2,
+      "retrieval_ms": 0.42,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "88432d0a_abs",
+        "query": "How many times did I bake egg tarts in the past two weeks?",
+        "n_history_turns": 510,
+        "n_saved_records": 510,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.42,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "80ec1f4f_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "80ec1f4f_abs",
+        "query": "How many different museums or galleries did I visit in December?",
+        "n_history_turns": 479,
+        "n_saved_records": 479,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "eeda8a6d_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.49,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "eeda8a6d_abs",
+        "query": "How many fish are there in my 30-gallon tank?",
+        "n_history_turns": 477,
+        "n_saved_records": 477,
+        "n_retrieved": 2,
+        "retrieval_ms": 0.49,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "60bf93ed_abs",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 0.0,
+      "mrr": 0.09090909090909091,
+      "retrieval_ms": 1.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "60bf93ed_abs",
+        "query": "How many days did it take for my iPad case to arrive after I bought it?",
+        "n_history_turns": 521,
+        "n_saved_records": 521,
+        "n_retrieved": 15,
+        "retrieval_ms": 1.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "edced276_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.43,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "edced276_abs",
+        "query": "How many days did I spend in total traveling in Hawaii and in Seattle?",
+        "n_history_turns": 544,
+        "n_saved_records": 544,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.43,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_372c3eed_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.57,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_372c3eed_abs",
+        "query": "How many years in total did I spend in formal education from high school to the completion of my Master's degree?",
+        "n_history_turns": 490,
+        "n_saved_records": 490,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.57,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8a2466db",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8a2466db",
+        "query": "Can you recommend some resources where I can learn more about video editing?",
+        "n_history_turns": 508,
+        "n_saved_records": 508,
+        "n_retrieved": 8,
+        "retrieval_ms": 1.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "06878be2",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 0.0,
+      "mrr": 0.09090909090909091,
+      "retrieval_ms": 0.71,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "06878be2",
+        "query": "Can you suggest some accessories that would complement my current photography setup?",
+        "n_history_turns": 443,
+        "n_saved_records": 443,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.71,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "75832dbd",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.1,
+      "retrieval_ms": 1.2,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "75832dbd",
+        "query": "Can you recommend some recent publications or conferences that I might find interesting?",
+        "n_history_turns": 474,
+        "n_saved_records": 474,
+        "n_retrieved": 12,
+        "retrieval_ms": 1.2,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0edc2aef",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.37,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0edc2aef",
+        "query": "Can you suggest a hotel for my upcoming trip to Miami?",
+        "n_history_turns": 475,
+        "n_saved_records": 475,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.37,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "35a27287",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.03,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "35a27287",
+        "query": "Can you recommend some interesting cultural events happening around me this weekend?",
+        "n_history_turns": 519,
+        "n_saved_records": 519,
+        "n_retrieved": 11,
+        "retrieval_ms": 1.03,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "32260d93",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.125,
+      "retrieval_ms": 0.28,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "32260d93",
+        "query": "Can you recommend a show or movie for me to watch tonight?",
+        "n_history_turns": 524,
+        "n_saved_records": 524,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.28,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "195a1a1b",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.93,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "195a1a1b",
+        "query": "Can you suggest some activities that I can do in the evening?",
+        "n_history_turns": 515,
+        "n_saved_records": 515,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.93,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "afdc33df",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.87,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "afdc33df",
+        "query": "My kitchen's becoming a bit of a mess again. Any tips for keeping it clean?",
+        "n_history_turns": 502,
+        "n_saved_records": 502,
+        "n_retrieved": 14,
+        "retrieval_ms": 1.87,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "caf03d32",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.94,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "caf03d32",
+        "query": "I've been struggling with my slow cooker recipes. Any advice on getting better results?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.94,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "54026fce",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.27,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "54026fce",
+        "query": "I've been thinking about ways to stay connected with my colleagues. Any suggestions?",
+        "n_history_turns": 472,
+        "n_saved_records": 472,
+        "n_retrieved": 14,
+        "retrieval_ms": 1.27,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "06f04340",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 0.0,
+      "mrr": 0.0,
+      "retrieval_ms": 0.45,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "06f04340",
+        "query": "What should I serve for dinner this weekend with my homegrown ingredients?",
+        "n_history_turns": 503,
+        "n_saved_records": 503,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.45,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6b7dfb22",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.16666666666666666,
+      "retrieval_ms": 0.81,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6b7dfb22",
+        "query": "I've been feeling a bit stuck with my paintings lately. Do you have any ideas on how I can find new inspiration?",
+        "n_history_turns": 471,
+        "n_saved_records": 471,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.81,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1a1907b4",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.1111111111111111,
+      "retrieval_ms": 1.98,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1a1907b4",
+        "query": "I've been thinking about making a cocktail for an upcoming get-together, but I'm not sure which one to choose. Any suggestions?",
+        "n_history_turns": 532,
+        "n_saved_records": 532,
+        "n_retrieved": 14,
+        "retrieval_ms": 1.98,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "09d032c9",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.1111111111111111,
+      "retrieval_ms": 0.92,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "09d032c9",
+        "query": "I've been having trouble with the battery life on my phone lately. Any tips?",
+        "n_history_turns": 481,
+        "n_saved_records": 481,
+        "n_retrieved": 15,
+        "retrieval_ms": 0.92,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "38146c39",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.14,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "38146c39",
+        "query": "I've been feeling like my chocolate chip cookies need something extra. Any advice?",
+        "n_history_turns": 538,
+        "n_saved_records": 538,
+        "n_retrieved": 13,
+        "retrieval_ms": 1.14,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "d24813b1",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.16666666666666666,
+      "retrieval_ms": 1.35,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "d24813b1",
+        "query": "I'm thinking of inviting my colleagues over for a small gathering. Any tips on what to bake?",
+        "n_history_turns": 485,
+        "n_saved_records": 485,
+        "n_retrieved": 12,
+        "retrieval_ms": 1.35,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "57f827a0",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.25,
+      "retrieval_ms": 0.87,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "57f827a0",
+        "query": "I was thinking about rearranging the furniture in my bedroom this weekend. Any tips?",
+        "n_history_turns": 495,
+        "n_saved_records": 495,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.87,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "95228167",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.3333333333333333,
+      "retrieval_ms": 1.0,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "95228167",
+        "query": "I'm getting excited about my visit to the music store this weekend. Any tips on what to look for in a new guitar?",
+        "n_history_turns": 507,
+        "n_saved_records": 507,
+        "n_retrieved": 12,
+        "retrieval_ms": 1.0,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "505af2f5",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.25,
+      "retrieval_ms": 0.87,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "505af2f5",
+        "query": "I was thinking of trying a new coffee creamer recipe. Any recommendations?",
+        "n_history_turns": 501,
+        "n_saved_records": 501,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.87,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "75f70248",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.59,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "75f70248",
+        "query": "I've been sneezing quite a bit lately. Do you think it might be my living room?",
+        "n_history_turns": 466,
+        "n_saved_records": 466,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.59,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "d6233ab6",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.125,
+      "retrieval_ms": 0.92,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "d6233ab6",
+        "query": "I've been feeling nostalgic lately. Do you think it would be a good idea to attend my high school reunion?",
+        "n_history_turns": 437,
+        "n_saved_records": 437,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.92,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1da05512",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.5,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1da05512",
+        "query": "I'm trying to decide whether to buy a NAS device now or wait. What do you think?",
+        "n_history_turns": 462,
+        "n_saved_records": 462,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.5,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "fca70973",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.72,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "fca70973",
+        "query": "I am planning another theme park weekend; do you have any suggestions?",
+        "n_history_turns": 442,
+        "n_saved_records": 442,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.72,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b6025781",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.04,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b6025781",
+        "query": "I'm planning my meal prep next week, any suggestions for new recipes?",
+        "n_history_turns": 460,
+        "n_saved_records": 460,
+        "n_retrieved": 10,
+        "retrieval_ms": 1.04,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a89d7624",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.25,
+      "retrieval_ms": 0.8,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a89d7624",
+        "query": "I'm planning a trip to Denver soon. Any suggestions on what to do there?",
+        "n_history_turns": 496,
+        "n_saved_records": 496,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.8,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b0479f84",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.73,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b0479f84",
+        "query": "I've got some free time tonight, any documentary recommendations?",
+        "n_history_turns": 502,
+        "n_saved_records": 502,
+        "n_retrieved": 13,
+        "retrieval_ms": 1.73,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1d4e3b97",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.81,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1d4e3b97",
+        "query": "I noticed my bike seems to be performing even better during my Sunday group rides. Could there be a reason for this?",
+        "n_history_turns": 474,
+        "n_saved_records": 474,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.81,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "07b6f563",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.96,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "07b6f563",
+        "query": "Can you suggest some useful accessories for my phone?",
+        "n_history_turns": 524,
+        "n_saved_records": 524,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.96,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1c0ddc50",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.25,
+      "retrieval_ms": 1.22,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1c0ddc50",
+        "query": "Can you suggest some activities I can do during my commute to work?",
+        "n_history_turns": 548,
+        "n_saved_records": 548,
+        "n_retrieved": 8,
+        "retrieval_ms": 1.22,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0a34ad58",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.12,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0a34ad58",
+        "query": "I\u2019m a bit anxious about getting around Tokyo. Do you have any helpful tips?",
+        "n_history_turns": 485,
+        "n_saved_records": 485,
+        "n_retrieved": 12,
+        "retrieval_ms": 1.12,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "d3ab962e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.28,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "d3ab962e",
+        "query": "What is the total distance of the hikes I did on two consecutive weekends?",
+        "n_history_turns": 530,
+        "n_saved_records": 530,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.28,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2311e44b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2311e44b",
+        "query": "How many pages do I have left to read in 'The Nightingale'?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "cc06de0d",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.97,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "cc06de0d",
+        "query": "For my daily commute, how much more expensive was the taxi ride compared to the train fare?",
+        "n_history_turns": 462,
+        "n_saved_records": 462,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.97,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a11281a2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.54,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a11281a2",
+        "query": "What was the approximate increase in Instagram followers I experienced in two weeks?",
+        "n_history_turns": 457,
+        "n_saved_records": 457,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.54,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "4f54b7c9",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.57,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "4f54b7c9",
+        "query": "How many antique items did I inherit or acquire from my family members?",
+        "n_history_turns": 491,
+        "n_saved_records": 491,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.57,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "85fa3a3f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.64,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "85fa3a3f",
+        "query": "What is the total cost of the new food bowl, measuring cup, dental chews, and flea and tick collar I got for Max?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.64,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "9aaed6a3",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.44,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "9aaed6a3",
+        "query": "How much cashback did I earn at SaveMart last Thursday?",
+        "n_history_turns": 541,
+        "n_saved_records": 541,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.44,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1f2b8d4f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.92,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1f2b8d4f",
+        "query": "What is the difference in price between my luxury boots and the similar pair found at the budget store?",
+        "n_history_turns": 522,
+        "n_saved_records": 522,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.92,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e6041065",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.5,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e6041065",
+        "query": "What percentage of packed shoes did I wear on my last trip?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.5,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "51c32626",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.42,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "51c32626",
+        "query": "When did I submit my research paper on sentiment analysis?",
+        "n_history_turns": 490,
+        "n_saved_records": 490,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.42,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "d905b33f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.57,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "d905b33f",
+        "query": "What percentage discount did I get on the book from my favorite author?",
+        "n_history_turns": 504,
+        "n_saved_records": 504,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.57,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "7405e8b1",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.6,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "7405e8b1",
+        "query": "Did I receive a higher percentage discount on my first order from HelloFresh, compared to my first UberEats order?",
+        "n_history_turns": 469,
+        "n_saved_records": 469,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.6,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "f35224e0",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.45,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "f35224e0",
+        "query": "What is the total number of episodes I've listened to from 'How I Built This' and 'My Favorite Murder'?",
+        "n_history_turns": 515,
+        "n_saved_records": 515,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.45,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6456829e",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.49,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6456829e",
+        "query": "How many plants did I initially plant for tomatoes and cucumbers?",
+        "n_history_turns": 488,
+        "n_saved_records": 488,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.49,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a4996e51",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.91,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a4996e51",
+        "query": "How many hours do I work in a typical week during peak campaign seasons?",
+        "n_history_turns": 512,
+        "n_saved_records": 512,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.91,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "3c1045c8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "3c1045c8",
+        "query": "How much older am I than the average age of employees in my department?",
+        "n_history_turns": 542,
+        "n_saved_records": 542,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "60036106",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.63,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "60036106",
+        "query": "What was the total number of people reached by my Facebook ad campaign and Instagram influencer collaboration?",
+        "n_history_turns": 483,
+        "n_saved_records": 483,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.63,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "681a1674",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.37,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "681a1674",
+        "query": "How many Marvel movies did I re-watch?",
+        "n_history_turns": 476,
+        "n_saved_records": 476,
+        "n_retrieved": 3,
+        "retrieval_ms": 0.37,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e25c3b8d",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.37,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e25c3b8d",
+        "query": "How much did I save on the designer handbag at TK Maxx?",
+        "n_history_turns": 530,
+        "n_saved_records": 530,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.37,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "4adc0475",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.37,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "4adc0475",
+        "query": "What is the total number of goals and assists I have in the recreational indoor soccer league?",
+        "n_history_turns": 490,
+        "n_saved_records": 490,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.37,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "4bc144e2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.45,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "4bc144e2",
+        "query": "How much did I spend on car wash and parking ticket?",
+        "n_history_turns": 530,
+        "n_saved_records": 530,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.45,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "ef66a6e5",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.41,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "ef66a6e5",
+        "query": "How many sports have I played competitively in the past?",
+        "n_history_turns": 445,
+        "n_saved_records": 445,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.41,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "5025383b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.42,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "5025383b",
+        "query": "What are the two hobbies that led me to join online communities?",
+        "n_history_turns": 446,
+        "n_saved_records": 446,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.42,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a1cc6108",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.23,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a1cc6108",
+        "query": "How old was I when Alex was born?",
+        "n_history_turns": 492,
+        "n_saved_records": 492,
+        "n_retrieved": 2,
+        "retrieval_ms": 0.23,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "9ee3ecd6",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.94,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "9ee3ecd6",
+        "query": "How many points do I need to earn to redeem a free skincare product at Sephora?",
+        "n_history_turns": 476,
+        "n_saved_records": 476,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.94,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "3fdac837",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.36,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "3fdac837",
+        "query": "What is the total number of days I spent in Japan and Chicago?",
+        "n_history_turns": 453,
+        "n_saved_records": 453,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.36,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "91b15a6e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.76,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "91b15a6e",
+        "query": "What is the minimum amount I could get if I sold the vintage diamond necklace and the antique vanity?",
+        "n_history_turns": 489,
+        "n_saved_records": 489,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.76,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "27016adc",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "27016adc",
+        "query": "What percentage of the countryside property's price is the cost of the renovations I plan to do on my current house?",
+        "n_history_turns": 491,
+        "n_saved_records": 491,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "720133ac",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.32,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "720133ac",
+        "query": "What is the total cost of Lola's vet visit and flea medication?",
+        "n_history_turns": 466,
+        "n_saved_records": 466,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.32,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "77eafa52",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.69,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "77eafa52",
+        "query": "How much more did I have to pay for the trip after the initial quote?",
+        "n_history_turns": 527,
+        "n_saved_records": 527,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.69,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8979f9ec",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8979f9ec",
+        "query": "What is the total number of lunch meals I got from the chicken fajitas and lentil soup?",
+        "n_history_turns": 469,
+        "n_saved_records": 469,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0100672e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.64,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0100672e",
+        "query": "How much did I spend on each coffee mug for my coworkers?",
+        "n_history_turns": 486,
+        "n_saved_records": 486,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.64,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a96c20ee",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a96c20ee",
+        "query": "At which university did I present a poster on my thesis research?",
+        "n_history_turns": 489,
+        "n_saved_records": 489,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "92a0aa75",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.25,
+      "retrieval_ms": 0.68,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "92a0aa75",
+        "query": "How long have I been working in my current role?",
+        "n_history_turns": 455,
+        "n_saved_records": 455,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.68,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "3fe836c9",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.62,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "3fe836c9",
+        "query": "How much more was the pre-approval amount than the final sale price of the house?",
+        "n_history_turns": 449,
+        "n_saved_records": 449,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.62,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1c549ce4",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.41,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1c549ce4",
+        "query": "What is the total cost of the car cover and detailing spray I purchased?",
+        "n_history_turns": 462,
+        "n_saved_records": 462,
+        "n_retrieved": 3,
+        "retrieval_ms": 0.41,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6c49646a",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.32,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6c49646a",
+        "query": "What is the total distance I covered in my four road trips?",
+        "n_history_turns": 429,
+        "n_saved_records": 429,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.32,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1192316e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.95,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1192316e",
+        "query": "What is the total time it takes I to get ready and commute to work?",
+        "n_history_turns": 467,
+        "n_saved_records": 467,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.95,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0ea62687",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.1,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0ea62687",
+        "query": "How much more miles per gallon was my car getting a few months ago compared to now?",
+        "n_history_turns": 460,
+        "n_saved_records": 460,
+        "n_retrieved": 9,
+        "retrieval_ms": 1.1,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "67e0d0f2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.69,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "67e0d0f2",
+        "query": "What is the total number of online courses I've completed?",
+        "n_history_turns": 510,
+        "n_saved_records": 510,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.69,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "bb7c3b45",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.71,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "bb7c3b45",
+        "query": "How much did I save on the Jimmy Choo heels?",
+        "n_history_turns": 495,
+        "n_saved_records": 495,
+        "n_retrieved": 8,
+        "retrieval_ms": 1.71,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "ba358f49",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.44,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "ba358f49",
+        "query": "How many years will I be when my friend Rachel gets married?",
+        "n_history_turns": 409,
+        "n_saved_records": 409,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.44,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "61f8c8f8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "61f8c8f8",
+        "query": "How much faster did I finish the 5K run compared to my previous year's time?",
+        "n_history_turns": 459,
+        "n_saved_records": 459,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "60159905",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.52,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "60159905",
+        "query": "How many dinner parties have I attended in the past month?",
+        "n_history_turns": 448,
+        "n_saved_records": 448,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.52,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "ef9cf60a",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.26,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "ef9cf60a",
+        "query": "How much did I spend on gifts for my sister?",
+        "n_history_turns": 522,
+        "n_saved_records": 522,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.26,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "73d42213",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "73d42213",
+        "query": "What time did I reach the clinic on Monday?",
+        "n_history_turns": 516,
+        "n_saved_records": 516,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "bc149d6b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "bc149d6b",
+        "query": "What is the total weight of the new feed I purchased in the past two months?",
+        "n_history_turns": 467,
+        "n_saved_records": 467,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "099778bb",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.35,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "099778bb",
+        "query": "What percentage of leadership positions do women hold in the my company?",
+        "n_history_turns": 466,
+        "n_saved_records": 466,
+        "n_retrieved": 2,
+        "retrieval_ms": 0.35,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "09ba9854",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.46,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "09ba9854",
+        "query": "How much will I save by taking the train from the airport to my hotel instead of a taxi?",
+        "n_history_turns": 479,
+        "n_saved_records": 479,
+        "n_retrieved": 2,
+        "retrieval_ms": 0.46,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "d6062bb9",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.67,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "d6062bb9",
+        "query": "What is the total number of views on my most popular videos on YouTube and TikTok?",
+        "n_history_turns": 532,
+        "n_saved_records": 532,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.67,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "157a136e",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "157a136e",
+        "query": "How many years older is my grandma than me?",
+        "n_history_turns": 503,
+        "n_saved_records": 503,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c18a7dc8",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.16666666666666666,
+      "retrieval_ms": 0.44,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c18a7dc8",
+        "query": "How many years older am I than when I graduated from college?",
+        "n_history_turns": 509,
+        "n_saved_records": 509,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.44,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a3332713",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.52,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a3332713",
+        "query": "What is the total amount I spent on gifts for my coworker and brother?",
+        "n_history_turns": 467,
+        "n_saved_records": 467,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.52,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "55241a1f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.04,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "55241a1f",
+        "query": "What is the total number of comments on my recent Facebook Live session and my most popular YouTube video?",
+        "n_history_turns": 514,
+        "n_saved_records": 514,
+        "n_retrieved": 7,
+        "retrieval_ms": 1.04,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a08a253f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.64,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a08a253f",
+        "query": "How many days a week do I attend fitness classes?",
+        "n_history_turns": 560,
+        "n_saved_records": 560,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.64,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "f0e564bc",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.77,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "f0e564bc",
+        "query": "What is the total amount I spent on the designer handbag and high-end skincare products?",
+        "n_history_turns": 508,
+        "n_saved_records": 508,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.77,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "078150f1",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.59,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "078150f1",
+        "query": "How much more money did I raise than my initial goal in the charity cycling event?",
+        "n_history_turns": 551,
+        "n_saved_records": 551,
+        "n_retrieved": 10,
+        "retrieval_ms": 1.59,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8cf4d046",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.22,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8cf4d046",
+        "query": "What is the average GPA of my undergraduate and graduate studies?",
+        "n_history_turns": 468,
+        "n_saved_records": 468,
+        "n_retrieved": 3,
+        "retrieval_ms": 0.22,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a346bb18",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.74,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a346bb18",
+        "query": "How many minutes did I exceed my target time by in the marathon?",
+        "n_history_turns": 478,
+        "n_saved_records": 478,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.74,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "37f165cf",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.29,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "37f165cf",
+        "query": "What was the page count of the two novels I finished in January and March?",
+        "n_history_turns": 567,
+        "n_saved_records": 567,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.29,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8e91e7d9",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 0.0,
+      "mrr": 0.0,
+      "retrieval_ms": 0.35,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8e91e7d9",
+        "query": "What is the total number of siblings I have?",
+        "n_history_turns": 498,
+        "n_saved_records": 498,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.35,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "87f22b4a",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.45,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "87f22b4a",
+        "query": "How much have I made from selling eggs this month?",
+        "n_history_turns": 474,
+        "n_saved_records": 474,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.45,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e56a43b9",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e56a43b9",
+        "query": "How much discount will I get on my next purchase at FreshMart?",
+        "n_history_turns": 448,
+        "n_saved_records": 448,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "efc3f7c2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.61,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "efc3f7c2",
+        "query": "How much earlier do I wake up on Fridays compared to other weekdays?",
+        "n_history_turns": 497,
+        "n_saved_records": 497,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.61,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "21d02d0d",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.61,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "21d02d0d",
+        "query": "How many fun runs did I miss in March due to work commitments?",
+        "n_history_turns": 497,
+        "n_saved_records": 497,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.61,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2311e44b_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2311e44b_abs",
+        "query": "How many pages do I have left to read in 'Sapiens'?",
+        "n_history_turns": 494,
+        "n_saved_records": 494,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6456829e_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6456829e_abs",
+        "query": "How many plants did I initially plant for tomatoes and chili peppers?",
+        "n_history_turns": 494,
+        "n_saved_records": 494,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e5ba910e_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e5ba910e_abs",
+        "query": "What is the total cost of my recently purchased headphones and the iPad?",
+        "n_history_turns": 522,
+        "n_saved_records": 522,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a96c20ee_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.62,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a96c20ee_abs",
+        "query": "At which university did I present a poster for my undergrad course research project?",
+        "n_history_turns": 535,
+        "n_saved_records": 535,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.62,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "ba358f49_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.49,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "ba358f49_abs",
+        "query": "How old will Rachel be when I get married?",
+        "n_history_turns": 477,
+        "n_saved_records": 477,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.49,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "09ba9854_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.84,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "09ba9854_abs",
+        "query": "How much will I save by taking the bus from the airport to my hotel instead of a taxi?",
+        "n_history_turns": 513,
+        "n_saved_records": 513,
+        "n_retrieved": 3,
+        "retrieval_ms": 0.84,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_59149c77",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.97,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_59149c77",
+        "query": "How many days passed between my visit to the Museum of Modern Art (MoMA) and the 'Ancient Civilizations' exhibit at the Metropolitan Museum of Art?",
+        "n_history_turns": 484,
+        "n_saved_records": 484,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.97,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_f49edff3",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.94,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_f49edff3",
+        "query": "Which three events happened in the order from first to last: the day I helped my friend prepare the nursery, the day I helped my cousin pick out stuff for her baby shower, and the day I ordered a customized phone case for my friend's birthday?",
+        "n_history_turns": 498,
+        "n_saved_records": 498,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.94,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "71017276",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.44,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "71017276",
+        "query": "How many weeks ago did I meet up with my aunt and receive the crystal chandelier?",
+        "n_history_turns": 614,
+        "n_saved_records": 614,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.44,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b46e15ed",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.57,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b46e15ed",
+        "query": "How many months have passed since I participated in two charity events in a row, on consecutive days?",
+        "n_history_turns": 478,
+        "n_saved_records": 478,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.57,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_fa19884c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.91,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_fa19884c",
+        "query": "How many days passed between the day I started playing along to my favorite songs on my old keyboard and the day I discovered a bluegrass band?",
+        "n_history_turns": 507,
+        "n_saved_records": 507,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.91,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0bc8ad92",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.7,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0bc8ad92",
+        "query": "How many months have passed since I last visited a museum with a friend?",
+        "n_history_turns": 443,
+        "n_saved_records": 443,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.7,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "af082822",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.49,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "af082822",
+        "query": "How many weeks ago did I attend the friends and family sale at Nordstrom?",
+        "n_history_turns": 495,
+        "n_saved_records": 495,
+        "n_retrieved": 15,
+        "retrieval_ms": 0.49,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_4929293a",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.51,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_4929293a",
+        "query": "Which event happened first, my cousin's wedding or Michael's engagement party?",
+        "n_history_turns": 486,
+        "n_saved_records": 486,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.51,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_b5700ca9",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.49,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_b5700ca9",
+        "query": "How many days ago did I attend the Maundy Thursday service at the Episcopal Church?",
+        "n_history_turns": 537,
+        "n_saved_records": 537,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.49,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "9a707b81",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.02,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "9a707b81",
+        "query": "How many days ago did I attend a baking class at a local culinary school when I made my friend's birthday cake?",
+        "n_history_turns": 530,
+        "n_saved_records": 530,
+        "n_retrieved": 11,
+        "retrieval_ms": 1.02,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_1d4ab0c9",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.75,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_1d4ab0c9",
+        "query": "How many days passed between the day I started watering my herb garden and the day I harvested my first batch of fresh herbs?",
+        "n_history_turns": 483,
+        "n_saved_records": 483,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.75,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_e072b769",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.69,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_e072b769",
+        "query": "How many weeks ago did I start using the cashback app 'Ibotta'?",
+        "n_history_turns": 444,
+        "n_saved_records": 444,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.69,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0db4c65d",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.85,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0db4c65d",
+        "query": "How many days had passed since I finished reading 'The Seven Husbands of Evelyn Hugo' when I attended the book reading event at the local library, where the author of 'The Silent Patient' is discussing her latest thriller novel?",
+        "n_history_turns": 462,
+        "n_saved_records": 462,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.85,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_1d80365e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.83,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_1d80365e",
+        "query": "How many days did I spend on my solo camping trip to Yosemite National Park?",
+        "n_history_turns": 517,
+        "n_saved_records": 517,
+        "n_retrieved": 7,
+        "retrieval_ms": 1.83,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_7f6b06db",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.25,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_7f6b06db",
+        "query": "What is the order of the three trips I took in the past three months, from earliest to latest?",
+        "n_history_turns": 558,
+        "n_saved_records": 558,
+        "n_retrieved": 15,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_6dc9b45b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_6dc9b45b",
+        "query": "How many months ago did I attend the Seattle International Film Festival?",
+        "n_history_turns": 565,
+        "n_saved_records": 565,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_8279ba02",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.2,
+      "retrieval_ms": 0.44,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_8279ba02",
+        "query": "How many days ago did I buy a smoker?",
+        "n_history_turns": 489,
+        "n_saved_records": 489,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.44,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_18c2b244",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.88,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_18c2b244",
+        "query": "What is the order of the three events: 'I signed up for the rewards program at ShopRite', 'I used a Buy One Get One Free coupon on Luvs diapers at Walmart', and 'I redeemed $12 cashback for a $10 Amazon gift card from Ibotta'?",
+        "n_history_turns": 495,
+        "n_saved_records": 495,
+        "n_retrieved": 4,
+        "retrieval_ms": 1.88,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_a1b77f9c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.68,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_a1b77f9c",
+        "query": "How many weeks in total do I spent on reading 'The Nightingale' and listening to 'Sapiens: A Brief History of Humankind' and 'The Power'?",
+        "n_history_turns": 498,
+        "n_saved_records": 498,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.68,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_1916e0ea",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.97,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_1916e0ea",
+        "query": "How many days passed between the day I cancelled my FarmFresh subscription and the day I did my online grocery shopping from Instacart?",
+        "n_history_turns": 533,
+        "n_saved_records": 533,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.97,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_7a0daae1",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.83,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_7a0daae1",
+        "query": "How many weeks passed between the day I bought my new tennis racket and the day I received it?",
+        "n_history_turns": 561,
+        "n_saved_records": 561,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.83,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_468eb063",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.3333333333333333,
+      "retrieval_ms": 0.45,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_468eb063",
+        "query": "How many days ago did I meet Emma?",
+        "n_history_turns": 498,
+        "n_saved_records": 498,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.45,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_7abb270c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.27,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_7abb270c",
+        "query": "What is the order of the six museums I visited from earliest to latest?",
+        "n_history_turns": 467,
+        "n_saved_records": 467,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.27,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_1e4a8aeb",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_1e4a8aeb",
+        "query": "How many days passed between the day I attended the gardening workshop and the day I planted the tomato saplings?",
+        "n_history_turns": 479,
+        "n_saved_records": 479,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_4fc4f797",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.81,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_4fc4f797",
+        "query": "How many days passed between the day I received feedback about my car's suspension and the day I tested my new suspension setup?",
+        "n_history_turns": 472,
+        "n_saved_records": 472,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.81,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "4dfccbf7",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.14,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "4dfccbf7",
+        "query": "How many days had passed since I started taking ukulele lessons when I decided to take my acoustic guitar to the guitar tech for servicing?",
+        "n_history_turns": 521,
+        "n_saved_records": 521,
+        "n_retrieved": 11,
+        "retrieval_ms": 1.14,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_61e13b3c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.71,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_61e13b3c",
+        "query": "How many weeks passed between the time I sold homemade baked goods at the Farmers' Market for the last time and the time I participated in the Spring Fling Market?",
+        "n_history_turns": 467,
+        "n_saved_records": 467,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.71,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_45189cb4",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.43,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_45189cb4",
+        "query": "What is the order of the sports events I watched in January?",
+        "n_history_turns": 501,
+        "n_saved_records": 501,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.43,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2ebe6c90",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.65,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2ebe6c90",
+        "query": "How many days did it take me to finish 'The Nightingale' by Kristin Hannah?",
+        "n_history_turns": 485,
+        "n_saved_records": 485,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.65,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_e061b84f",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 0.0,
+      "mrr": 0.0,
+      "retrieval_ms": 0.79,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_e061b84f",
+        "query": "What is the order of the three sports events I participated in during the past month, from earliest to latest?",
+        "n_history_turns": 467,
+        "n_saved_records": 467,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.79,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "370a8ff4",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.39,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "370a8ff4",
+        "query": "How many weeks had passed since I recovered from the flu when I went on my 10th jog outdoors?",
+        "n_history_turns": 498,
+        "n_saved_records": 498,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.39,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_d6585ce8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.54,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_d6585ce8",
+        "query": "What is the order of the concerts and musical events I attended in the past two months, starting from the earliest?",
+        "n_history_turns": 491,
+        "n_saved_records": 491,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.54,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_4ef30696",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.02,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_4ef30696",
+        "query": "How many days passed between the day I finished reading 'The Nightingale' and the day I started reading 'The Hitchhiker's Guide to the Galaxy'?",
+        "n_history_turns": 520,
+        "n_saved_records": 520,
+        "n_retrieved": 10,
+        "retrieval_ms": 1.02,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_ec93e27f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.69,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_ec93e27f",
+        "query": "Which mode of transport did I use most recently, a bus or a train?",
+        "n_history_turns": 516,
+        "n_saved_records": 516,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.69,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6e984301",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.53,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6e984301",
+        "query": "How many weeks have I been taking sculpting classes when I invested in my own set of sculpting tools?",
+        "n_history_turns": 513,
+        "n_saved_records": 513,
+        "n_retrieved": 14,
+        "retrieval_ms": 1.53,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8077ef71",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.43,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8077ef71",
+        "query": "How many days ago did I attend a networking event?",
+        "n_history_turns": 554,
+        "n_saved_records": 554,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.43,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_f420262c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.5,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_f420262c",
+        "query": "What is the order of airlines I flew with from earliest to latest before today?",
+        "n_history_turns": 495,
+        "n_saved_records": 495,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.5,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_8e165409",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.86,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_8e165409",
+        "query": "How many days passed between the day I repotted the previous spider plant and the day I gave my neighbor, Mrs. Johnson, a few cuttings from my spider plant?",
+        "n_history_turns": 480,
+        "n_saved_records": 480,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.86,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_74aed68e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.76,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_74aed68e",
+        "query": "How many days passed between the day I replaced my spark plugs and the day I participated in the Turbocharged Tuesdays auto racking event?",
+        "n_history_turns": 480,
+        "n_saved_records": 480,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.76,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "bcbe585f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.74,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "bcbe585f",
+        "query": "How many weeks ago did I attend a bird watching workshop at the local Audubon society?",
+        "n_history_turns": 453,
+        "n_saved_records": 453,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.74,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_21adecb5",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.72,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_21adecb5",
+        "query": "How many months passed between the completion of my undergraduate degree and the submission of my master's thesis?",
+        "n_history_turns": 511,
+        "n_saved_records": 511,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.72,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "5e1b23de",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.58,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "5e1b23de",
+        "query": "How many months ago did I attend the photography workshop?",
+        "n_history_turns": 445,
+        "n_saved_records": 445,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.58,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_98f46fc6",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.57,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_98f46fc6",
+        "query": "Which event did I participate in first, the charity gala or the charity bake sale?",
+        "n_history_turns": 490,
+        "n_saved_records": 490,
+        "n_retrieved": 3,
+        "retrieval_ms": 0.57,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_af6db32f",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_af6db32f",
+        "query": "How many days ago did I watch the Super Bowl?",
+        "n_history_turns": 476,
+        "n_saved_records": 476,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "eac54adc",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.62,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "eac54adc",
+        "query": "How many days ago did I launch my website when I signed a contract with my first client?",
+        "n_history_turns": 464,
+        "n_saved_records": 464,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.62,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_7ddcf75f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_7ddcf75f",
+        "query": "How many days ago did I go on a whitewater rafting trip in the Oregon mountains?",
+        "n_history_turns": 480,
+        "n_saved_records": 480,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_a2d1d1f6",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.74,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_a2d1d1f6",
+        "query": "How many days ago did I harvest my first batch of fresh herbs from the herb garden kit?",
+        "n_history_turns": 476,
+        "n_saved_records": 476,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.74,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_85da3956",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.4,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_85da3956",
+        "query": "How many weeks ago did I attend the 'Summer Nights' festival at Universal Studios Hollywood?",
+        "n_history_turns": 505,
+        "n_saved_records": 505,
+        "n_retrieved": 8,
+        "retrieval_ms": 1.4,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_b0863698",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.25,
+      "retrieval_ms": 0.96,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_b0863698",
+        "query": "How many days ago did I participate in the 5K charity run?",
+        "n_history_turns": 457,
+        "n_saved_records": 457,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.96,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_68e94287",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.93,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_68e94287",
+        "query": "Which event happened first, my participation in the #PlankChallenge or my post about vegan chili recipe?",
+        "n_history_turns": 491,
+        "n_saved_records": 491,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.93,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_e414231e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.66,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_e414231e",
+        "query": "How many days passed between the day I fixed my mountain bike and the day I decided to upgrade my road bike's pedals?",
+        "n_history_turns": 507,
+        "n_saved_records": 507,
+        "n_retrieved": 4,
+        "retrieval_ms": 1.66,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_7ca326fa",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.93,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_7ca326fa",
+        "query": "Who graduated first, second and third among Emma, Rachel and Alex?",
+        "n_history_turns": 516,
+        "n_saved_records": 516,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.93,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_7bc6cf22",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.92,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_7bc6cf22",
+        "query": "How many days ago did I read the March 15th issue of The New Yorker?",
+        "n_history_turns": 519,
+        "n_saved_records": 519,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.92,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2ebe6c92",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.53,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2ebe6c92",
+        "query": "Which book did I finish a week ago?",
+        "n_history_turns": 487,
+        "n_saved_records": 487,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.53,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_e061b84g",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 0.0,
+      "mrr": 0.0,
+      "retrieval_ms": 0.37,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_e061b84g",
+        "query": "I mentioned participating in a sports event two weeks ago. What was the event?",
+        "n_history_turns": 566,
+        "n_saved_records": 566,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.37,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "71017277",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.125,
+      "retrieval_ms": 0.71,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "71017277",
+        "query": "I received a piece of jewelry last Saturday from whom?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.71,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b46e15ee",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.31,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b46e15ee",
+        "query": "What charity event did I participate in a month ago?",
+        "n_history_turns": 457,
+        "n_saved_records": 457,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.31,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_d6585ce9",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.99,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_d6585ce9",
+        "query": "Who did I go with to the music event last Saturday?",
+        "n_history_turns": 438,
+        "n_saved_records": 437,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.99,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_1e4a8aec",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.25,
+      "retrieval_ms": 0.45,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_1e4a8aec",
+        "query": "What gardening-related activity did I do two weeks ago?",
+        "n_history_turns": 498,
+        "n_saved_records": 498,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.45,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_f420262d",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.3,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_f420262d",
+        "query": "What was the airline that I flied with on Valentine's day?",
+        "n_history_turns": 454,
+        "n_saved_records": 454,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.3,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_59149c78",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.2,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_59149c78",
+        "query": "I mentioned that I participated in an art-related event two weeks ago. Where was that event held at?",
+        "n_history_turns": 497,
+        "n_saved_records": 497,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_e414231f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.35,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_e414231f",
+        "query": "Which bike did I fixed or serviced the past weekend?",
+        "n_history_turns": 490,
+        "n_saved_records": 490,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.35,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_4929293b",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 0.0,
+      "mrr": 0.0,
+      "retrieval_ms": 0.5,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_4929293b",
+        "query": "What was the the life event of one of my relatives that I participated in a week ago?",
+        "n_history_turns": 469,
+        "n_saved_records": 469,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.5,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_468eb064",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.45,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_468eb064",
+        "query": "Who did I meet with during the lunch last Tuesday?",
+        "n_history_turns": 460,
+        "n_saved_records": 460,
+        "n_retrieved": 15,
+        "retrieval_ms": 0.45,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_fa19884d",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.41,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_fa19884d",
+        "query": "What is the artist that I started to listen to last Friday?",
+        "n_history_turns": 556,
+        "n_saved_records": 556,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.41,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "9a707b82",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.1,
+      "retrieval_ms": 0.39,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "9a707b82",
+        "query": "I mentioned cooking something for my friend a couple of days ago. What was it?",
+        "n_history_turns": 532,
+        "n_saved_records": 532,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.39,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "eac54add",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 0.0,
+      "mrr": 0.0,
+      "retrieval_ms": 0.36,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "eac54add",
+        "query": "What was the significant buisiness milestone I mentioned four weeks ago?",
+        "n_history_turns": 476,
+        "n_saved_records": 476,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.36,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "4dfccbf8",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.31,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "4dfccbf8",
+        "query": "What did I do with Rachel on the Wednesday two months ago?",
+        "n_history_turns": 455,
+        "n_saved_records": 455,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.31,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0bc8ad93",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0bc8ad93",
+        "query": "I mentioned visiting a museum two months ago. Did I visit with a friend or not?",
+        "n_history_turns": 486,
+        "n_saved_records": 486,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6e984302",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.2,
+      "retrieval_ms": 0.37,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6e984302",
+        "query": "I mentioned an investment for a competition four weeks ago? What did I buy?",
+        "n_history_turns": 460,
+        "n_saved_records": 460,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.37,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_8279ba03",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 0.0,
+      "mrr": 0.0,
+      "retrieval_ms": 0.32,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_8279ba03",
+        "query": "What kitchen appliance did I buy 10 days ago?",
+        "n_history_turns": 500,
+        "n_saved_records": 500,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.32,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_b5700ca0",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.43,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_b5700ca0",
+        "query": "Where did I attend the religious activity last week?",
+        "n_history_turns": 500,
+        "n_saved_records": 500,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.43,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_68e94288",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_68e94288",
+        "query": "What was the social media activity I participated 5 days ago?",
+        "n_history_turns": 459,
+        "n_saved_records": 459,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_2655b836",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.82,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_2655b836",
+        "query": "What was the first issue I had with my new car after its first service?",
+        "n_history_turns": 465,
+        "n_saved_records": 465,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.82,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_2487a7cb",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.08,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_2487a7cb",
+        "query": "Which event did I attend first, the 'Effective Time Management' workshop or the 'Data Analysis using Python' webinar?",
+        "n_history_turns": 495,
+        "n_saved_records": 495,
+        "n_retrieved": 5,
+        "retrieval_ms": 1.08,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_76048e76",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.45,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_76048e76",
+        "query": "Which vehicle did I take care of first in February, the bike or the car?",
+        "n_history_turns": 482,
+        "n_saved_records": 482,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.45,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_2312f94c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_2312f94c",
+        "query": "Which device did I got first, the Samsung Galaxy S22 or the Dell XPS 13?",
+        "n_history_turns": 467,
+        "n_saved_records": 467,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0bb5a684",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.83,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0bb5a684",
+        "query": "How many days before the team meeting I was preparing for did I attend the workshop on 'Effective Communication in the Workplace'?",
+        "n_history_turns": 463,
+        "n_saved_records": 463,
+        "n_retrieved": 3,
+        "retrieval_ms": 0.83,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "08f4fc43",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.63,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "08f4fc43",
+        "query": "How many days had passed between the Sunday mass at St. Mary's Church and the Ash Wednesday service at the cathedral?",
+        "n_history_turns": 480,
+        "n_saved_records": 480,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.63,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2c63a862",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.19,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2c63a862",
+        "query": "How many days did it take for me to find a house I loved after starting to work with Rachel?",
+        "n_history_turns": 529,
+        "n_saved_records": 529,
+        "n_retrieved": 8,
+        "retrieval_ms": 1.19,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_385a5000",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_385a5000",
+        "query": "Which seeds were started first, the tomatoes or the marigolds?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2a1811e2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.52,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2a1811e2",
+        "query": "How many days had passed between the Hindu festival of Holi and the Sunday mass at St. Mary's Church?",
+        "n_history_turns": 479,
+        "n_saved_records": 479,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.52,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "bbf86515",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "bbf86515",
+        "query": "How many days before the 'Rack Fest' did I participate in the 'Turbocharged Tuesdays' event?",
+        "n_history_turns": 487,
+        "n_saved_records": 487,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_5dcc0aab",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.5,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_5dcc0aab",
+        "query": "Which pair of shoes did I clean last month?",
+        "n_history_turns": 547,
+        "n_saved_records": 547,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.5,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_0b2f1d21",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.42,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_0b2f1d21",
+        "query": "Which event happened first, the purchase of the coffee maker or the malfunction of the stand mixer?",
+        "n_history_turns": 497,
+        "n_saved_records": 497,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.42,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "f0853d11",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.65,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "f0853d11",
+        "query": "How many days had passed between the 'Walk for Hunger' event and the 'Coastal Cleanup' event?",
+        "n_history_turns": 500,
+        "n_saved_records": 500,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.65,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_6ed717ea",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.46,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_6ed717ea",
+        "query": "Which item did I purchase first, the dog bed for Max or the training pads for Luna?",
+        "n_history_turns": 489,
+        "n_saved_records": 489,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.46,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_70e84552",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.46,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_70e84552",
+        "query": "Which task did I complete first, fixing the fence or trimming the goats' hooves?",
+        "n_history_turns": 467,
+        "n_saved_records": 467,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.46,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a3838d2b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.9,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a3838d2b",
+        "query": "How many charity events did I participate in before the 'Run for the Cure' event?",
+        "n_history_turns": 484,
+        "n_saved_records": 484,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.9,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_93159ced",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.68,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_93159ced",
+        "query": "How long have I been working before I started my current job at NovaTech?",
+        "n_history_turns": 444,
+        "n_saved_records": 444,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.68,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_2d58bcd6",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.67,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_2d58bcd6",
+        "query": "Which book did I finish reading first, 'The Hate U Give' or 'The Nightingale'?",
+        "n_history_turns": 483,
+        "n_saved_records": 483,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.67,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_65aabe59",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.66,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_65aabe59",
+        "query": "Which device did I set up first, the smart thermostat or the mesh network system?",
+        "n_history_turns": 452,
+        "n_saved_records": 452,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.66,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "982b5123",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.57,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "982b5123",
+        "query": "How many months ago did I book the Airbnb in San Francisco?",
+        "n_history_turns": 473,
+        "n_saved_records": 473,
+        "n_retrieved": 5,
+        "retrieval_ms": 1.57,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b9cfe692",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.46,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b9cfe692",
+        "query": "How long did I take to finish 'The Seven Husbands of Evelyn Hugo' and 'The Nightingale' combined?",
+        "n_history_turns": 492,
+        "n_saved_records": 492,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.46,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_4edbafa2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.42,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_4edbafa2",
+        "query": "What was the date on which I attended the first BBQ event in June?",
+        "n_history_turns": 460,
+        "n_saved_records": 459,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.42,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c8090214",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.57,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c8090214",
+        "query": "How many days before I bought the iPhone 13 Pro did I attend the Holiday Market?",
+        "n_history_turns": 459,
+        "n_saved_records": 459,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.57,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_483dd43c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.47,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_483dd43c",
+        "query": "Which show did I start watching first, 'The Crown' or 'Game of Thrones'?",
+        "n_history_turns": 532,
+        "n_saved_records": 532,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.47,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e4e14d04",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.44,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e4e14d04",
+        "query": "How long had I been a member of 'Book Lovers Unite' when I attended the meetup?",
+        "n_history_turns": 461,
+        "n_saved_records": 461,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.44,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c9f37c46",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.65,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c9f37c46",
+        "query": "How long had I been watching stand-up comedy specials regularly when I attended the open mic night at the local comedy club?",
+        "n_history_turns": 511,
+        "n_saved_records": 511,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.65,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_2c50253f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.65,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_2c50253f",
+        "query": "What time do I wake up on Tuesdays and Thursdays?",
+        "n_history_turns": 591,
+        "n_saved_records": 591,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.65,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "dcfa8644",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.88,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "dcfa8644",
+        "query": "How many days had passed since I bought my Adidas running shoes when I realized one of the shoelaces on my old Converse sneakers had broken?",
+        "n_history_turns": 470,
+        "n_saved_records": 470,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.88,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_b4a80587",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.42,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_b4a80587",
+        "query": "Which event happened first, the road trip to the coast or the arrival of the new prime lens?",
+        "n_history_turns": 542,
+        "n_saved_records": 542,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.42,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_9a159967",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_9a159967",
+        "query": "Which airline did I fly with the most in March and April?",
+        "n_history_turns": 470,
+        "n_saved_records": 470,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "cc6d1ec1",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.34,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "cc6d1ec1",
+        "query": "How long had I been bird watching when I attended the bird watching workshop?",
+        "n_history_turns": 457,
+        "n_saved_records": 457,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.34,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_8c8961ae",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.82,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_8c8961ae",
+        "query": "Which trip did I take first, the one to Europe with family or the solo trip to Thailand?",
+        "n_history_turns": 485,
+        "n_saved_records": 485,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.82,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_d9af6064",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.6,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_d9af6064",
+        "query": "Which device did I set up first, the smart thermostat or the new router?",
+        "n_history_turns": 534,
+        "n_saved_records": 534,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.6,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_7de946e7",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.57,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_7de946e7",
+        "query": "Which health issue did I deal with first, the persistent cough or the skin tag removal?",
+        "n_history_turns": 533,
+        "n_saved_records": 533,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.57,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "d01c6aa8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.34,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "d01c6aa8",
+        "query": "How old was I when I moved to the United States?",
+        "n_history_turns": 429,
+        "n_saved_records": 429,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.34,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "993da5e2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 2.0,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "993da5e2",
+        "query": "How long had I been using the new area rug when I rearranged my living room furniture?",
+        "n_history_turns": 486,
+        "n_saved_records": 486,
+        "n_retrieved": 10,
+        "retrieval_ms": 2.0,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a3045048",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.77,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a3045048",
+        "query": "How many days before my best friend's birthday party did I order her gift?",
+        "n_history_turns": 584,
+        "n_saved_records": 584,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.77,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_d31cdae3",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.6,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_d31cdae3",
+        "query": "Which trip did the narrator take first, the solo trip to Europe or the family road trip across the American Southwest?",
+        "n_history_turns": 480,
+        "n_saved_records": 480,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.6,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_cd90e484",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.62,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_cd90e484",
+        "query": "How long did I use my new binoculars before I saw the American goldfinches returning to the area?",
+        "n_history_turns": 508,
+        "n_saved_records": 508,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.62,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_88806d6e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.32,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_88806d6e",
+        "query": "Who did I meet first, Mark and Sarah or Tom?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.32,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_4cd9eba1",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.51,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_4cd9eba1",
+        "query": "How many weeks have I been accepted into the exchange program when I started attending the pre-departure orientation sessions?",
+        "n_history_turns": 500,
+        "n_saved_records": 500,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.51,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_93f6379c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.44,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_93f6379c",
+        "query": "Which group did I join first, 'Page Turners' or 'Marketing Professionals'?",
+        "n_history_turns": 445,
+        "n_saved_records": 445,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.44,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b29f3365",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.65,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b29f3365",
+        "query": "How long had I been taking guitar lessons when I bought the new guitar amp?",
+        "n_history_turns": 494,
+        "n_saved_records": 494,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.65,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_2f56ae70",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.71,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_2f56ae70",
+        "query": "Which streaming service did I start using most recently?",
+        "n_history_turns": 458,
+        "n_saved_records": 458,
+        "n_retrieved": 17,
+        "retrieval_ms": 0.71,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6613b389",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.85,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6613b389",
+        "query": "How many months before my anniversary did Rachel get engaged?",
+        "n_history_turns": 452,
+        "n_saved_records": 452,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.85,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_78cf46a3",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.6,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_78cf46a3",
+        "query": "Which event happened first, the narrator losing their phone charger or the narrator receiving their new phone case?",
+        "n_history_turns": 505,
+        "n_saved_records": 505,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.6,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_0a05b494",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.51,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_0a05b494",
+        "query": "Who did I meet first, the woman selling jam at the farmer's market or the tourist from Australia?",
+        "n_history_turns": 506,
+        "n_saved_records": 506,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.51,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_1a1dc16d",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.32,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_1a1dc16d",
+        "query": "Which event happened first, the meeting with Rachel or the pride parade?",
+        "n_history_turns": 453,
+        "n_saved_records": 453,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.32,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_2f584639",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.46,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_2f584639",
+        "query": "Which gift did I buy first, the necklace for my sister or the photo album for my mom?",
+        "n_history_turns": 472,
+        "n_saved_records": 472,
+        "n_retrieved": 3,
+        "retrieval_ms": 0.46,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_213fd887",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.8,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_213fd887",
+        "query": "Which event did I participate in first, the volleyball league or the charity 5K run to raise money for a local children's hospital?",
+        "n_history_turns": 446,
+        "n_saved_records": 446,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.8,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_5438fa52",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.54,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_5438fa52",
+        "query": "Which event happened first, my attendance at a cultural festival or the start of my Spanish classes?",
+        "n_history_turns": 513,
+        "n_saved_records": 513,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.54,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_c27434e8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.7,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_c27434e8",
+        "query": "Which project did I start first, the Ferrari model or the Japanese Zero fighter plane model?",
+        "n_history_turns": 500,
+        "n_saved_records": 500,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.7,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_fe651585",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.36,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_fe651585",
+        "query": "Who became a parent first, Rachel or Alex?",
+        "n_history_turns": 471,
+        "n_saved_records": 471,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.36,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8c18457d",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.62,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8c18457d",
+        "query": "How many days had passed between the day I bought a gift for my brother's graduation ceremony and the day I bought a birthday gift for my best friend?",
+        "n_history_turns": 434,
+        "n_saved_records": 434,
+        "n_retrieved": 8,
+        "retrieval_ms": 1.62,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_70e84552_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.47,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_70e84552_abs",
+        "query": "Which task did I complete first, fixing the fence or purchasing three cows from Peter?",
+        "n_history_turns": 520,
+        "n_saved_records": 520,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.47,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_93159ced_abs",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.3333333333333333,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_93159ced_abs",
+        "query": "How long have I been working before I started my current job at Google?",
+        "n_history_turns": 608,
+        "n_saved_records": 608,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "982b5123_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.32,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "982b5123_abs",
+        "query": "When did I book the Airbnb in Sacramento?",
+        "n_history_turns": 505,
+        "n_saved_records": 505,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.32,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c8090214_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.63,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c8090214_abs",
+        "query": "How many days before I bought my iPad did I attend the Holiday Market?",
+        "n_history_turns": 506,
+        "n_saved_records": 506,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.63,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_c27434e8_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.69,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_c27434e8_abs",
+        "query": "Which project did I start first, the Ferrari model or the Porsche 991 Turbo S model?",
+        "n_history_turns": 482,
+        "n_saved_records": 482,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.69,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "gpt4_fe651585_abs",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.29,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "gpt4_fe651585_abs",
+        "query": "Who became a parent first, Tom or Alex?",
+        "n_history_turns": 492,
+        "n_saved_records": 491,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.29,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6a1eabeb",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.59,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6a1eabeb",
+        "query": "What was my personal best time in the charity 5K run?",
+        "n_history_turns": 413,
+        "n_saved_records": 413,
+        "n_retrieved": 8,
+        "retrieval_ms": 1.59,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6aeb4375",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.59,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6aeb4375",
+        "query": "How many Korean restaurants have I tried in my city?",
+        "n_history_turns": 468,
+        "n_saved_records": 468,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.59,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "830ce83f",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.52,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "830ce83f",
+        "query": "Where did Rachel move to after her recent relocation?",
+        "n_history_turns": 511,
+        "n_saved_records": 511,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.52,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "852ce960",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.36,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "852ce960",
+        "query": "What was the amount I was pre-approved for when I got my mortgage from Wells Fargo?",
+        "n_history_turns": 396,
+        "n_saved_records": 396,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.36,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "945e3d21",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.09,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "945e3d21",
+        "query": "How often do I attend yoga classes to help with my anxiety?",
+        "n_history_turns": 489,
+        "n_saved_records": 489,
+        "n_retrieved": 9,
+        "retrieval_ms": 1.09,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "d7c942c3",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.67,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "d7c942c3",
+        "query": "Is my mom using the same grocery list method as me?",
+        "n_history_turns": 520,
+        "n_saved_records": 520,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.67,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "71315a70",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.46,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "71315a70",
+        "query": "How many hours have I spent on my abstract ocean sculpture?",
+        "n_history_turns": 514,
+        "n_saved_records": 514,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.46,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "89941a93",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.67,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "89941a93",
+        "query": "How many bikes do I currently own?",
+        "n_history_turns": 528,
+        "n_saved_records": 528,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.67,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "ce6d2d27",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.89,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "ce6d2d27",
+        "query": "What day of the week do I take a cocktail-making class?",
+        "n_history_turns": 521,
+        "n_saved_records": 521,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.89,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "9ea5eabc",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.73,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "9ea5eabc",
+        "query": "Where did I go on my most recent family trip?",
+        "n_history_turns": 537,
+        "n_saved_records": 537,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.73,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "07741c44",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.52,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "07741c44",
+        "query": "Where do I initially keep my old sneakers?",
+        "n_history_turns": 513,
+        "n_saved_records": 513,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.52,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a1eacc2a",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.96,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a1eacc2a",
+        "query": "How many short stories have I written since I started writing regularly?",
+        "n_history_turns": 474,
+        "n_saved_records": 474,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.96,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "184da446",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.68,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "184da446",
+        "query": "How many pages of 'A Short History of Nearly Everything' have I read so far?",
+        "n_history_turns": 473,
+        "n_saved_records": 473,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.68,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "031748ae",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.3,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "031748ae",
+        "query": "How many engineers do I lead when I just started my new role as Senior Software Engineer? How many engineers do I lead now?",
+        "n_history_turns": 494,
+        "n_saved_records": 494,
+        "n_retrieved": 11,
+        "retrieval_ms": 1.3,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "4d6b87c8",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.45,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "4d6b87c8",
+        "query": "How many titles are currently on my to-watch list?",
+        "n_history_turns": 516,
+        "n_saved_records": 516,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.45,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0f05491a",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.79,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0f05491a",
+        "query": "How many stars do I need to reach the gold level on my Starbucks Rewards app?",
+        "n_history_turns": 489,
+        "n_saved_records": 489,
+        "n_retrieved": 3,
+        "retrieval_ms": 0.79,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "08e075c7",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.52,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "08e075c7",
+        "query": "How long have I been using my Fitbit Charge 3?",
+        "n_history_turns": 484,
+        "n_saved_records": 484,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.52,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "f9e8c073",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.8,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "f9e8c073",
+        "query": "How many sessions of the bereavement support group did I attend?",
+        "n_history_turns": 504,
+        "n_saved_records": 504,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.8,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "41698283",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "41698283",
+        "query": "What type of camera lens did I purchase most recently?",
+        "n_history_turns": 476,
+        "n_saved_records": 476,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2698e78f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.39,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2698e78f",
+        "query": "How often do I see my therapist, Dr. Smith?",
+        "n_history_turns": 478,
+        "n_saved_records": 478,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.39,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b6019101",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.58,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b6019101",
+        "query": "How many MCU films did I watch in the last 3 months?",
+        "n_history_turns": 510,
+        "n_saved_records": 510,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.58,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "45dc21b6",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.41,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "45dc21b6",
+        "query": "How many of Emma's recipes have I tried out?",
+        "n_history_turns": 485,
+        "n_saved_records": 485,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.41,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "5a4f22c0",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.4,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "5a4f22c0",
+        "query": "What company is Rachel, an old colleague from my previous company, currently working at?",
+        "n_history_turns": 487,
+        "n_saved_records": 487,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.4,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6071bd76",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.91,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6071bd76",
+        "query": "For the coffee-to-water ratio in my French press, did I switch to more water per tablespoon of coffee, or less?",
+        "n_history_turns": 482,
+        "n_saved_records": 482,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.91,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e493bb7c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e493bb7c",
+        "query": "Where is the painting 'Ethereal Dreams' by Emma Taylor currently hanging?",
+        "n_history_turns": 506,
+        "n_saved_records": 506,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "618f13b2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.8,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "618f13b2",
+        "query": "How many times have I worn my new black Converse Chuck Taylor All Star sneakers?",
+        "n_history_turns": 506,
+        "n_saved_records": 506,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.8,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "72e3ee87",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.67,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "72e3ee87",
+        "query": "How many episodes of the Science series have I completed on Crash Course?",
+        "n_history_turns": 496,
+        "n_saved_records": 496,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.67,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c4ea545c",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 0.78,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c4ea545c",
+        "query": "Do I go to the gym more frequently than I did previously?",
+        "n_history_turns": 490,
+        "n_saved_records": 490,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.78,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "01493427",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.69,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "01493427",
+        "query": "How many new postcards have I added to my collection since I started collecting again?",
+        "n_history_turns": 487,
+        "n_saved_records": 487,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.69,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6a27ffc2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6a27ffc2",
+        "query": "How many videos of Corey Schafer's Python programming series have I completed so far?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2133c1b5",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.45,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2133c1b5",
+        "query": "How long have I been living in my current apartment in Harajuku?",
+        "n_history_turns": 523,
+        "n_saved_records": 523,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.45,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "18bc8abd",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.5,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "18bc8abd",
+        "query": "What brand of BBQ sauce am I currently obsessed with?",
+        "n_history_turns": 436,
+        "n_saved_records": 436,
+        "n_retrieved": 4,
+        "retrieval_ms": 0.5,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "db467c8c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "db467c8c",
+        "query": "How long have my parents been staying with me in the US?",
+        "n_history_turns": 475,
+        "n_saved_records": 475,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "7a87bd0c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.32,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "7a87bd0c",
+        "query": "How long have I been sticking to my daily tidying routine?",
+        "n_history_turns": 506,
+        "n_saved_records": 506,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.32,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e61a7584",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.39,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e61a7584",
+        "query": "How long have I had my cat, Luna?",
+        "n_history_turns": 496,
+        "n_saved_records": 496,
+        "n_retrieved": 2,
+        "retrieval_ms": 0.39,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1cea1afa",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.81,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1cea1afa",
+        "query": "How many Instagram followers do I currently have?",
+        "n_history_turns": 485,
+        "n_saved_records": 485,
+        "n_retrieved": 3,
+        "retrieval_ms": 0.81,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "ed4ddc30",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.39,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "ed4ddc30",
+        "query": "How many dozen eggs do we currently have stocked up in our refrigerator?",
+        "n_history_turns": 543,
+        "n_saved_records": 543,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.39,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8fb83627",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.45,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8fb83627",
+        "query": "How many issues of National Geographic have I finished reading?",
+        "n_history_turns": 485,
+        "n_saved_records": 485,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.45,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b01defab",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b01defab",
+        "query": "Did I finish reading 'The Nightingale' by Kristin Hannah?",
+        "n_history_turns": 503,
+        "n_saved_records": 503,
+        "n_retrieved": 3,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "22d2cb42",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.63,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "22d2cb42",
+        "query": "Where did I get my guitar serviced?",
+        "n_history_turns": 473,
+        "n_saved_records": 473,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.63,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0e4e4c46",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.44,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0e4e4c46",
+        "query": "What is my current highest score in Ticket to Ride?",
+        "n_history_turns": 481,
+        "n_saved_records": 481,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.44,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "4b24c848",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.42,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "4b24c848",
+        "query": "How many tops have I bought from H&M so far?",
+        "n_history_turns": 514,
+        "n_saved_records": 514,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.42,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "7e974930",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.43,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "7e974930",
+        "query": "How much did I earn at the Downtown Farmers Market on my most recent visit?",
+        "n_history_turns": 502,
+        "n_saved_records": 502,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.43,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "603deb26",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.23,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "603deb26",
+        "query": "How many times have I tried making a Negroni at home since my friend Emma showed me how to make it?",
+        "n_history_turns": 472,
+        "n_saved_records": 472,
+        "n_retrieved": 9,
+        "retrieval_ms": 1.23,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "59524333",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.47,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "59524333",
+        "query": "What time do I usually go to the gym?",
+        "n_history_turns": 528,
+        "n_saved_records": 528,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.47,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "5831f84d",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.75,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "5831f84d",
+        "query": "How many Crash Course videos have I watched in the past few weeks?",
+        "n_history_turns": 422,
+        "n_saved_records": 422,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.75,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "eace081b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.58,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "eace081b",
+        "query": "Where am I planning to stay for my birthday trip to Hawaii?",
+        "n_history_turns": 489,
+        "n_saved_records": 489,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.58,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "affe2881",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.67,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "affe2881",
+        "query": "How many different species of birds have I seen in my local park?",
+        "n_history_turns": 484,
+        "n_saved_records": 481,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.67,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "50635ada",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.65,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "50635ada",
+        "query": "What was my previous frequent flyer status on United Airlines before I got the current status?",
+        "n_history_turns": 531,
+        "n_saved_records": 531,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.65,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e66b632c",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.97,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e66b632c",
+        "query": "What was my previous personal best time for the charity 5K run?",
+        "n_history_turns": 506,
+        "n_saved_records": 506,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.97,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0ddfec37",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.71,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0ddfec37",
+        "query": "How many autographed baseballs have I added to my collection in the first three months of collection?",
+        "n_history_turns": 483,
+        "n_saved_records": 483,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.71,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "f685340e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.47,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "f685340e",
+        "query": "How often do I play tennis with my friends at the local park previously? How often do I play now?",
+        "n_history_turns": 424,
+        "n_saved_records": 424,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.47,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "cc5ded98",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.86,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "cc5ded98",
+        "query": "How much time do I dedicate to coding exercises each day?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.86,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "dfde3500",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.74,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "dfde3500",
+        "query": "What day of the week did I meet with my previous language exchange tutor Juan?",
+        "n_history_turns": 480,
+        "n_saved_records": 480,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.74,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "69fee5aa",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.68,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "69fee5aa",
+        "query": "How many pre-1920 American coins do I have in my collection?",
+        "n_history_turns": 483,
+        "n_saved_records": 483,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.68,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "7401057b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.3,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "7401057b",
+        "query": "How many free night's stays can I redeem at any Hilton property with my accumulated points?",
+        "n_history_turns": 446,
+        "n_saved_records": 446,
+        "n_retrieved": 9,
+        "retrieval_ms": 1.3,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "cf22b7bf",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.72,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "cf22b7bf",
+        "query": "How much weight have I lost since I started going to the gym consistently?",
+        "n_history_turns": 550,
+        "n_saved_records": 550,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.72,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a2f3aa27",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.32,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a2f3aa27",
+        "query": "How many followers do I have on Instagram now?",
+        "n_history_turns": 448,
+        "n_saved_records": 448,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.32,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c7dc5443",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.44,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c7dc5443",
+        "query": "What is my current record in the recreational volleyball league?",
+        "n_history_turns": 478,
+        "n_saved_records": 478,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.44,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "06db6396",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.61,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "06db6396",
+        "query": "How many projects have I completed since starting painting classes?",
+        "n_history_turns": 479,
+        "n_saved_records": 479,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.61,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "3ba21379",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.48,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "3ba21379",
+        "query": "What type of vehicle model am I currently working on?",
+        "n_history_turns": 431,
+        "n_saved_records": 431,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.48,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "9bbe84a2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.61,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "9bbe84a2",
+        "query": "What was my previous goal for my Apex Legends level before I updated my goal?",
+        "n_history_turns": 459,
+        "n_saved_records": 459,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.61,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "10e09553",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.77,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "10e09553",
+        "query": "How many largemouth bass did I catch with Alex on the earlier fishing trip to Lake Michigan before the 7/22 trip?",
+        "n_history_turns": 472,
+        "n_saved_records": 472,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.77,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "dad224aa",
+      "recall_at_1": 0.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.5,
+      "retrieval_ms": 1.81,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "dad224aa",
+        "query": "What time do I wake up on Saturday mornings?",
+        "n_history_turns": 521,
+        "n_saved_records": 521,
+        "n_retrieved": 4,
+        "retrieval_ms": 1.81,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "ba61f0b9",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.49,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "ba61f0b9",
+        "query": "How many women are on the team led by my former manager Rachel?",
+        "n_history_turns": 454,
+        "n_saved_records": 454,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.49,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "42ec0761",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.31,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "42ec0761",
+        "query": "Do I have a spare screwdriver for opening up my laptop?",
+        "n_history_turns": 521,
+        "n_saved_records": 521,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.31,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "5c40ec5b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.44,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "5c40ec5b",
+        "query": "How many times have I met up with Alex from Germany?",
+        "n_history_turns": 479,
+        "n_saved_records": 479,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.44,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c6853660",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.55,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c6853660",
+        "query": "Did I mostly recently increase or decrease the limit on the number of cups of coffee in the morning?",
+        "n_history_turns": 477,
+        "n_saved_records": 477,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.55,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "26bdc477",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.5,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "26bdc477",
+        "query": "How many trips have I taken my Canon EOS 80D camera on?",
+        "n_history_turns": 498,
+        "n_saved_records": 498,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.5,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0977f2af",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.46,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0977f2af",
+        "query": "What new kitchen gadget did I invest in before getting the Air Fryer?",
+        "n_history_turns": 484,
+        "n_saved_records": 484,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.46,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6aeb4375_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.46,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6aeb4375_abs",
+        "query": "How many Italian restaurants have I tried in my city?",
+        "n_history_turns": 521,
+        "n_saved_records": 521,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.46,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "031748ae_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.85,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "031748ae_abs",
+        "query": "How many engineers do I lead when I just started my new role as Software Engineer Manager?",
+        "n_history_turns": 523,
+        "n_saved_records": 523,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.85,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2698e78f_abs",
+      "recall_at_1": 0.0,
+      "recall_at_5": 0.0,
+      "recall_at_10": 0.0,
+      "mrr": 0.0,
+      "retrieval_ms": 0.35,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2698e78f_abs",
+        "query": "How often do I see Dr. Johnson?",
+        "n_history_turns": 462,
+        "n_saved_records": 462,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.35,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2133c1b5_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.33,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2133c1b5_abs",
+        "query": "How long have I been living in my current apartment in Shinjuku?",
+        "n_history_turns": 476,
+        "n_saved_records": 476,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.33,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0ddfec37_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.62,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0ddfec37_abs",
+        "query": "How many autographed football have I added to my collection in the first three months of collection?",
+        "n_history_turns": 447,
+        "n_saved_records": 447,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.62,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "f685340e_abs",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.68,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "f685340e_abs",
+        "query": "How often do I play table tennis with my friends at the local park?",
+        "n_history_turns": 456,
+        "n_saved_records": 456,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.68,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "89941a94",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.91,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "89941a94",
+        "query": "Before I purchased the gravel bike, do I have other bikes in addition to my mountain bike and my commuter bike?",
+        "n_history_turns": 523,
+        "n_saved_records": 523,
+        "n_retrieved": 5,
+        "retrieval_ms": 0.91,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "07741c45",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.65,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "07741c45",
+        "query": "Where do I currently keep my old sneakers?",
+        "n_history_turns": 527,
+        "n_saved_records": 527,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.65,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "7161e7e2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.53,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "7161e7e2",
+        "query": "I'm checking our previous chat about the shift rotation sheet for GM social media agents. Can you remind me what was the rotation for Admon on a Sunday?",
+        "n_history_turns": 550,
+        "n_saved_records": 550,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.53,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c4f10528",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.94,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c4f10528",
+        "query": "I'm planning to visit Bandung again and I was wondering if you could remind me of the name of that restaurant in Cihampelas Walk that serves a great Nasi Goreng?",
+        "n_history_turns": 485,
+        "n_saved_records": 485,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.94,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "89527b6b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.77,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "89527b6b",
+        "query": "I'm going back to our previous conversation about the children's book on dinosaurs. Can you remind me what color was the scaly body of the Plesiosaur in the image?",
+        "n_history_turns": 467,
+        "n_saved_records": 467,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.77,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e9327a54",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.85,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e9327a54",
+        "query": "I'm planning to revisit Orlando. I was wondering if you could remind me of that unique dessert shop with the giant milkshakes we talked about last time?",
+        "n_history_turns": 533,
+        "n_saved_records": 533,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.85,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "4c36ccef",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.39,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "4c36ccef",
+        "query": "Can you remind me of the name of the romantic Italian restaurant in Rome you recommended for dinner?",
+        "n_history_turns": 521,
+        "n_saved_records": 521,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.39,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6ae235be",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.92,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6ae235be",
+        "query": "I remember you told me about the refining processes at CITGO's three refineries earlier. Can you remind me what kind of processes are used at the Lake Charles Refinery?",
+        "n_history_turns": 454,
+        "n_saved_records": 454,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.92,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "7e00a6cb",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.88,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "7e00a6cb",
+        "query": "I'm planning my trip to Amsterdam again and I was wondering, what was the name of that hostel near the Red Light District that you recommended last time?",
+        "n_history_turns": 564,
+        "n_saved_records": 564,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.88,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1903aded",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.96,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1903aded",
+        "query": "I think we discussed work from home jobs for seniors earlier. Can you remind me what was the 7th job in the list you provided?",
+        "n_history_turns": 486,
+        "n_saved_records": 486,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.96,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "ceb54acb",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.22,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "ceb54acb",
+        "query": "In our previous chat, you suggested 'sexual compulsions' and a few other options for alternative terms for certain behaviors. Can you remind me what the other four options were?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 15,
+        "retrieval_ms": 1.22,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "f523d9fe",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.61,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "f523d9fe",
+        "query": "I wanted to check back on our previous conversation about Netflix. I mentioned that I wanted to be able to access all seasons of old shows? Do you remember what show I used as an example, the one that only had the last season available?",
+        "n_history_turns": 484,
+        "n_saved_records": 484,
+        "n_retrieved": 10,
+        "retrieval_ms": 1.61,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "0e5e2d1a",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.8,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "0e5e2d1a",
+        "query": "I wanted to follow up on our previous conversation about binaural beats for anxiety and depression. Can you remind me how many subjects were in the study published in the journal Music and Medicine that found significant reductions in symptoms of depression, anxiety, and stress?",
+        "n_history_turns": 450,
+        "n_saved_records": 450,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.8,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "fea54f57",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.02,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "fea54f57",
+        "query": "I was thinking about our previous conversation about the Fifth Album, and I was wondering if you could remind me what song you said best exemplified the band's growth and development as artists?",
+        "n_history_turns": 527,
+        "n_saved_records": 527,
+        "n_retrieved": 11,
+        "retrieval_ms": 1.02,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "cc539528",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.12,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "cc539528",
+        "query": "I wanted to follow up on our previous conversation about front-end and back-end development. Can you remind me of the specific back-end programming languages you recommended I learn?",
+        "n_history_turns": 496,
+        "n_saved_records": 496,
+        "n_retrieved": 9,
+        "retrieval_ms": 1.12,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "dc439ea3",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.75,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "dc439ea3",
+        "query": "I was looking back at our previous conversation about Native American powwows and I was wondering, which traditional game did you say was often performed by skilled dancers at powwows?",
+        "n_history_turns": 476,
+        "n_saved_records": 476,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.75,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "18dcd5a5",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.04,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "18dcd5a5",
+        "query": "I'm going back to our previous chat about the Lost Temple of the Djinn one-shot. Can you remind me how many mummies the party will face in the temple?",
+        "n_history_turns": 503,
+        "n_saved_records": 503,
+        "n_retrieved": 11,
+        "retrieval_ms": 1.04,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "488d3006",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.76,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "488d3006",
+        "query": "I'm planning to go back to the Natural Park of Moncayo mountain in Arag\u00f3n and I was wondering, what was the name of that hiking trail you recommended that takes you through the park's most stunning landscapes and offers panoramic views of the surrounding mountainside?",
+        "n_history_turns": 509,
+        "n_saved_records": 509,
+        "n_retrieved": 6,
+        "retrieval_ms": 1.76,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "58470ed2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.51,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "58470ed2",
+        "query": "I was going through our previous conversation about The Library of Babel, and I wanted to confirm - what did Borges say about the center and circumference of the Library?",
+        "n_history_turns": 471,
+        "n_saved_records": 471,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.51,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8cf51dda",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.62,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8cf51dda",
+        "query": "I'm going back to our previous conversation about the grant aim page on molecular subtypes and endometrial cancer. Can you remind me what were the three objectives we outlined for the project?",
+        "n_history_turns": 454,
+        "n_saved_records": 454,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.62,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1d4da289",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.98,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1d4da289",
+        "query": "I was thinking about our previous conversation about data privacy and security. You mentioned that companies use two-factor authentication to enhance security. Can you remind me what kind of two-factor authentication methods you were referring to?",
+        "n_history_turns": 506,
+        "n_saved_records": 506,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.98,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8464fc84",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.73,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8464fc84",
+        "query": "I'm planning to visit the Vatican again and I was wondering if you could remind me of the name of that famous deli near the Vatican that serves the best cured meats and cheeses?",
+        "n_history_turns": 484,
+        "n_saved_records": 484,
+        "n_retrieved": 14,
+        "retrieval_ms": 0.73,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8aef76bc",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.03,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8aef76bc",
+        "query": "I'm going back to our previous conversation about DIY home decor projects using recycled materials. Can you remind me what sealant you recommended for the newspaper flower vase?",
+        "n_history_turns": 492,
+        "n_saved_records": 492,
+        "n_retrieved": 11,
+        "retrieval_ms": 1.03,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "71a3fd6b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "71a3fd6b",
+        "query": "I'm planning my trip to Speyer again and I wanted to confirm, what's the phone number of the Speyer tourism board that you provided me earlier?",
+        "n_history_turns": 439,
+        "n_saved_records": 439,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "2bf43736",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.83,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "2bf43736",
+        "query": "I was going through our previous chat and I wanted to clarify something about the prayer of beginners in Tanqueray's Spiritual Life treatise. Can you remind me which chapter of the second part discusses vocal prayer and meditation?",
+        "n_history_turns": 478,
+        "n_saved_records": 478,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.83,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "70b3e69b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.23,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "70b3e69b",
+        "query": "I was going through our previous conversation about the impact of the political climate in Catalonia on its literature and music. Can you remind me of the example you gave of a Spanish-Catalan singer-songwriter who supports unity between Catalonia and Spain?",
+        "n_history_turns": 495,
+        "n_saved_records": 495,
+        "n_retrieved": 6,
+        "retrieval_ms": 1.23,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8752c811",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.56,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8752c811",
+        "query": "I remember you provided a list of 100 prompt parameters that I can specify to influence your output. Can you remind me what was the 27th parameter on that list?",
+        "n_history_turns": 493,
+        "n_saved_records": 493,
+        "n_retrieved": 16,
+        "retrieval_ms": 1.56,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "3249768e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.3,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "3249768e",
+        "query": "I'm looking back at our previous conversation about building a cocktail bar. You recommended five bottles to make the widest variety of gin-based cocktails. Can you remind me what the fifth bottle was?",
+        "n_history_turns": 475,
+        "n_saved_records": 475,
+        "n_retrieved": 9,
+        "retrieval_ms": 1.3,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1b9b7252",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.57,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1b9b7252",
+        "query": "I wanted to follow up on our previous conversation about mindfulness techniques. You mentioned some great resources for guided imagery exercises, can you remind me of the website that had free exercises like 'The Mountain Meditation' and 'The Body Scan Meditation'?",
+        "n_history_turns": 466,
+        "n_saved_records": 466,
+        "n_retrieved": 9,
+        "retrieval_ms": 1.57,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1568498a",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.74,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1568498a",
+        "query": "I'm looking back at our previous chess game and I was wondering, what was the move you made after 27. Kg2 Bd5+?",
+        "n_history_turns": 478,
+        "n_saved_records": 478,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.74,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "6222b6eb",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.4,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "6222b6eb",
+        "query": "I was going through our previous conversation about atmospheric correction methods, and I wanted to confirm - you mentioned that 6S, MAJA, and Sen2Cor are all algorithms for atmospheric correction of remote sensing images. Can you remind me which one is implemented in the SIAC_GEE tool?",
+        "n_history_turns": 497,
+        "n_saved_records": 497,
+        "n_retrieved": 11,
+        "retrieval_ms": 1.4,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e8a79c70",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.46,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e8a79c70",
+        "query": "I was going through our previous conversation about making a classic French omelette, and I wanted to confirm - how many eggs did you say we need for the recipe?",
+        "n_history_turns": 483,
+        "n_saved_records": 483,
+        "n_retrieved": 10,
+        "retrieval_ms": 1.46,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "d596882b",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.1,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "d596882b",
+        "query": "I'm planning another trip to New York City and I was wondering if you could remind me of that vegan eatery you recommended last time, the one with multiple locations throughout the city?",
+        "n_history_turns": 474,
+        "n_saved_records": 474,
+        "n_retrieved": 10,
+        "retrieval_ms": 1.1,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e3fc4d6e",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.54,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e3fc4d6e",
+        "query": "I wanted to follow up on our previous conversation about the fusion breakthrough at Lawrence Livermore National Laboratory. Can you remind me who is the President's Chief Advisor for Science and Technology mentioned in the article?",
+        "n_history_turns": 519,
+        "n_saved_records": 519,
+        "n_retrieved": 13,
+        "retrieval_ms": 0.54,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "51b23612",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.87,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "51b23612",
+        "query": "I was going through our previous conversation about political propaganda and humor, and I was wondering if you could remind me of that Soviet cartoon you mentioned that mocked Western culture?",
+        "n_history_turns": 481,
+        "n_saved_records": 481,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.87,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "3e321797",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.06,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "3e321797",
+        "query": "I wanted to follow up on our previous conversation about natural remedies for dark circles under the eyes. You mentioned applying tomato juice mixed with lemon juice, how long did you say I should leave it on for?",
+        "n_history_turns": 490,
+        "n_saved_records": 490,
+        "n_retrieved": 9,
+        "retrieval_ms": 1.06,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e982271f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.18,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e982271f",
+        "query": "I was going through our previous chat. Can you remind me of the name of the last venue you recommended in the list of popular venues in Portland for indie music shows?",
+        "n_history_turns": 589,
+        "n_saved_records": 589,
+        "n_retrieved": 9,
+        "retrieval_ms": 1.18,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "352ab8bd",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.09,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "352ab8bd",
+        "query": "Can you remind me what was the average improvement in framerate when using the Hardware-Aware Modular Training (HAMT) agent in the 'To Adapt or Not to Adapt? Real-Time Adaptation for Semantic Segmentation' submission?",
+        "n_history_turns": 539,
+        "n_saved_records": 539,
+        "n_retrieved": 10,
+        "retrieval_ms": 1.09,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "fca762bc",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.23,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "fca762bc",
+        "query": "I wanted to follow up on our previous conversation about language learning apps. You mentioned a few options, and I was wondering if you could remind me of the one that uses mnemonics to help learners memorize words and phrases?",
+        "n_history_turns": 459,
+        "n_saved_records": 459,
+        "n_retrieved": 11,
+        "retrieval_ms": 1.23,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "7a8d0b71",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.51,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "7a8d0b71",
+        "query": "I'm looking back at our previous chat about the DHL Wellness Retreats campaign. Can you remind me how much was allocated for influencer marketing in the campaign plan?",
+        "n_history_turns": 489,
+        "n_saved_records": 489,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.51,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "a40e080f",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.43,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "a40e080f",
+        "query": "I was going through our previous conversation and I was wondering if you could remind me of the two companies you mentioned that prioritize employee safety and well-being like Triumvirate?",
+        "n_history_turns": 529,
+        "n_saved_records": 529,
+        "n_retrieved": 10,
+        "retrieval_ms": 1.43,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "8b9d4367",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.75,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "8b9d4367",
+        "query": "I wanted to follow up on our previous conversation about private sector businesses in Chaudhary. Can you remind me of the company that employs over 40,000 people in the rug-manufacturing industry?",
+        "n_history_turns": 537,
+        "n_saved_records": 537,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.75,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "5809eb10",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.65,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "5809eb10",
+        "query": "I'm looking back at our previous conversation about the Bajimaya v Reward Homes Pty Ltd case. Can you remind me what year the construction of the house began?",
+        "n_history_turns": 606,
+        "n_saved_records": 606,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.65,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "41275add",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.59,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "41275add",
+        "query": "I wanted to follow up on our previous conversation about YouTube videos for workplace posture. Can you remind me of the Mayo Clinic video you recommended?",
+        "n_history_turns": 531,
+        "n_saved_records": 530,
+        "n_retrieved": 9,
+        "retrieval_ms": 0.59,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "4388e9dd",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.64,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "4388e9dd",
+        "query": "I was going through our previous chat and I was wondering, what was Andy wearing in the script you wrote for the comedy movie scene?",
+        "n_history_turns": 477,
+        "n_saved_records": 477,
+        "n_retrieved": 12,
+        "retrieval_ms": 0.64,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "4baee567",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.76,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "4baee567",
+        "query": "I was looking back at our previous chat and I wanted to confirm, how many times did the Chiefs play the Jaguars at Arrowhead Stadium?",
+        "n_history_turns": 514,
+        "n_saved_records": 514,
+        "n_retrieved": 10,
+        "retrieval_ms": 0.76,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "561fabcd",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.58,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "561fabcd",
+        "query": "I was thinking back to our previous conversation about the Radiation Amplified zombie, and I was wondering if you remembered what we finally decided to name it?",
+        "n_history_turns": 495,
+        "n_saved_records": 495,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.58,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "b759caee",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.38,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "b759caee",
+        "query": "I was looking back at our previous conversation about buying unique engagement rings directly from designers. Can you remind me of the Instagram handle of the UK-based designer who works with unusual gemstones?",
+        "n_history_turns": 516,
+        "n_saved_records": 516,
+        "n_retrieved": 10,
+        "retrieval_ms": 1.38,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "ac031881",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.75,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "ac031881",
+        "query": "I'm trying to recall what the designation on my jumpsuit was that helped me find the file number in the records room?",
+        "n_history_turns": 529,
+        "n_saved_records": 529,
+        "n_retrieved": 3,
+        "retrieval_ms": 0.75,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "28bcfaac",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.73,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "28bcfaac",
+        "query": "I'm going back to our previous conversation about music theory. You mentioned some online resources for learning music theory. Can you remind me of the website you recommended for free lessons and exercises?",
+        "n_history_turns": 500,
+        "n_saved_records": 500,
+        "n_retrieved": 11,
+        "retrieval_ms": 1.73,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "16c90bf4",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.95,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "16c90bf4",
+        "query": "I'm looking back at our previous conversation about the Seco de Cordero recipe from Ancash. You mentioned using a light or medium-bodied beer, but I was wondering if you could remind me what type of beer you specifically recommended?",
+        "n_history_turns": 509,
+        "n_saved_records": 509,
+        "n_retrieved": 11,
+        "retrieval_ms": 1.95,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c8f1aeed",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.75,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c8f1aeed",
+        "query": "I wanted to follow up on our previous conversation about fracking in the Marcellus Shale region. You mentioned that some states require fracking companies to monitor groundwater quality at nearby wells before drilling and for a certain period after drilling is complete. Can you remind me which state you mentioned as an example that has this requirement?",
+        "n_history_turns": 504,
+        "n_saved_records": 504,
+        "n_retrieved": 12,
+        "retrieval_ms": 1.75,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "eaca4986",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.88,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "eaca4986",
+        "query": "I'm looking back at our previous conversation where you created two sad songs for me. Can you remind me what was the chord progression for the chorus in the second song?",
+        "n_history_turns": 513,
+        "n_saved_records": 513,
+        "n_retrieved": 11,
+        "retrieval_ms": 0.88,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "c7cf7dfd",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.84,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "c7cf7dfd",
+        "query": "I'm going back to our previous conversation about traditional Indian embroidery and tailoring techniques. Can you remind me of the name of that online store based in India that sells traditional Indian fabrics, threads, and embellishments?",
+        "n_history_turns": 520,
+        "n_saved_records": 520,
+        "n_retrieved": 6,
+        "retrieval_ms": 1.84,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "e48988bc",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 1.19,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "e48988bc",
+        "query": "I was looking back at our previous conversation about environmentally responsible supply chain practices, and I was wondering if you could remind me of the company you mentioned that's doing a great job with sustainability?",
+        "n_history_turns": 530,
+        "n_saved_records": 530,
+        "n_retrieved": 12,
+        "retrieval_ms": 1.19,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "1de5cff2",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.94,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "1de5cff2",
+        "query": "I was going through our previous conversation about high-end fashion brands, and I was wondering if you could remind me of the brand that uses wild rubber sourced from the Amazon rainforest?",
+        "n_history_turns": 473,
+        "n_saved_records": 473,
+        "n_retrieved": 8,
+        "retrieval_ms": 0.94,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "65240037",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.74,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "65240037",
+        "query": "I remember you told me to dilute tea tree oil with a carrier oil before applying it to my skin. Can you remind me what the recommended ratio is?",
+        "n_history_turns": 489,
+        "n_saved_records": 489,
+        "n_retrieved": 6,
+        "retrieval_ms": 0.74,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    },
+    {
+      "item_id": "778164c6",
+      "recall_at_1": 1.0,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 1.0,
+      "retrieval_ms": 0.73,
+      "status": "ok",
+      "error": "",
+      "metadata": {
+        "item_id": "778164c6",
+        "query": "I was looking back at our previous conversation about Caribbean dishes and I was wondering, what was the name of that Jamaican dish you recommended I try with snapper that has fruit in it?",
+        "n_history_turns": 542,
+        "n_saved_records": 542,
+        "n_retrieved": 7,
+        "retrieval_ms": 0.73,
+        "dataset": "longmemeval-s",
+        "retrieval_method": "bm25"
+      }
+    }
+  ]
+}

--- a/tests/benchmarks/results/external/longmemeval_s_20260629.md
+++ b/tests/benchmarks/results/external/longmemeval_s_20260629.md
@@ -1,0 +1,32 @@
+# Popoto External Benchmark: longmemeval-s
+
+**Run date:** 2026-06-29  
+**Python:** 3.12.13  
+**Platform:** macOS-26.3.1-arm64-arm-64bit  
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Questions evaluated | 500 / 500 |
+| Errors | 0 |
+| Skipped | 0 |
+| Recall@1 | 0.8560 |
+| Recall@5 | 0.9520 |
+| Recall@10 | 0.9780 |
+| MRR | 0.8987 |
+| Latency p50 (ms) | 0.57 |
+| Latency p95 (ms) | 1.46 |
+
+## Notes
+
+- Baseline run: relevance-only scoring (DecayingSortedField).
+- No vector/embedding retrieval wired in (BM25-style baseline).
+- LoCoMo: image-only turns skipped (text-only evaluation).
+
+## Reference Numbers
+
+agentmemory BM25+Vector (all-MiniLM-L6-v2) on LongMemEval-S:
+- Recall@5: 95.2%, Recall@10: 98.6%, MRR: 88.2%
+
+Popoto baseline is score-only (no embedding retrieval). Issue #395 will add hybrid BM25+vector retrieval to close this gap.

--- a/tests/benchmarks/results/external/longmemeval_s_latest.json
+++ b/tests/benchmarks/results/external/longmemeval_s_latest.json
@@ -1,1 +1,1 @@
-longmemeval_s_20260522.json
+longmemeval_s_20260629.json

--- a/tests/benchmarks/results/external/longmemeval_s_latest.md
+++ b/tests/benchmarks/results/external/longmemeval_s_latest.md
@@ -1,1 +1,1 @@
-longmemeval_s_20260522.md
+longmemeval_s_20260629.md

--- a/tests/benchmarks/test_external.py
+++ b/tests/benchmarks/test_external.py
@@ -13,7 +13,11 @@ from pathlib import Path
 from tests.benchmarks.datasets import BenchmarkItem
 from tests.benchmarks.datasets.longmemeval_s import iter_items as iter_longmemeval
 from tests.benchmarks.datasets.locomo import iter_items as iter_locomo
-from tests.benchmarks.metrics.retrieval import recall_at_k
+from tests.benchmarks.metrics.retrieval import (
+    fractional_recall_at_k,
+    mean_reciprocal_rank,
+    recall_at_k,
+)
 
 FIXTURES_DIR = Path(__file__).parent / "datasets" / "fixtures"
 LME_FIXTURE = FIXTURES_DIR / "longmemeval_s_sample.json"
@@ -62,24 +66,91 @@ class TestRecallAtK:
         assert recall_at_k(["a", "b"], {"a"}, k=-1) == 0.0
 
     def test_multiple_relevant_all_found(self):
-        """Multiple relevant items, all in top-k — 1.0."""
+        """Multiple relevant items, all in top-k — any-hit 1.0."""
         assert recall_at_k(["a", "b", "c"], {"a", "b"}, k=5) == 1.0
 
-    def test_multiple_relevant_partial(self):
-        """Multiple relevant items, half in top-k — 0.5."""
-        result = recall_at_k(["a", "x", "y"], {"a", "b"}, k=3)
-        assert result == pytest.approx(0.5)
+    def test_multiple_relevant_partial_is_any_hit(self):
+        """Multiple relevant items, only one in top-k — any-hit is 1.0.
+
+        Regression guard for issue #433: under the corrected any-hit
+        definition, finding ANY relevant item scores 1.0 (not the fractional
+        0.5). Fractional behavior now lives in fractional_recall_at_k.
+        """
+        assert recall_at_k(["a", "x", "y"], {"a", "b"}, k=3) == 1.0
 
     def test_single_item_boundary(self):
         """Exactly k items in retrieved, relevant is the last one."""
         assert recall_at_k(["x", "y", "z", "a"], {"a"}, k=4) == 1.0
         assert recall_at_k(["x", "y", "z", "a"], {"a"}, k=3) == 0.0
 
-    def test_caps_at_1_for_single_relevant(self):
-        """With a single relevant item, recall@k cannot exceed 1.0."""
-        result = recall_at_k(["a", "b", "c"], {"a"}, k=10)
-        assert result <= 1.0
-        assert result == 1.0
+    def test_returns_only_zero_or_one(self):
+        """Any-hit recall is binary: never a fraction (issue #433)."""
+        assert recall_at_k(["a", "b", "c"], {"a"}, k=10) == 1.0
+        assert recall_at_k(["x", "y", "z"], {"a"}, k=10) == 0.0
+        assert recall_at_k(["a", "x"], {"a", "b", "c"}, k=5) == 1.0
+
+    def test_multi_evidence_rank1_hit_is_one(self):
+        """Multi-evidence ground truth, rank-1 hit — recall@1 == 1.0.
+
+        The core of issue #433: a top-1 hit on a question with multiple
+        evidence sessions must score 1.0, not 1/|relevant|.
+        """
+        assert recall_at_k(["a", "x", "y"], {"a", "b", "c"}, k=1) == 1.0
+
+    def test_mrr_le_recall_invariant(self):
+        """MRR <= any-hit recall over the full list must always hold (#433).
+
+        MRR is bounded above by any-hit recall: a first-relevant item at rank
+        r contributes 1/r <= 1 to MRR but a full 1.0 to any-hit recall once k
+        reaches r. The universal per-query bound is therefore against recall
+        evaluated over the entire ranked list. (For a fixed small k whose
+        window ends before the first hit, R@k can legitimately be 0 while
+        MRR > 0 — that is not a violation.) This invariant is the guard whose
+        aggregate failure (MRR 0.899 > R@5 0.888) exposed the original bug.
+        """
+        cases = [
+            (["a", "b", "c"], {"a"}),
+            (["x", "a", "y"], {"a", "b"}),
+            (["x", "y", "z", "a"], {"a", "c"}),
+            (["x", "y", "z"], {"a"}),  # miss: both 0.0
+            (["a", "b"], {"a", "b"}),
+        ]
+        for retrieved, relevant in cases:
+            mrr = mean_reciprocal_rank(retrieved, relevant)
+            any_hit = recall_at_k(retrieved, relevant, len(retrieved))
+            assert mrr <= any_hit + 1e-9, (
+                f"MRR {mrr} > any-hit recall {any_hit} " f"for {retrieved} / {relevant}"
+            )
+            # When the first hit is within the window, R@k == 1.0 >= MRR.
+            for k in (1, 5, 10):
+                if recall_at_k(retrieved, relevant, k) == 1.0:
+                    assert mrr <= 1.0
+
+
+class TestFractionalRecallAtK:
+    """Unit tests for the retained fractional_recall_at_k helper (issue #433)."""
+
+    def test_partial_is_fraction(self):
+        """One of two relevant items in top-k — fractional 0.5."""
+        assert fractional_recall_at_k(
+            ["a", "x", "y"], {"a", "b"}, k=3
+        ) == pytest.approx(0.5)
+
+    def test_all_found_is_one(self):
+        """All relevant items found — 1.0."""
+        assert fractional_recall_at_k(["a", "b", "c"], {"a", "b"}, k=5) == 1.0
+
+    def test_rank1_hit_multi_evidence_is_fraction(self):
+        """Rank-1 hit on 3-evidence question — fractional 1/3 (contrast any-hit)."""
+        assert fractional_recall_at_k(
+            ["a", "x", "y"], {"a", "b", "c"}, k=1
+        ) == pytest.approx(1 / 3)
+
+    def test_edge_cases_zero(self):
+        """Empty / non-positive-k edge cases — 0.0."""
+        assert fractional_recall_at_k([], {"a"}, k=5) == 0.0
+        assert fractional_recall_at_k(["a"], set(), k=5) == 0.0
+        assert fractional_recall_at_k(["a"], {"a"}, k=0) == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -228,4 +299,6 @@ class TestLoCoMoAdapter:
         items = list(iter_locomo(fixture_path=LOCOMO_FIXTURE))
         for item in items:
             for turn in item.history:
-                assert turn["content"].strip(), f"Turn content should not be empty: {turn}"
+                assert turn[
+                    "content"
+                ].strip(), f"Turn content should not be empty: {turn}"


### PR DESCRIPTION
## Problem

The committed LongMemEval-S baseline reported an aggregate that is **mathematically impossible** under the any-hit recall definition the report claims to compute: `MRR (0.8987) > Recall@5 (0.8883)`. MRR is bounded above by any-hit recall, so `MRR > R@5` signals a metric-definition mismatch.

**Root cause:** `recall_at_k` returned **fractional** recall (`hits / len(relevant)`). LongMemEval-S has **multi-evidence** ground truth (a question may map to 2-6 evidence sessions), so a top-1 hit on a 2-evidence question scored `recall@1 = 1/2 = 0.5`, never 1.0 — deflating the aggregate (worst at k=1: 0.549 vs true 0.856). `mean_reciprocal_rank` was already correct; only the recall normalization was wrong.

The docstring ("equivalent to a hit-rate") and the report's embedded external reference (`agentmemory ... Recall@5: 95.2%`) both assume the **any-hit** definition.

## Fix

- `recall_at_k` now returns the **any-hit hit-rate** (`1.0` if any relevant item is in top-k, else `0.0`).
- Fractional recall retained as a separate, clearly named `fractional_recall_at_k` (per-evidence coverage analysis; not the headline metric).
- Regenerated the LongMemEval-S report against the corrected adapter (#436) + this metric.

## Regenerated numbers (500 questions, BM25 score-only)

| Metric | Before (fractional) | After (any-hit) | agentmemory ref |
|--------|--------------------:|----------------:|----------------:|
| Recall@1 | 0.549 | **0.856** | — |
| Recall@5 | 0.888 | **0.952** | 0.952 |
| Recall@10 | 0.937 | **0.978** | 0.986 |
| MRR | 0.899 | 0.899 | 0.882 |

R@5 now matches the agentmemory reference (95.2%) to the digit, and the invariant `MRR (0.899) ≤ R@5 (0.952)` holds.

## Tests

- `test_multiple_relevant_partial_is_any_hit` — any-hit `== 1.0` (was fractional 0.5)
- `test_multi_evidence_rank1_hit_is_one` — multi-evidence rank-1 hit `== 1.0`
- `test_returns_only_zero_or_one` — binary output
- `test_mrr_le_recall_invariant` — `MRR ≤ any-hit recall` guard (the property whose aggregate failure exposed the bug)
- `TestFractionalRecallAtK` — coverage for the retained fractional helper

`pytest tests/benchmarks/test_external.py` → 36 passed; `pytest tests/benchmarks/` → 222 passed.

## Verification

- [x] Headline `recall_at_k` returns any-hit (0.0/1.0), docstring matches
- [x] Fractional recall in a separate, clearly named function
- [x] Invariant test `MRR ≤ R@k`
- [x] Multi-evidence rank-1 hit ⇒ recall == 1.0
- [x] Report regenerated; `R@5 ≈ 0.952`, `MRR ≤ R@5` holds
- [x] LoCoMo inherits the fix via the shared metric path (adapter tracked in #434)

Plan: docs/plans/external_recall_at_k_any_hit.md

Closes #433