### PR TITLE
fix(#434): LoCoMo adapter parses real snap-research/locomo schema

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -20,7 +20,7 @@ the relevant memory given a natural-language query. It supports two datasets:
 | Dataset | Questions | Sessions | Notes |
 |---------|-----------|----------|-------|
 | **LongMemEval-S** | 500 | ~48 per question | Single ground-truth session per question |
-| **LoCoMo** | ~350 QA pairs | 50 dialogues | Text-only; image turns skipped |
+| **LoCoMo** | ~350 QA pairs | 50 dialogues | Multi-session dict schema; image turns ingested via BLIP caption so image-evidence stays retrievable |
 
 ### Metrics
 

--- a/tests/benchmarks/datasets/fixtures/locomo_sample.json
+++ b/tests/benchmarks/datasets/fixtures/locomo_sample.json
@@ -1,141 +1,133 @@
 [
   {
-    "dialogue_id": "locomo_001",
-    "conversation": [
-      {
-        "session": 1,
-        "turn_id": "t001",
-        "role": "speaker1",
-        "text": "I just got back from my hiking trip in Colorado. It was absolutely amazing!"
-      },
-      {
-        "session": 1,
-        "turn_id": "t002",
-        "role": "speaker2",
-        "text": "That sounds fantastic! How long were you there?"
-      },
-      {
-        "session": 1,
-        "turn_id": "t003",
-        "role": "speaker1",
-        "text": "About two weeks. We hiked fourteen mountains over 14,000 feet."
-      },
-      {
-        "session": 2,
-        "turn_id": "t004",
-        "role": "speaker1",
-        "text": "I started a new job at a tech startup last month."
-      },
-      {
-        "session": 2,
-        "turn_id": "t005",
-        "role": "speaker2",
-        "text": "Congrats! What kind of work do you do there?"
-      },
-      {
-        "session": 2,
-        "turn_id": "t006",
-        "role": "speaker1",
-        "text": "I'm a backend software engineer focusing on distributed systems."
-      },
-      {
-        "session": 3,
-        "turn_id": "t007",
-        "role": "speaker1",
-        "text": "My daughter started college this fall. She's studying marine biology."
-      },
-      {
-        "session": 3,
-        "turn_id": "t008",
-        "role": "speaker2",
-        "text": "That's wonderful! Does she want to work in conservation?"
-      },
-      {
-        "session": 3,
-        "turn_id": "t009",
-        "role": "speaker1",
-        "text": "Yes, she hopes to work with coral reef preservation someday."
-      }
-    ],
+    "sample_id": "conv-26",
+    "conversation": {
+      "speaker_a": "Caroline",
+      "speaker_b": "Melanie",
+      "session_1_date_time": "1:56 pm on 8 May, 2023",
+      "session_1": [
+        {
+          "speaker": "Caroline",
+          "dia_id": "D1:1",
+          "text": "I just got back from my hiking trip in Colorado. It was absolutely amazing!"
+        },
+        {
+          "speaker": "Melanie",
+          "dia_id": "D1:2",
+          "text": "That sounds fantastic! How long were you there?"
+        },
+        {
+          "speaker": "Caroline",
+          "dia_id": "D1:3",
+          "img_url": ["https://example.com/peak.jpg"],
+          "blip_caption": "a snow-capped mountain peak under a clear blue sky"
+        }
+      ],
+      "session_2_date_time": "10:13 am on 21 May, 2023",
+      "session_2": [
+        {
+          "speaker": "Caroline",
+          "dia_id": "D2:1",
+          "text": "I started a new job at a tech startup last month."
+        },
+        {
+          "speaker": "Melanie",
+          "dia_id": "D2:2",
+          "text": "Congrats! What kind of work do you do there?"
+        },
+        {
+          "speaker": "Caroline",
+          "dia_id": "D2:3",
+          "text": "I'm a backend software engineer focusing on distributed systems."
+        }
+      ]
+    },
     "qa": [
       {
-        "question": "Where did speaker1 go on their hiking trip?",
+        "question": "Where did Caroline go on her hiking trip?",
         "answer": "Colorado",
-        "evidence_turn_id": "t001",
-        "type": "factual"
+        "evidence": ["D1:1"],
+        "category": 2
       },
       {
-        "question": "What is speaker1's profession?",
+        "question": "What did the photo from the hiking trip show?",
+        "answer": "A snow-capped mountain peak",
+        "evidence": ["D1:3"],
+        "category": 2
+      },
+      {
+        "question": "What is Caroline's profession?",
         "answer": "Backend software engineer",
-        "evidence_turn_id": "t006",
-        "type": "factual"
+        "evidence": ["D2:3"],
+        "category": 2
       },
       {
-        "question": "What does speaker1's daughter study?",
-        "answer": "Marine biology",
-        "evidence_turn_id": "t007",
-        "type": "factual"
+        "question": "Did Caroline mention climbing Mount Everest?",
+        "adversarial_answer": "Not mentioned in the conversation.",
+        "category": 5
       }
     ]
   },
   {
-    "dialogue_id": "locomo_002",
-    "conversation": [
-      {
-        "session": 1,
-        "turn_id": "t101",
-        "role": "speaker1",
-        "text": "I've been taking piano lessons for the past year."
-      },
-      {
-        "session": 1,
-        "turn_id": "t102",
-        "role": "speaker2",
-        "text": "That's great! Have you played any pieces yet?"
-      },
-      {
-        "session": 1,
-        "turn_id": "t103",
-        "role": "speaker1",
-        "text": "I can play a few Chopin nocturnes now. It took a lot of practice."
-      },
-      {
-        "session": 2,
-        "turn_id": "t104",
-        "role": "speaker1",
-        "text": "I'm vegetarian and have been for the past five years."
-      },
-      {
-        "session": 2,
-        "turn_id": "t105",
-        "role": "speaker2",
-        "text": "Do you ever miss eating meat?"
-      },
-      {
-        "session": 2,
-        "turn_id": "t106",
-        "role": "speaker1",
-        "text": "Sometimes, but I feel much healthier now."
-      }
-    ],
+    "sample_id": "conv-31",
+    "conversation": {
+      "speaker_a": "John",
+      "speaker_b": "Aisha",
+      "session_1_date_time": "9:02 pm on 2 June, 2023",
+      "session_1": [
+        {
+          "speaker": "John",
+          "dia_id": "D1:1",
+          "text": "I've been taking piano lessons for the past year."
+        },
+        {
+          "speaker": "Aisha",
+          "dia_id": "D1:2",
+          "text": "That's great! Have you played any pieces yet?"
+        },
+        {
+          "speaker": "John",
+          "dia_id": "D1:3",
+          "text": "I can play a few Chopin nocturnes now. It took a lot of practice."
+        }
+      ],
+      "session_2_date_time": "7:45 am on 19 June, 2023",
+      "session_2": [
+        {
+          "speaker": "John",
+          "dia_id": "D2:1",
+          "text": "I'm vegetarian and have been for the past five years."
+        },
+        {
+          "speaker": "Aisha",
+          "dia_id": "D2:2",
+          "text": "Do you ever miss eating meat?"
+        },
+        {
+          "speaker": "John",
+          "dia_id": "D2:3",
+          "text": "Sometimes, but I feel much healthier now."
+        }
+      ]
+    },
     "qa": [
       {
-        "question": "What musical instrument does speaker1 play?",
+        "question": "What musical instrument does John play?",
         "answer": "Piano",
-        "evidence_turn_id": "t101",
-        "type": "factual"
+        "evidence": ["D1:1"],
+        "category": 2
       },
       {
-        "question": "What composer's pieces has speaker1 learned?",
+        "question": "Whose compositions has John learned to play?",
         "answer": "Chopin",
-        "evidence_turn_id": "t103",
-        "type": "factual"
+        "evidence": ["D1:3"],
+        "category": 2
       },
       {
-        "question": "What is speaker1's diet?",
+        "question": "What is John's diet?",
         "answer": "Vegetarian",
-        "evidence_turn_id": "t104",
-        "type": "factual"
+        "evidence": ["D2:1"],
+        "category": 2
       }
     ]
   }

--- a/tests/benchmarks/datasets/locomo.py
+++ b/tests/benchmarks/datasets/locomo.py
@@ -8,9 +8,10 @@ License: Public research use (see https://snap-research.github.io/locomo/)
 Size:    ~50 multi-session dialogues, ~600 turns/dialogue, ~16K tokens each
 
 LoCoMo is grounded question-answering over long multi-session dialogues.
-Each question is paired with a specific conversation segment as evidence.
-Only text turns are used (vision/image turns are skipped — Popoto does not
-support multimodal content).
+Each question is paired with one or more conversation turns as evidence
+(referenced by their ``dia_id``). Image turns are ingested via their
+``blip_caption`` so that evidence pointing at an image turn stays reachable;
+a turn is skipped only when it has neither ``text`` nor ``blip_caption``.
 
 Usage:
     from tests.benchmarks.datasets.locomo import iter_items
@@ -85,6 +86,7 @@ def _download_dataset() -> Path:
             downloaded_path = Path(downloaded)
             if downloaded_path != CACHED_FILE:
                 import shutil
+
                 shutil.copy2(downloaded_path, CACHED_FILE)
             logger.info("LoCoMo: downloaded to %s", CACHED_FILE)
             return CACHED_FILE
@@ -101,28 +103,38 @@ def _download_dataset() -> Path:
 
 
 def _parse_dialogue(dialogue: dict, dialogue_idx: int) -> list[BenchmarkItem]:
-    """Parse one LoCoMo dialogue into a list of BenchmarkItems (one per QA pair).
+    """Parse one LoCoMo sample into a list of BenchmarkItems (one per QA pair).
 
-    LoCoMo format (locomo10.json / locomo.json):
+    Real snap-research/locomo schema (locomo10.json) — ``conversation`` is a
+    DICT, not a list:
     [
         {
-            "dialogue_id": "...",
-            "conversation": [
-                {
-                    "session": 1,
-                    "turn_id": "...",   # may be int or str
-                    "role": "speaker1"|"speaker2",
-                    "text": "...",      # main text field
-                    "blip_caption": ... # image caption (skip if no text)
-                },
+            "sample_id": "...",
+            "conversation": {
+                "speaker_a": "<name>",
+                "speaker_b": "<name>",
+                "session_1_date_time": "...",
+                "session_1": [
+                    {
+                        "speaker": "<name>",       # speaker_a or speaker_b name
+                        "dia_id": "D1:11",         # canonical per-turn id
+                        "text": "...",             # main text (may be absent)
+                        "img_url": [...],          # optional, image turns
+                        "blip_caption": "..."      # optional, image caption
+                    },
+                    ...
+                ],
+                "session_2_date_time": "...",
+                "session_2": [ ... ],
                 ...
-            ],
+            },
             "qa": [
                 {
                     "question": "...",
-                    "answer": "...",
-                    "evidence_turn_id": "...",   # may be int, str, or list
-                    "type": "...",               # question type
+                    "answer": "...",               # adversarial uses
+                    "adversarial_answer": "...",   #   adversarial_answer instead
+                    "evidence": ["D1:11", ...],    # dia_ids (absent if adversarial)
+                    "category": 1                  # int question type
                 },
                 ...
             ]
@@ -130,15 +142,20 @@ def _parse_dialogue(dialogue: dict, dialogue_idx: int) -> list[BenchmarkItem]:
         ...
     ]
 
+    History rows use the turn's ``dia_id`` verbatim as ``turn_id`` so that
+    ``qa[].evidence`` (also ``dia_id``s) can intersect them. Image turns are
+    ingested via ``blip_caption``; a turn is skipped only when it has neither
+    ``text`` nor ``blip_caption``.
+
     Args:
-        dialogue: Raw dialogue dict.
+        dialogue: Raw sample dict.
         dialogue_idx: Index for error messages.
 
     Returns:
-        List of BenchmarkItem (one per QA pair in the dialogue).
+        List of BenchmarkItem (one per QA pair in the sample).
 
     Raises:
-        ValueError: If required fields are missing.
+        ValueError: If required fields are missing or have the wrong shape.
     """
     required = ["conversation", "qa"]
     for field in required:
@@ -147,45 +164,55 @@ def _parse_dialogue(dialogue: dict, dialogue_idx: int) -> list[BenchmarkItem]:
                 f"LoCoMo dialogue[{dialogue_idx}] missing required field: {field!r}"
             )
 
-    dialogue_id = dialogue.get("dialogue_id", str(dialogue_idx))
-    raw_conversation = dialogue["conversation"]
+    sample_id = dialogue.get("sample_id", str(dialogue_idx))
+    conversation = dialogue["conversation"]
     raw_qa = dialogue["qa"]
 
-    if not isinstance(raw_conversation, list):
+    if not isinstance(conversation, dict):
         raise ValueError(
-            f"LoCoMo dialogue[{dialogue_idx}] 'conversation' must be a list"
+            f"LoCoMo dialogue[{dialogue_idx}] 'conversation' must be a dict"
         )
     if not isinstance(raw_qa, list):
-        raise ValueError(
-            f"LoCoMo dialogue[{dialogue_idx}] 'qa' must be a list"
-        )
+        raise ValueError(f"LoCoMo dialogue[{dialogue_idx}] 'qa' must be a list")
 
-    # Build history: only text turns (skip image-only turns)
+    # Map the two speaker names to deterministic role slots.
+    name_to_role = {}
+    if conversation.get("speaker_a") is not None:
+        name_to_role[conversation["speaker_a"]] = "user"
+    if conversation.get("speaker_b") is not None:
+        name_to_role[conversation["speaker_b"]] = "assistant"
+
+    # Select session_N keys (skip *_date_time / speaker_a / speaker_b), in N order.
+    session_keys = sorted(
+        (
+            k
+            for k in conversation
+            if k.startswith("session_") and not k.endswith("_date_time")
+        ),
+        key=lambda k: int(k.split("_")[1]),
+    )
+
+    # Build history keyed by dia_id; ingest blip_caption for image turns.
     history = []
-    turn_id_set: set[str] = set()
-    for turn in raw_conversation:
-        text = turn.get("text", "") or turn.get("content", "")
-        if not text or not text.strip():
-            # Skip image-only or empty turns
+    for session_key in session_keys:
+        turns = conversation[session_key]
+        if not isinstance(turns, list):
             continue
-        raw_turn_id = turn.get("turn_id", turn.get("id", ""))
-        turn_id = str(raw_turn_id) if raw_turn_id != "" else str(len(history))
-        session = turn.get("session", 1)
-        role = turn.get("role", "user")
-        # Normalize role to standard names
-        if role in ("speaker1", "user", "human"):
-            role = "user"
-        elif role in ("speaker2", "assistant", "bot"):
-            role = "assistant"
-        history.append(
-            {
-                "role": role,
-                "content": text.strip(),
-                "turn_id": turn_id,
-                "session_id": str(session),
-            }
-        )
-        turn_id_set.add(turn_id)
+        for turn in turns:
+            content = turn.get("text") or turn.get("blip_caption")
+            if not content or not str(content).strip():
+                # Skip turns with neither text nor blip_caption.
+                continue
+            speaker = turn.get("speaker", "")
+            history.append(
+                {
+                    "role": name_to_role.get(speaker, "user"),
+                    "content": str(content).strip(),
+                    "turn_id": str(turn.get("dia_id", "")),
+                    "session_id": session_key,
+                    "speaker": speaker,
+                }
+            )
 
     items = []
     for qa_idx, qa in enumerate(raw_qa):
@@ -198,16 +225,16 @@ def _parse_dialogue(dialogue: dict, dialogue_idx: int) -> list[BenchmarkItem]:
             continue
 
         question = qa["question"]
-        item_id = f"{dialogue_id}::qa{qa_idx}"
+        item_id = f"{sample_id}::qa{qa_idx}"
 
-        # Parse evidence_turn_id (may be int, str, or list)
-        raw_evidence = qa.get("evidence_turn_id", qa.get("evidence", ""))
-        if isinstance(raw_evidence, list):
-            relevant_ids = {str(e) for e in raw_evidence if e != ""}
-        elif raw_evidence != "" and raw_evidence is not None:
-            relevant_ids = {str(raw_evidence)}
-        else:
-            relevant_ids = set()
+        # Evidence is a list of dia_ids; adversarial QAs have no evidence.
+        relevant_ids = {
+            str(e) for e in qa.get("evidence", []) if e is not None and e != ""
+        }
+        is_adversarial = "evidence" not in qa
+        answer = qa.get("answer")
+        if answer is None:
+            answer = qa.get("adversarial_answer", "")
 
         items.append(
             BenchmarkItem(
@@ -216,11 +243,12 @@ def _parse_dialogue(dialogue: dict, dialogue_idx: int) -> list[BenchmarkItem]:
                 query=question,
                 relevant_ids=relevant_ids,
                 metadata={
-                    "answer": qa.get("answer", ""),
-                    "question_type": qa.get("type", ""),
-                    "dialogue_id": dialogue_id,
+                    "answer": answer,
+                    "question_type": qa.get("category"),
+                    "sample_id": sample_id,
                     "dataset": "locomo",
-                    "note": "text-only (image turns skipped)",
+                    "adversarial": is_adversarial,
+                    "note": "image turns ingested via blip_caption",
                 },
             )
         )

--- a/tests/benchmarks/test_external.py
+++ b/tests/benchmarks/test_external.py
@@ -7,6 +7,9 @@ Tests cover:
 - LoCoMo adapter schema validation
 """
 
+import json
+import logging
+
 import pytest
 from pathlib import Path
 
@@ -280,25 +283,114 @@ class TestLoCoMoAdapter:
         assert len(items) <= 3
 
     def test_multiple_qa_per_dialogue(self):
-        """Each dialogue in the fixture has multiple QA pairs."""
-        # Fixture has 2 dialogues × 3 QA = 6 items
+        """Each sample in the fixture yields one item per QA pair."""
+        # Fixture: conv-26 has 4 QA (3 normal + 1 adversarial), conv-31 has 3 QA
         items = list(iter_locomo(fixture_path=LOCOMO_FIXTURE))
-        assert len(items) == 6
+        assert len(items) == 7
 
     def test_history_shared_across_qa(self):
-        """All QA items from the same dialogue share the same history."""
+        """All QA items from the same sample share the same history."""
         items = list(iter_locomo(fixture_path=LOCOMO_FIXTURE))
-        # Items 0-2 should be from locomo_001, items 3-5 from locomo_002
-        history_0 = items[0].history
-        history_1 = items[1].history
-        history_2 = items[2].history
-        assert history_0 == history_1 == history_2
+        # Items 0-3 are from conv-26 (4 QA), items 4-6 from conv-31 (3 QA).
+        conv26 = [it for it in items if it.metadata["sample_id"] == "conv-26"]
+        conv31 = [it for it in items if it.metadata["sample_id"] == "conv-31"]
+        assert len(conv26) == 4
+        assert len(conv31) == 3
+        # Histories are shared (identical) within a sample.
+        assert all(it.history == conv26[0].history for it in conv26)
+        assert all(it.history == conv31[0].history for it in conv31)
+        # Distinct samples have distinct histories.
+        assert conv26[0].history != conv31[0].history
 
-    def test_text_only_turns(self):
-        """All history turns should have non-empty content (image turns skipped)."""
+    def test_blip_caption_turns_ingested(self):
+        """Image turns are ingested via blip_caption, not skipped.
+
+        A turn is only dropped when it has neither ``text`` nor
+        ``blip_caption``; every ingested turn has non-empty content.
+        """
         items = list(iter_locomo(fixture_path=LOCOMO_FIXTURE))
         for item in items:
             for turn in item.history:
                 assert turn[
                     "content"
                 ].strip(), f"Turn content should not be empty: {turn}"
+        # The image turn (D1:3 in conv-26) is present via its caption.
+        conv26 = next(it for it in items if it.metadata["sample_id"] == "conv-26")
+        image_turns = [t for t in conv26.history if t["turn_id"] == "D1:3"]
+        assert len(image_turns) == 1
+        assert "snow-capped mountain peak" in image_turns[0]["content"]
+
+    def test_dia_id_intersection(self):
+        """Non-adversarial evidence dia_ids must be reachable in history.
+
+        This is the core proof of the fix: relevant_ids (built from
+        ``qa[].evidence`` dia_ids) intersect the history turn_ids (also
+        dia_ids), so the scorer can actually score a hit.
+        """
+        items = list(iter_locomo(fixture_path=LOCOMO_FIXTURE))
+        non_adversarial = [it for it in items if not it.metadata["adversarial"]]
+        assert non_adversarial, "fixture must contain non-adversarial items"
+        for item in non_adversarial:
+            history_ids = {row["turn_id"] for row in item.history}
+            assert item.relevant_ids, f"{item.item_id} should have evidence"
+            assert item.relevant_ids <= history_ids, (
+                f"{item.item_id} evidence {item.relevant_ids} not reachable "
+                f"in history {history_ids}"
+            )
+
+    def test_adversarial_item_empty_evidence(self):
+        """Adversarial QA yields an item with empty evidence and adv answer."""
+        items = list(iter_locomo(fixture_path=LOCOMO_FIXTURE))
+        adversarial = [it for it in items if it.metadata["adversarial"]]
+        assert len(adversarial) == 1
+        adv = adversarial[0]
+        assert adv.relevant_ids == set()
+        assert adv.metadata["answer"] == "Not mentioned in the conversation."
+
+    def test_malformed_sample_skipped_with_warning(self, tmp_path, caplog):
+        """A sample missing a required field is skipped (with a warning);
+        valid samples are NOT skipped."""
+        malformed = [
+            {
+                "sample_id": "bad",
+                # missing 'conversation'
+                "qa": [{"question": "?", "answer": "x", "evidence": ["D1:1"]}],
+            },
+            {
+                "sample_id": "good",
+                "conversation": {
+                    "speaker_a": "A",
+                    "speaker_b": "B",
+                    "session_1_date_time": "now",
+                    "session_1": [{"speaker": "A", "dia_id": "D1:1", "text": "hello"}],
+                },
+                "qa": [{"question": "?", "answer": "hello", "evidence": ["D1:1"]}],
+            },
+        ]
+        fixture = tmp_path / "malformed_locomo.json"
+        fixture.write_text(json.dumps(malformed))
+
+        with caplog.at_level(logging.WARNING):
+            items = list(iter_locomo(fixture_path=fixture))
+
+        # Only the valid sample's QA is yielded; the malformed one is skipped.
+        assert len(items) == 1
+        assert items[0].metadata["sample_id"] == "good"
+        assert any("Skipping malformed" in rec.message for rec in caplog.records)
+
+    def test_mrr_le_recall_over_fixture_items(self):
+        """MRR <= any-hit Recall@k for retrievals that hit fixture evidence.
+
+        Constructs a retrieved list (the item's own history turn_ids) that
+        hits the evidence and asserts the shared-metric invariant holds.
+        """
+        items = list(iter_locomo(fixture_path=LOCOMO_FIXTURE))
+        non_adversarial = [it for it in items if not it.metadata["adversarial"]]
+        assert non_adversarial
+        for item in non_adversarial:
+            retrieved = [row["turn_id"] for row in item.history]
+            mrr = mean_reciprocal_rank(retrieved, item.relevant_ids)
+            any_hit = recall_at_k(retrieved, item.relevant_ids, len(retrieved))
+            assert mrr <= any_hit + 1e-9
+            # Evidence is reachable, so a full-list retrieval always hits.
+            assert any_hit == 1.0


### PR DESCRIPTION
## Summary

The LoCoMo benchmark adapter was written against a **fictional schema** — the same class of bug fixed for LongMemEval-S in #436. It had two fatal defects:

1. **Every dialogue silently skipped → 0 items → 0.0 score.** `_parse_dialogue` required `conversation` to be a `list`, but real LoCoMo keys it as a **dict** (`session_N` / `session_N_date_time` / `speaker_a` / `speaker_b`). The resulting `ValueError` was swallowed as a warning, so a run *looked* successful while measuring nothing.
2. **Ground truth unrecoverable even when records parsed.** It synthesized integer `turn_id`s instead of preserving `dia_id` (e.g. `"D1:11"`), which `qa[].evidence` references — so retrieved turn_ids could never intersect `relevant_ids`.

## Changes

- Rewrote `_parse_dialogue` for the real schema: iterate `conversation` as a dict (`session_N` sorted by `N`), use `dia_id` as `turn_id`, read `speaker` / `category` / `evidence` / `sample_id`, map `speaker_a`→`user` / `speaker_b`→`assistant`, ingest image turns via `blip_caption` so image-evidence stays reachable. Adversarial QAs emit with empty `relevant_ids`.
- Replaced the fictional fixture with a real-schema sample.
- Added tests: `test_dia_id_intersection` (relevant_ids ⊆ history turn_ids), `test_adversarial_item_empty_evidence`, `test_malformed_sample_skipped_with_warning` (caplog), and an `MRR ≤ Recall@k` invariant check (the metric path corrected in #438 is inherited for free).
- Updated `docs/benchmarks.md` (image turns are ingested, not skipped).

## Verification

- `pytest tests/benchmarks/test_external.py -q` → **40 passed**
- `black --check` clean on touched files
- Plan verification grep table passes (list-check gone, `dia_id` used, no synthesized turn_ids, fictional keys removed from adapter + fixture)

## Scope

A real `locomo10.json` benchmark run + committed report is **out of scope** (deferred, like the LongMemEval report step) — this fixes the adapter and validates it with a real-schema fixture.

Plan: docs/plans/locomo_adapter_real_schema.md

Closes #434