### PR TITLE
feat(#437): hybrid BM25+vector retrieval mode for external benchmark

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -92,6 +92,7 @@ python -m tests.benchmarks.run_external \
 | `--limit N` | all | Evaluate at most N questions (sampled per `--sample`) |
 | `--sample MODE` | `stride` | How `--limit` selects: `stride` (even spread, representative), `stratified` (proportional per `question_type`), `shuffle` (seeded random), `head` (legacy contiguous prefix). Ignored without `--limit`. |
 | `--seed N` | 0 | Seed for `shuffle`/`stratified` sampling |
+| `--retrieval-mode MODE` | `lexical` | `lexical` (BM25 only) or `hybrid` (BM25 + vector via RRF). See [Retrieval Modes](#retrieval-modes). |
 | `--dry-run` | off | Print results without saving report files |
 | `--fixture PATH` | download | Load dataset from a local JSON file |
 | `--output DIR` | `results/external/` | Override output directory |
@@ -121,6 +122,49 @@ Each JSON report includes:
 - `notes` — retrieval mode description
 - `questions` — per-question detail (item_id, recall scores, status, errors, and `metadata.question_type`)
 
+### Retrieval Modes
+
+`--retrieval-mode` selects how the harness retrieves candidates. Both modes drive
+`ContextAssembler.assemble()`; field presence on the per-item model determines the
+effective mode (`retrieval_mode="auto"`):
+
+| Mode | Fields | Fusion | Cost |
+|------|--------|--------|------|
+| `lexical` (default) | `BM25Field` | none (BM25 ranking) | no model download; fast |
+| `hybrid` | `BM25Field` + `EmbeddingField` | BM25 + vector via **RRF (k=60)** | one-time ~90 MB `all-MiniLM-L6-v2` download; slower (CPU embedding) |
+
+Hybrid is **Valkey-safe**: vector similarity is computed in-process with numpy
+cosine over `EmbeddingField` `.npy` files — no RediSearch, no vector-search modules,
+no `FT.*` / `BF.*` commands. The vector signal uses the local
+[`SentenceTransformersProvider`](fields.md#sentencetransformersprovider) (no API key).
+
+```bash
+# Lexical (default) — BM25 only, no model download:
+python -m tests.benchmarks.run_external --dataset longmemeval-s
+
+# Hybrid — BM25 + vector (downloads MiniLM on first run):
+pip install -e ".[benchmark]"
+python -m tests.benchmarks.run_external --dataset longmemeval-s --retrieval-mode hybrid
+```
+
+**LongMemEval-S, 500 questions (any-hit Recall):**
+
+| Mode | Recall@1 | Recall@5 | Recall@10 | MRR |
+|------|---------:|---------:|----------:|----:|
+| `lexical` (BM25) | 0.856 | 0.952 | 0.978 | 0.899 |
+| `hybrid` (BM25+vector, RRF) | — see note | — | — | — |
+| agentmemory reference (BM25+vector) | — | 0.952 | 0.986 | 0.882 |
+
+> **Hybrid full-run number is pending.** The hybrid retrieval *path* is implemented
+> and validated (effective mode resolves to `hybrid`, RRF fusion executes, vector
+> cosine is numpy-only) — see the harness tests. The committed 500-question hybrid
+> comparison is a separate, deliberately-deferred run: it embeds every turn on CPU
+> (~275k turns), which is far slower than the lexical pass. Run it locally with
+> `python -m tests.benchmarks.run_external --dataset longmemeval-s --retrieval-mode hybrid`
+> and commit the resulting artifact to fill this row. Notably, the lexical BM25
+> baseline already matches the reference Recall@5 (0.952), so the hybrid headroom on
+> this dataset is at the Recall@10 margin.
+
 ### Baseline Numbers (v1.6.3)
 
 **LongMemEval-S (fixture sample, 3 questions):**
@@ -148,7 +192,9 @@ are indistinguishable — the baseline is intentionally a floor.
 
 **Reference:** agentmemory BM25+Vector (all-MiniLM-L6-v2) achieves
 Recall@5 = 95.2%, Recall@10 = 98.6%, MRR = 88.2% on LongMemEval-S.
-Issue #395 will add hybrid retrieval to close this gap.
+Hybrid retrieval is available via `--retrieval-mode hybrid` (see
+[Retrieval Modes](#retrieval-modes)); the lexical BM25 baseline already
+matches the reference Recall@5 (0.952).
 
 ### Architecture
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -1308,7 +1308,7 @@ generate an embedding, and writes the vector atomically to disk.
 
 ### Embedding Providers
 
-Popoto ships with three built-in providers. You can also implement your own by
+Popoto ships with four built-in providers. You can also implement your own by
 subclassing `AbstractEmbeddingProvider`.
 
 **VoyageProvider** (recommended for retrieval):
@@ -1351,6 +1351,22 @@ Requires a running Ollama server (`ollama serve`) with the model pulled
 (`ollama pull nomic-embed-text`). Uses stdlib only -- no extras to install.
 See [Content and Embedding Fields](features/content-and-embedding-fields.md#ollamaprovider)
 for setup details.
+
+**SentenceTransformersProvider** (local, no API key):
+
+```python
+from popoto.embeddings.sentence_transformers import SentenceTransformersProvider
+
+provider = SentenceTransformersProvider(
+    model_name="all-MiniLM-L6-v2",   # default (384-dim)
+)
+```
+
+Runs `all-MiniLM-L6-v2` locally via `sentence-transformers` (installed by the
+`[benchmark]` extra: `pip install popoto[benchmark]`). No API key or daemon; the
+model (~90 MB) is downloaded from Hugging Face on first use and cached. Used by the
+external benchmark harness for hybrid retrieval — see
+[Benchmarking](benchmarks.md#retrieval-modes).
 
 ### Querying with semantic_search()
 

--- a/src/popoto/embeddings/__init__.py
+++ b/src/popoto/embeddings/__init__.py
@@ -12,6 +12,9 @@ Available providers:
     - OpenAIProvider: OpenAI embeddings (requires openai package)
     - OllamaProvider: Local Ollama embeddings (requires a running Ollama
       server; stdlib-only, no extra package needed)
+    - SentenceTransformersProvider: Local sentence-transformers embeddings
+      (all-MiniLM-L6-v2, 384-dim, no API key; requires the [benchmark] extra,
+      imported lazily)
 """
 
 from abc import ABC, abstractmethod
@@ -72,4 +75,14 @@ class AbstractEmbeddingProvider(ABC):
 
 from .ollama import OllamaProvider  # noqa: E402  (stdlib-only, safe to eagerly import)
 
-__all__ = ["AbstractEmbeddingProvider", "OllamaProvider"]
+# Safe to eagerly import: the heavy sentence-transformers dependency is
+# imported lazily inside SentenceTransformersProvider.embed(), not here.
+from .sentence_transformers import (  # noqa: E402
+    SentenceTransformersProvider,
+)
+
+__all__ = [
+    "AbstractEmbeddingProvider",
+    "OllamaProvider",
+    "SentenceTransformersProvider",
+]

--- a/src/popoto/embeddings/sentence_transformers.py
+++ b/src/popoto/embeddings/sentence_transformers.py
@@ -1,0 +1,133 @@
+"""
+Sentence-Transformers embedding provider.
+
+Wraps a local `sentence-transformers` model (``all-MiniLM-L6-v2`` by
+default) behind the AbstractEmbeddingProvider interface. Inference runs
+entirely on the local machine, so there is no API key, no per-token cost,
+and no network dependency on a paid external provider.
+
+The first use downloads the model weights (~90MB for ``all-MiniLM-L6-v2``)
+from Hugging Face and caches them locally; subsequent uses are offline.
+
+``sentence-transformers`` is a heavy optional dependency (it pulls in
+PyTorch). It is therefore imported **lazily** inside ``embed()`` so that
+``import popoto.embeddings`` stays cheap and does not require the package to
+be installed. The dependency ships under the ``[benchmark]`` optional extra::
+
+    pip install popoto[benchmark]
+
+Example:
+    from popoto.embeddings.sentence_transformers import (
+        SentenceTransformersProvider,
+    )
+    provider = SentenceTransformersProvider()
+    vectors = provider.embed(["hello world"])
+"""
+
+from typing import List, Optional
+
+from . import AbstractEmbeddingProvider
+
+# Dimensionality of ``all-MiniLM-L6-v2`` output vectors. Known a priori for
+# MiniLM, so ``dimensions`` can be reported without loading the model.
+_MINILM_DIMENSIONS = 384
+
+
+def _load_sentence_transformer_cls():
+    """Lazily import and return the ``SentenceTransformer`` class.
+
+    Raises:
+        ImportError: If ``sentence-transformers`` is not installed, with an
+            actionable hint pointing at the ``[benchmark]`` extra.
+    """
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError as e:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(
+            "sentence-transformers is required to use "
+            "SentenceTransformersProvider. Install it with: "
+            "pip install popoto[benchmark]"
+        ) from e
+    return SentenceTransformer
+
+
+class SentenceTransformersProvider(AbstractEmbeddingProvider):
+    """Local Sentence-Transformers embedding provider.
+
+    Wraps a ``sentence-transformers`` model and produces dense vectors with
+    no API key. The default model, ``all-MiniLM-L6-v2``, emits 384-dim
+    vectors and is symmetric (the same encoder is used for documents and
+    queries), so ``input_type`` is accepted for interface compatibility but
+    ignored.
+
+    The underlying model is loaded lazily on the first ``embed()`` call and
+    cached on the instance; constructing the provider does nothing heavy and
+    triggers no download.
+
+    Args:
+        model_name: Name of the sentence-transformers model to load.
+            Default ``all-MiniLM-L6-v2`` (384-dim).
+        dimensions: Output vector dimensionality. Defaults to 384 for the
+            MiniLM model; override only if you pass a different model.
+
+    Raises:
+        ImportError: At ``embed()`` time if ``sentence-transformers`` is not
+            installed. Install it with ``pip install popoto[benchmark]``.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "all-MiniLM-L6-v2",
+        dimensions: int = _MINILM_DIMENSIONS,
+    ):
+        self._model_name = model_name
+        self._dimensions = dimensions
+        # _model stays None until the first embed() call loads (and caches) it.
+        self._model = None
+
+    def _get_model(self):
+        """Load and cache the sentence-transformers model on first use."""
+        if self._model is None:
+            SentenceTransformer = _load_sentence_transformer_cls()
+            self._model = SentenceTransformer(self._model_name)
+        return self._model
+
+    def embed(
+        self,
+        texts: List[str],
+        input_type: Optional[str] = None,
+    ) -> List[List[float]]:
+        """Generate embeddings with a local sentence-transformers model.
+
+        Args:
+            texts: List of text strings to embed.
+            input_type: Accepted for interface compatibility but ignored —
+                ``all-MiniLM-L6-v2`` is a symmetric encoder.
+
+        Returns:
+            List of embedding vectors, one per input text. An empty input
+            list returns ``[]`` without loading the model.
+
+        Raises:
+            ImportError: If ``sentence-transformers`` is not installed.
+        """
+        if not texts:
+            return []
+
+        model = self._get_model()
+        # model.encode returns a numpy ndarray; .tolist() yields plain floats.
+        return model.encode(list(texts)).tolist()
+
+    @property
+    def dimensions(self) -> int:
+        """Embedding vector dimensionality (384 for ``all-MiniLM-L6-v2``)."""
+        return self._dimensions
+
+    @property
+    def max_batch_size(self) -> int:
+        """Conservative batch limit for local CPU inference.
+
+        Embedding many texts in a single forward pass can be memory-heavy on
+        modest hardware. Users with more headroom can subclass and override.
+        """
+        return 64

--- a/tests/benchmarks/run_external.py
+++ b/tests/benchmarks/run_external.py
@@ -110,16 +110,18 @@ class QuestionResult:
 # ---------------------------------------------------------------------------
 
 
-def run_item(item: BenchmarkItem) -> QuestionResult:
+def run_item(item: BenchmarkItem, retrieval_mode: str = "lexical") -> QuestionResult:
     """Run a single benchmark item through ExternalScenario.
 
     Args:
         item: BenchmarkItem from a dataset adapter.
+        retrieval_mode: ``"lexical"`` (BM25 only) or ``"hybrid"`` (BM25 +
+            vector via RRF). Threaded into the scenario.
 
     Returns:
         QuestionResult with recall metrics and latency.
     """
-    scenario = ExternalScenario(item=item)
+    scenario = ExternalScenario(item=item, retrieval_mode=retrieval_mode)
     scenario_result = scenario.execute()
 
     if scenario_result.status != "ok":
@@ -191,6 +193,7 @@ def compute_aggregate(
     sample_mode: str = "head",
     seed: int = 0,
     limit=None,
+    retrieval_mode: str = "lexical",
 ) -> dict:
     """Compute aggregate metrics over all question results.
 
@@ -201,6 +204,8 @@ def compute_aggregate(
             reproducibility).
         seed: RNG seed used for this run (recorded for reproducibility).
         limit: ``--limit`` value used for this run (``None`` = full dataset).
+        retrieval_mode: ``"lexical"`` or ``"hybrid"`` — the retrieval mode the
+            run was executed in (recorded and surfaced in the report).
 
     Returns:
         Dict with aggregate metrics, per-``question_type`` breakdown, the
@@ -232,9 +237,25 @@ def compute_aggregate(
         avg_r1 = avg_r5 = avg_r10 = avg_mrr = 0.0
         p50 = p95 = 0.0
 
+    if retrieval_mode == "hybrid":
+        mode_notes = [
+            "Retrieval mode: hybrid — ContextAssembler.assemble() is the "
+            "primary path; effective mode resolves to 'hybrid'.",
+            "Hybrid fuses BM25 (lexical) + vector (all-MiniLM-L6-v2, 384-dim, "
+            "in-process numpy cosine) via Reciprocal Rank Fusion (k=60).",
+        ]
+    else:
+        mode_notes = [
+            "Retrieval mode: lexical — ContextAssembler.assemble() is the "
+            "primary path; effective mode resolves to 'lexical'.",
+            "Lexical uses BM25 (query-sensitive) only; no vector/embedding "
+            "signal is fused in this mode.",
+        ]
+
     now = datetime.now(timezone.utc)
     return {
         "dataset": dataset,
+        "retrieval_mode": retrieval_mode,
         "run_date": now.strftime("%Y-%m-%d"),
         "run_timestamp": now.isoformat(),
         "sampling": {
@@ -260,9 +281,8 @@ def compute_aggregate(
             "p50_ms": round(p50, 2),
             "p95_ms": round(p95, 2),
         },
-        "notes": [
-            "Baseline run: relevance-only scoring (DecayingSortedField).",
-            "No vector/embedding retrieval wired in (BM25-style baseline).",
+        "notes": mode_notes
+        + [
             "LoCoMo: image-only turns skipped (text-only evaluation).",
         ],
         "questions": [r.to_dict() for r in results],
@@ -287,6 +307,7 @@ def build_markdown_report(aggregate: dict) -> str:
     s = aggregate["summary"]
     run_date = aggregate["run_date"]
     machine = aggregate["machine"]
+    retrieval_mode = aggregate.get("retrieval_mode", "lexical")
     sampling = aggregate.get("sampling", {})
     sample_mode = sampling.get("sample_mode", "head")
     seed = sampling.get("seed", 0)
@@ -297,6 +318,7 @@ def build_markdown_report(aggregate: dict) -> str:
         f"# Popoto External Benchmark: {ds}",
         "",
         f"**Run date:** {run_date}  ",
+        f"**Retrieval mode:** {retrieval_mode}  ",
         f"**Python:** {machine['python_version']}  ",
         f"**Platform:** {machine['platform']}  ",
         f"**Sample mode:** {sample_mode}  ",
@@ -345,10 +367,21 @@ def build_markdown_report(aggregate: dict) -> str:
     lines.append("agentmemory BM25+Vector (all-MiniLM-L6-v2) on LongMemEval-S:")
     lines.append("- Recall@5: 95.2%, Recall@10: 98.6%, MRR: 88.2%")
     lines.append("")
-    lines.append(
-        "Popoto baseline is score-only (no embedding retrieval). "
-        "Issue #395 will add hybrid BM25+vector retrieval to close this gap."
-    )
+    lines.append("Popoto BM25-only baseline on LongMemEval-S (any-hit, #438):")
+    lines.append("- Recall@5: 95.2%, Recall@10: 97.8%")
+    lines.append("")
+    if retrieval_mode == "hybrid":
+        lines.append(
+            "This run used **hybrid** retrieval (BM25 + all-MiniLM-L6-v2 vector "
+            "fused via RRF, k=60). Compare Recall@5/Recall@10 above against the "
+            "BM25-only baseline and the agentmemory hybrid reference."
+        )
+    else:
+        lines.append(
+            "This run used **lexical** retrieval (BM25 only). Re-run with "
+            "`--retrieval-mode hybrid` to fuse the all-MiniLM-L6-v2 vector "
+            "signal (RRF, k=60) and compare against the agentmemory reference."
+        )
     lines.append("")
     return "\n".join(lines)
 
@@ -445,6 +478,17 @@ def main():
         help="Seed for shuffle/stratified sampling (default: 0)",
     )
     parser.add_argument(
+        "--retrieval-mode",
+        choices=("lexical", "hybrid"),
+        default="lexical",
+        help=(
+            "Retrieval mode (default: lexical). 'lexical' uses BM25 only and "
+            "needs no model download; 'hybrid' adds an all-MiniLM-L6-v2 vector "
+            "signal fused with BM25 via RRF (k=60) and requires the "
+            "[benchmark] extra plus a one-time ~90MB model download."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Run without saving report artifacts",
@@ -505,11 +549,13 @@ def main():
         return 1
 
     logger.info(
-        "Starting benchmark: dataset=%s limit=%s sample=%s seed=%s dry_run=%s",
+        "Starting benchmark: dataset=%s limit=%s sample=%s seed=%s "
+        "retrieval_mode=%s dry_run=%s",
         args.dataset,
         args.limit or "all",
         args.sample,
         args.seed,
+        args.retrieval_mode,
         args.dry_run,
     )
 
@@ -527,7 +573,7 @@ def main():
                 elapsed,
             )
 
-        q_result = run_item(item)
+        q_result = run_item(item, retrieval_mode=args.retrieval_mode)
         results.append(q_result)
 
         if q_result.status == "ok":
@@ -558,6 +604,7 @@ def main():
         sample_mode=args.sample,
         seed=args.seed,
         limit=args.limit,
+        retrieval_mode=args.retrieval_mode,
     )
     s = aggregate["summary"]
 
@@ -565,6 +612,7 @@ def main():
     print("\n" + "=" * 60)
     print(f"BENCHMARK RESULTS: {args.dataset.upper()}")
     print("=" * 60)
+    print(f"  Retrieval mode      : {args.retrieval_mode}")
     print(f"  Questions evaluated : {s['n_ok']} / {s['n_total']}")
     print(f"  Errors              : {s['n_errors']}")
     print(f"  Recall@1            : {s['recall_at_1']:.4f}")

--- a/tests/benchmarks/scenarios/external_base.py
+++ b/tests/benchmarks/scenarios/external_base.py
@@ -15,39 +15,44 @@ Model class used:
     - importance: FloatField (fixed at 0.5 for baseline)
     - relevance: DecayingSortedField (scored via CompositeScoreQuery)
     - certainty: ConfidenceField (initial 0.5)
-    - content_index: BM25Field (hybrid retrieval — lexical signal)
+    - content_index: BM25Field (lexical signal — always present)
+    - embedding: EmbeddingField (vector signal — present only in hybrid mode)
 
     Class is re-created per benchmark item with a unique name prefix to
     ensure Redis key isolation between items. teardown() scans and deletes
-    all keys matching the class prefix.
+    all keys matching the class prefix (and the per-class embedding dir).
 
-Retrieval mode:
-    ``ContextAssembler`` is constructed with ``retrieval_mode="auto"``.
-    Because the model has a BM25Field but no EmbeddingField (no provider
-    configured), auto-mode resolves to ``"composite"`` — but BM25 lexical
-    search is available for direct use via ``keyword_search()``.
-
-    Effective mode selection (issue #395):
+Retrieval mode (issue #437):
+    Retrieval is driven through ``ContextAssembler.assemble()`` as the
+    **primary** path. The assembler is constructed with
+    ``retrieval_mode="auto"`` so field presence drives mode resolution
+    (issue #395):
     - Model has BM25Field + EmbeddingField → ``"hybrid"`` (BM25 + vector via RRF)
-    - Model has BM25Field only → ``"composite"`` (auto fallback)
-    - Model has EmbeddingField only → ``"composite"`` (auto fallback)
-    - Model has neither → ``"composite"`` (original behaviour)
+    - Model has BM25Field only → ``"lexical"`` (query-sensitive BM25, no vector)
+    - Model has neither → ``"composite"`` (query-blind)
 
-    The benchmark baseline uses BM25Field only. Adding an EmbeddingField
-    with a configured provider would enable full hybrid mode.
+    ``ExternalScenario(retrieval_mode="lexical")`` (the default) declares a
+    BM25Field only, so auto-mode resolves to ``"lexical"``.
+    ``ExternalScenario(retrieval_mode="hybrid")`` additionally declares an
+    EmbeddingField with a local SentenceTransformersProvider, so auto-mode
+    resolves to ``"hybrid"`` and the RRF fusion (k=60) runs.
 
 This module is text-only: turns without content are silently skipped.
 """
 
 import logging
+import os
+import shutil
 import time
 import uuid
 from typing import Any, Dict, List, Optional
 
 from src import popoto
+from src.popoto.embeddings.sentence_transformers import SentenceTransformersProvider
 from src.popoto.fields.bm25_field import BM25Field
 from src.popoto.fields.confidence_field import ConfidenceField
 from src.popoto.fields.decaying_sorted_field import DecayingSortedField
+from src.popoto.fields.embedding_field import EmbeddingField, _get_embeddings_dir
 from src.popoto.recipes.context_assembler import ContextAssembler
 from src.popoto.redis_db import POPOTO_REDIS_DB
 
@@ -60,37 +65,62 @@ logger = logging.getLogger("POPOTO.Benchmark.ExternalScenario")
 BASELINE_SCORE_WEIGHTS = {"relevance": 1.0}
 
 
-def _build_external_model_class(safe_prefix: str):
+def _build_external_model_class(safe_prefix: str, with_embedding: bool = False):
     """Build a fresh Popoto Model class for one benchmark item.
 
     Uses a unique class name derived from ``safe_prefix`` so each item
     gets its own Redis key namespace. This prevents cross-item contamination
     when running multiple items sequentially.
 
-    Includes BM25Field for lexical retrieval. ContextAssembler will use
-    ``retrieval_mode="auto"``; when both BM25Field and EmbeddingField are
-    present the hybrid (RRF) pull path is used automatically.
+    Always includes a BM25Field for the lexical signal. When
+    ``with_embedding`` is True, also declares an EmbeddingField backed by a
+    local SentenceTransformersProvider (all-MiniLM-L6-v2), so that
+    ``ContextAssembler(retrieval_mode="auto")`` resolves to the ``"hybrid"``
+    (RRF) pull path. With BM25 only, auto-mode resolves to ``"lexical"``.
 
     Args:
         safe_prefix: Short alphanumeric prefix (e.g., "a3f9b2c1").
+        with_embedding: If True, add an EmbeddingField for hybrid retrieval.
 
     Returns:
         A new Popoto Model class with agent_id, content, importance,
-        relevance, certainty, and content_index fields.
+        relevance, certainty, content_index, and (in hybrid mode) embedding
+        fields.
     """
 
-    class ExternalBenchmarkMemory(popoto.Model):
-        turn_id = popoto.AutoKeyField()
-        agent_id = popoto.KeyField()
-        content = popoto.StringField(default="")
-        importance = popoto.FloatField(default=0.5)
-        relevance = DecayingSortedField(
-            decay_rate=0.5,
-            base_score_field="importance",
-            partition_by="agent_id",
-        )
-        certainty = ConfidenceField(initial_confidence=0.5)
-        content_index = BM25Field(source="content")
+    if with_embedding:
+
+        class ExternalBenchmarkMemory(popoto.Model):
+            turn_id = popoto.AutoKeyField()
+            agent_id = popoto.KeyField()
+            content = popoto.StringField(default="")
+            importance = popoto.FloatField(default=0.5)
+            relevance = DecayingSortedField(
+                decay_rate=0.5,
+                base_score_field="importance",
+                partition_by="agent_id",
+            )
+            certainty = ConfidenceField(initial_confidence=0.5)
+            content_index = BM25Field(source="content")
+            embedding = EmbeddingField(
+                source="content",
+                provider=SentenceTransformersProvider(),
+            )
+
+    else:
+
+        class ExternalBenchmarkMemory(popoto.Model):
+            turn_id = popoto.AutoKeyField()
+            agent_id = popoto.KeyField()
+            content = popoto.StringField(default="")
+            importance = popoto.FloatField(default=0.5)
+            relevance = DecayingSortedField(
+                decay_rate=0.5,
+                base_score_field="importance",
+                partition_by="agent_id",
+            )
+            certainty = ConfidenceField(initial_confidence=0.5)
+            content_index = BM25Field(source="content")
 
     ExternalBenchmarkMemory.__name__ = f"ExtMem{safe_prefix}"
     ExternalBenchmarkMemory.__qualname__ = f"ExtMem{safe_prefix}"
@@ -107,13 +137,22 @@ class ExternalScenario(Scenario):
         item: BenchmarkItem from a dataset adapter.
         overrides: Optional override dict (unused in baseline; present for
             API compatibility with sweep infrastructure).
+        retrieval_mode: ``"lexical"`` (default, BM25 only) or ``"hybrid"``
+            (BM25 + vector via RRF). Hybrid additionally declares an
+            EmbeddingField on the model so auto-mode resolves to hybrid.
     """
 
     name = "external_base"
 
-    def __init__(self, item: BenchmarkItem, overrides: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        item: BenchmarkItem,
+        overrides: Optional[Dict[str, Any]] = None,
+        retrieval_mode: str = "lexical",
+    ):
         super().__init__(overrides)
         self.item = item
+        self.retrieval_mode = retrieval_mode
         self._agent_id = f"extbench:{uuid.uuid4().hex[:12]}"
         self._model_class = None
         self._assembler = None
@@ -132,11 +171,12 @@ class ExternalScenario(Scenario):
             ConnectionError: If Redis is unavailable.
         """
         safe_prefix = uuid.uuid4().hex[:8]
-        self._model_class = _build_external_model_class(safe_prefix)
-        # retrieval_mode="auto": selects hybrid when BM25+EmbeddingField
-        # detected, composite otherwise. The baseline model has BM25Field
-        # only → composite path, but keyword_search() is available via
-        # BM25Field.search() for direct use.
+        self._model_class = _build_external_model_class(
+            safe_prefix, with_embedding=self.retrieval_mode == "hybrid"
+        )
+        # retrieval_mode="auto": field presence drives resolution (issue #395).
+        # BM25 + EmbeddingField (hybrid mode) → "hybrid" (RRF k=60); BM25 only
+        # (lexical mode) → "lexical". assemble() is the primary retrieval path.
         self._assembler = ContextAssembler(
             model_class=self._model_class,
             score_weights=BASELINE_SCORE_WEIGHTS,
@@ -185,20 +225,19 @@ class ExternalScenario(Scenario):
     def run(self) -> ScenarioResult:
         """Run retrieval and return ScenarioResult.
 
-        Uses BM25 keyword search (via ``content_index`` BM25Field) to rank
-        turns by lexical relevance to the query. When the assembled result
-        contains no records from the composite path, falls back to BM25-only
-        retrieval to maximise R@K signal.
+        Drives retrieval through ``ContextAssembler.assemble()`` as the
+        **primary** path (issue #437). The assembler's effective mode is
+        resolved from field presence: ``"lexical"`` (BM25 only) or
+        ``"hybrid"`` (BM25 + vector fused via RRF). The selected records are
+        mapped to their Redis keys, then back to ground-truth session/turn
+        IDs via ``_session_key_map``.
 
         Measures latency of the retrieval call only (not ingestion).
-        Maps retrieved Redis keys to session IDs via _session_key_map to
-        produce comparable relevant_ids and retrieved_ids.
 
         Returns:
-            ScenarioResult with retrieved_ids as Redis keys and relevant_ids
-            as session IDs (from ground truth). Both are in the same key space
-            because relevant_ids from the dataset are session IDs and we build
-            a session_id -> redis_keys mapping during setup.
+            ScenarioResult with retrieved_ids as session/turn IDs and
+            relevant_ids from ground truth (same key space, via the
+            session_id/turn_id -> redis_keys mapping built during setup).
         """
         if not self._assembler:
             return ScenarioResult(
@@ -216,43 +255,31 @@ class ExternalScenario(Scenario):
 
         t0 = time.monotonic()
 
-        # Primary retrieval: BM25 keyword search on content (issue #395 hybrid path)
-        # The model has BM25Field(source="content"), so we can search lexically.
+        # Primary retrieval: ContextAssembler.assemble(). With both BM25 and
+        # EmbeddingField present (hybrid mode) this runs _pull_path_hybrid()
+        # (RRF k=60); with BM25 only it runs the lexical pull path.
         retrieved_keys: List[str] = []
-        retrieval_method = "bm25"
         try:
-            bm25_results = BM25Field.search(
-                self._model_class,
-                "content_index",
-                self.item.query,
-                limit=20,
+            assembly_result = self._assembler.assemble(
+                query_cues={"topic": self.item.query},
+                agent_id=self._agent_id,
             )
-            if bm25_results:
-                retrieved_keys = [rk for rk, _score in bm25_results]
+            for record in assembly_result.records:
+                try:
+                    retrieved_keys.append(record.db_key.redis_key)
+                except Exception:
+                    retrieved_keys.append(str(id(record)))
         except Exception as e:
-            logger.warning("BM25 search failed, falling back to assembler: %s", e)
-            retrieval_method = "composite_fallback"
+            return ScenarioResult(
+                scenario_name=self.name,
+                status="error",
+                error_message=f"assemble() failed: {e}",
+            )
 
-        # Fallback: if BM25 produced nothing, use composite assembler
-        if not retrieved_keys:
-            try:
-                assembly_result = self._assembler.assemble(
-                    query_cues={"topic": self.item.query},
-                    agent_id=self._agent_id,
-                )
-                retrieved_keys = []
-                for record in assembly_result.records:
-                    try:
-                        retrieved_keys.append(record.db_key.redis_key)
-                    except Exception:
-                        retrieved_keys.append(str(id(record)))
-                retrieval_method = "composite_fallback"
-            except Exception as e:
-                return ScenarioResult(
-                    scenario_name=self.name,
-                    status="error",
-                    error_message=f"assemble() failed: {e}",
-                )
+        # The assembler's effective mode (e.g. "lexical" / "hybrid").
+        retrieval_method = getattr(
+            self._assembler, "_effective_mode", self.retrieval_mode
+        )
 
         retrieval_ms = (time.monotonic() - t0) * 1000
 
@@ -334,5 +361,13 @@ class ExternalScenario(Scenario):
                     break
         except Exception:
             pass
+
+        # Remove on-disk embedding artifacts (.npy + index sidecar) for this
+        # per-item model class. No-op in lexical mode (dir never created).
+        if self._model_class:
+            shutil.rmtree(
+                os.path.join(_get_embeddings_dir(), self._model_class.__name__),
+                ignore_errors=True,
+            )
 
         super().teardown()

--- a/tests/benchmarks/test_external.py
+++ b/tests/benchmarks/test_external.py
@@ -582,3 +582,85 @@ class TestQuestionTypeThreading:
         result = ExternalScenario(item=item).execute()
         assert result.status == "ok"
         assert result.metadata.get("question_type") == "single-session-user"
+
+
+# ---------------------------------------------------------------------------
+# Retrieval-mode contract (issue #437)
+# ---------------------------------------------------------------------------
+
+
+_MINILM_REPO = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def _minilm_cached() -> bool:
+    """True only if all-MiniLM-L6-v2 is already in the HF cache.
+
+    Guards the hybrid smoke test so the suite never triggers a ~90MB download
+    (or requires network) when the model is absent.
+    """
+    try:
+        from huggingface_hub import try_to_load_from_cache
+    except Exception:
+        return False
+    try:
+        path = try_to_load_from_cache(repo_id=_MINILM_REPO, filename="config.json")
+    except Exception:
+        return False
+    return isinstance(path, str)
+
+
+def _dog_item():
+    """A tiny BenchmarkItem whose query lexically matches a single session."""
+    return BenchmarkItem(
+        item_id="q1",
+        history=[
+            {
+                "role": "user",
+                "content": "I adopted a golden retriever named Max.",
+                "turn_id": "s1::0",
+                "session_id": "s1",
+            },
+            {
+                "role": "assistant",
+                "content": "Max is a great name for a dog.",
+                "turn_id": "s1::1",
+                "session_id": "s1",
+            },
+        ],
+        query="What is my dog Max?",
+        relevant_ids={"s1"},
+        metadata={"dataset": "longmemeval-s", "question_type": "single-session-user"},
+    )
+
+
+class TestRetrievalModeContract:
+    """assemble() is the primary path; effective mode is reported (issue #437)."""
+
+    def test_lexical_is_assemble_primary(self):
+        """Default lexical run drives assemble() and reports effective mode."""
+        from tests.benchmarks.scenarios.external_base import ExternalScenario
+
+        result = ExternalScenario(item=_dog_item()).execute()
+        assert result.status == "ok"
+        # retrieval_method records the assembler's effective mode, not the old
+        # BM25-direct "bm25"/"composite_fallback" values.
+        assert result.metadata.get("retrieval_method") == "lexical"
+        # Records are returned and mapped back to ground-truth session IDs.
+        assert "s1" in result.retrieved_ids
+
+    @pytest.mark.skipif(
+        not _minilm_cached(),
+        reason="all-MiniLM-L6-v2 not cached; skipping hybrid smoke test",
+    )
+    def test_hybrid_effective_mode_and_records(self):
+        """Hybrid run resolves the assembler to 'hybrid' and returns records."""
+        from tests.benchmarks.scenarios.external_base import ExternalScenario
+
+        scenario = ExternalScenario(item=_dog_item(), retrieval_mode="hybrid")
+        try:
+            result = scenario.execute()
+        except Exception as e:  # model load/runtime hiccup → skip, don't fail
+            pytest.skip(f"hybrid model unavailable at runtime: {e}")
+        assert result.status == "ok"
+        assert result.metadata.get("retrieval_method") == "hybrid"
+        assert "s1" in result.retrieved_ids

--- a/tests/embeddings/test_sentence_transformers_provider.py
+++ b/tests/embeddings/test_sentence_transformers_provider.py
@@ -1,0 +1,95 @@
+"""Tests for SentenceTransformersProvider (issue #437).
+
+Covers the offline-safe contract:
+- dimensions == 384 without loading the model
+- embed([]) == [] without loading the model
+- a missing sentence-transformers dependency raises an actionable ImportError
+- the provider implements AbstractEmbeddingProvider
+
+A single real ``encode`` round-trip is included but GUARDED behind a
+skip-if-model-not-cached check so the suite stays green (and downloads
+nothing) when offline.
+"""
+
+import sys
+
+import pytest
+
+from src.popoto.embeddings import (
+    AbstractEmbeddingProvider,
+    SentenceTransformersProvider,
+)
+
+MODEL_REPO = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def _model_is_cached() -> bool:
+    """Return True only if the MiniLM weights are already in the HF cache.
+
+    Used to skip the real-encode test when the model has not been downloaded,
+    so the unit suite never triggers a ~90MB download or needs network.
+    """
+    try:
+        from huggingface_hub import try_to_load_from_cache
+    except Exception:
+        return False
+    try:
+        path = try_to_load_from_cache(repo_id=MODEL_REPO, filename="config.json")
+    except Exception:
+        return False
+    return isinstance(path, str)
+
+
+class TestContract:
+    """Interface and offline-safe behavior."""
+
+    def test_is_abstract_subclass(self):
+        assert issubclass(SentenceTransformersProvider, AbstractEmbeddingProvider)
+
+    def test_dimensions_is_384_without_loading(self):
+        """dimensions reports 384 without loading the model (no download)."""
+        provider = SentenceTransformersProvider()
+        assert provider.dimensions == 384
+        # The model must NOT have been loaded just to read dimensions.
+        assert provider._model is None
+
+    def test_embed_empty_returns_empty_without_loading(self):
+        """embed([]) short-circuits to [] without loading the model."""
+        provider = SentenceTransformersProvider()
+        assert provider.embed([]) == []
+        assert provider._model is None
+
+    def test_max_batch_size_is_conservative(self):
+        assert SentenceTransformersProvider().max_batch_size == 64
+
+
+class TestMissingDependency:
+    """The missing-dependency branch must fail loud with an actionable hint."""
+
+    def test_embed_without_sentence_transformers_raises(self, monkeypatch):
+        """Simulate sentence-transformers being absent via import monkeypatch."""
+        # Force `from sentence_transformers import SentenceTransformer` to fail.
+        monkeypatch.setitem(sys.modules, "sentence_transformers", None)
+
+        provider = SentenceTransformersProvider()
+        with pytest.raises(ImportError, match=r"popoto\[benchmark\]"):
+            provider.embed(["this should fail to embed"])
+
+
+@pytest.mark.skipif(
+    not _model_is_cached(),
+    reason="all-MiniLM-L6-v2 not cached; skipping to avoid a ~90MB download",
+)
+class TestRealEncode:
+    """One real encode round-trip, only when the model is already cached."""
+
+    def test_encode_roundtrip_shape(self):
+        provider = SentenceTransformersProvider()
+        try:
+            vectors = provider.embed(["hello world", "a second sentence"])
+        except Exception as e:  # network hiccup / load failure → skip, don't fail
+            pytest.skip(f"model unavailable at runtime: {e}")
+        assert len(vectors) == 2
+        assert len(vectors[0]) == 384
+        assert len(vectors[1]) == 384
+        assert all(isinstance(x, float) for x in vectors[0])


### PR DESCRIPTION
## Summary

The external benchmark could only run **lexical (BM25)** retrieval — the hybrid RRF path in `ContextAssembler` never executed because `ExternalScenario.run()` called `BM25Field.search` directly, and the per-item model declared no `EmbeddingField`. There was also no local (no-API-key) embedding provider.

## Changes

- **New `SentenceTransformersProvider`** (`src/popoto/embeddings/sentence_transformers.py`) wrapping `all-MiniLM-L6-v2` (384-dim). Lazy-imports `sentence_transformers` so `import popoto.embeddings` stays torch-free; `embed([]) == []`; missing-dep raises with a `pip install popoto[benchmark]` hint. Exported from `embeddings/__init__.py`.
- **`ExternalScenario`** gains `retrieval_mode='lexical'|'hybrid'`. Hybrid declares an `EmbeddingField` alongside `BM25Field` so `retrieval_mode='auto'` resolves to hybrid; `run()` now drives `ContextAssembler.assemble()` as the **primary** path (records → redis_key, `_session_key_map` reverse-mapping preserved). `teardown()` removes the per-class `.embeddings/` dir. Stale `composite`→`lexical` docstrings fixed.
- **`run_external.py`**: `--retrieval-mode {lexical,hybrid}` (default `lexical`); mode in report header/notes; stale "no vector retrieval" notes replaced.
- **Tests**: provider unit tests (dims, empty, missing-dep, guarded real encode) + `TestRetrievalModeContract` (lexical assemble-primary; hybrid effective-mode, guarded skip-if-not-cached).
- **Docs**: `SentenceTransformersProvider` in `fields.md`; `--retrieval-mode` + a "Retrieval Modes" section in `benchmarks.md`.

## Valkey-safety

Vector cosine is computed **in-process with numpy** over `EmbeddingField` `.npy` files — **no** RediSearch / `FT.*` / `BF.*` commands. Verified by grep.

## Verification

- `pytest tests/benchmarks/test_external.py tests/embeddings/ -q` → **77 passed** (real-encode + hybrid tests executed; model cached locally)
- **Lexical no-regression**: A/B run of the `assemble()`-primary path vs the old BM25-direct path on the same sample → **bit-identical** R@1/R@5/R@10/MRR
- Hybrid smoke (3 questions) ran end-to-end: effective mode `hybrid`, records returned, teardown clean
- `black --check` clean; `mkdocs build --strict` builds; Valkey grep empty

## Deferred (tracked separately)

The **full 500-question hybrid comparison run** is deliberately deferred — it embeds ~275k turns on CPU and is far slower than the lexical pass. The hybrid *path* is validated by the harness tests; the committed comparison number is a follow-up run. Hybrid is opt-in, so CI/default stays on the fast lexical path. (The lexical BM25 baseline already matches the agentmemory reference Recall@5 of 0.952.)

Plan: docs/plans/benchmark_hybrid_retrieval.md

Closes #437