### PR TITLE
test(#445): guard default agent-memory recipe against BM25 wiring drift

### DIFF
--- a/docs/guides/agent-memory-quickstart.md
+++ b/docs/guides/agent-memory-quickstart.md
@@ -1,3 +1,10 @@
+<!-- Maintainer note: tests/test_default_recipe_wiring.py parses this file.
+     It executes the `class Memory` definitions from the ```python blocks
+     before the `## Level 5` heading and asserts the recipe in effect at the
+     ContextAssembler step declares a BM25Field (query-sensitive retrieval,
+     issue #445). If you restructure the level headings or remove
+     `content_bm25` from the Level 2-4 models, that test will fail by design. -->
+
 # Agent Memory Quickstart
 
 Add programmable memory to your AI agent in 5 progressive levels. Each level is independently useful — adopt only what you need.

--- a/docs/plans/default_recipe_bm25_wiring.md
+++ b/docs/plans/default_recipe_bm25_wiring.md
@@ -6,6 +6,7 @@ owner: Claude (SDLC pipeline, issue #445)
 created: 2026-07-03
 tracking: https://github.com/tomcounsell/popoto/issues/445
 last_comment_id: none
+revision_applied: true
 ---
 
 # Default Recipe BM25 Wiring Check (query-sensitivity regression guard)
@@ -177,9 +178,17 @@ message naming the doc, the missing field, and the query-blind consequence.
 - Parse `docs/guides/agent-memory-quickstart.md` relative to the test file
   (`Path(__file__).resolve().parent.parent / "docs" / ...`) so it works from
   any checkout/worktree.
-- Section split on `^## ` headings; the ContextAssembler section is identified
-  by "ContextAssembler" in the `## Level 5` heading text (matching on the
-  stable "Level 5" prefix, asserting it mentions ContextAssembler).
+- Section split on `^## ` headings; the ContextAssembler (Level 5) section is
+  identified **solely** by matching the regex `^## Level 5\b` against the
+  heading line. The extractor **must NOT** require the substring
+  "ContextAssembler" in the heading text — the real heading is
+  `## Level 5: Cognition — LLM-Ready Context Assembly`, which contains no such
+  substring, so a heading-substring gate would find nothing and the extractor
+  would bind to the wrong recipe (or raise). If a semantic anchor is wanted for
+  extra safety, assert that "ContextAssembler" appears in the Level 5 section
+  **body** (the text between the `## Level 5` heading and the next `## `
+  heading), never in the heading itself. See Implementation Note (Critique
+  Results) for the rationale and the anti-pattern this replaces.
 - Exec only `Import`/`ImportFrom`/`ClassDef` nodes via
   `ast.parse` → filter → `compile` → `exec` into a shared namespace. Class
   definitions do not write to Redis at class-creation time; instances are
@@ -367,9 +376,14 @@ a one-file test change.
 
 ## Critique Results
 
+Verdict: **READY TO BUILD (with concerns)** — one CONCERN and one NIT. The
+CONCERN is addressed by this revision pass (`revision_applied: true`); the NIT
+is intentionally left as planned.
+
 | Severity | Critic | Finding | Addressed By | Implementation Note |
 |----------|--------|---------|--------------|---------------------|
-| | | (populated by /do-plan-critique) | | |
+| CONCERN | do-plan-critique | Level 5 section detection required the substring "ContextAssembler" in the `## Level 5` heading text, but the real heading is `## Level 5: Cognition — LLM-Ready Context Assembly` (no such substring). A heading-substring gate finds nothing → extractor binds the wrong recipe or raises, and the guard could pass vacuously or fail spuriously. | Technical Approach (section-split bullet) rewritten this revision. | **Anchor Level 5 detection ONLY on `re.match(r"^## Level 5\b", heading_line)` against the heading line. Do NOT test the heading for the substring "ContextAssembler". If a semantic anchor is desired, assert "ContextAssembler" appears in the Level 5 section BODY (text between the `## Level 5` heading and the next `## ` heading), not the heading. Heading text after the `Level 5` token is free to change without breaking the extractor.** |
+| NIT | do-plan-critique | Test 4 (`test_recipe_levels_after_attention_keep_bm25`) scope — asserts every `Memory` from the second definition onward declares `BM25Field`. | Left as planned — no change. | Intentional: pins the doc's "query-sensitive from Level 2 on" narrative; the redundancy with test 2 is deliberate and cheap. |
 
 ---
 

--- a/docs/plans/default_recipe_bm25_wiring.md
+++ b/docs/plans/default_recipe_bm25_wiring.md
@@ -1,0 +1,384 @@
+---
+status: Ready
+type: chore
+appetite: Small
+owner: Claude (SDLC pipeline, issue #445)
+created: 2026-07-03
+tracking: https://github.com/tomcounsell/popoto/issues/445
+last_comment_id: none
+---
+
+# Default Recipe BM25 Wiring Check (query-sensitivity regression guard)
+
+## Problem
+
+The CSR harness (#418, `tests/benchmarks/csr/`) validates the ContextAssembler
+mode-resolution *mechanism* with per-case model classes that hardcode
+`BM25Field` — lexical mode is guaranteed by construction. That was an explicit
+scope cut in `docs/plans/deterministic_eval_harness.md` (No-Gos), with this
+follow-up mandated at ship time.
+
+Nothing in the test suite binds the *shipped default recipe* — the model users
+are steered toward by `docs/guides/agent-memory-quickstart.md` and the
+ContextAssembler docs — to a query-sensitive retrieval mode. A #409-class
+regression (removing or misconfiguring `BM25Field` on the documented default
+recipe) would leave CSR green while production retrieval silently reverts to
+the query-blind `composite` path (`_pull_path_composite` never reads query
+text for ranking; the June audit measured P@10 ≈ random for that path).
+
+**This drift is not hypothetical.** The existing mirror tests have already
+diverged from the docs: the quickstart's Level 2–4 `Memory` models declare
+`content_bm25 = BM25Field(source="content")`, but the hand-copied mirrors in
+`tests/test_guide_examples.py` (`GuideL2Memory`, `GuideL3Memory`,
+`GuideL4Memory`, `GuideL5Memory`, `GuideCAMemory`) and
+`tests/test_adoption_ladder.py` (`AttentionMemory` et al.) do **not** declare
+any `BM25Field`. Hand-copied mirrors cannot guard doc-level recipe wiring.
+
+**Current behavior:** No test fails if `BM25Field` is dropped from the
+quickstart recipe. The suite would stay green while every user following the
+docs gets query-blind retrieval from `ContextAssembler(retrieval_mode="auto")`.
+
+**Desired outcome:** A narrow unit test that parses the actual quickstart doc,
+materializes the recipe model users end up with at the ContextAssembler step
+(Level 5), and asserts the resolved effective mode is query-sensitive
+(`lexical` or `hybrid`), never `composite`.
+
+## Freshness Check
+
+**Baseline commit:** `2d7f31f` (main HEAD at plan time)
+**Issue filed at:** 2026-07-03T09:56:50Z (same day as planning)
+**Disposition:** Unchanged
+
+**File:line references re-verified:**
+- `src/popoto/recipes/context_assembler.py:946-954` — `"auto"` resolution:
+  BM25+Embedding → `hybrid`; BM25 only → `lexical`; neither → `composite`. Confirmed.
+- `src/popoto/recipes/context_assembler.py:1180` — `_pull_path_composite` exists
+  and takes `query_cues` only for filtering, not ranking. Confirmed.
+- `docs/guides/agent-memory-quickstart.md:56,104,145` — Level 2/3/4 `Memory`
+  models each declare `content_bm25 = BM25Field(source="content")`. Confirmed.
+- `docs/plans/deterministic_eval_harness.md:592` — No-Gos section mandating this
+  follow-up. Confirmed.
+
+**Cited sibling issues/PRs re-checked:**
+- #418 — closed, shipped via PR #444 (CSR harness). Landscape unchanged since.
+- #409 — closed via PR #426 (BM25 first-class retrieval mode + recipe default).
+- #446 — open, parallel pipeline touching `src/popoto/fields/bm25_field.py`
+  (source only; this plan never edits that file).
+
+**Commits on main since issue was filed (touching referenced files):** none.
+
+**Active plans in `docs/plans/` overlapping this area:**
+`deterministic_eval_harness.md` is Complete; its No-Gos mandate exactly this
+work. No active overlap.
+
+## Prior Art
+
+- **PR #400**: Defaulted ContextAssembler to hybrid retrieval (BM25 + vector +
+  graph via RRF) — established the pull-path modes.
+- **PR #426 (issue #409)**: Made BM25 a first-class retrieval mode and recipe
+  default; added the quickstart's `content_bm25` declarations and the
+  `auto → lexical` resolution for BM25-only models. This plan guards that
+  wiring against regression.
+- **PR #444 (issue #418)**: CSR harness; its No-Gos explicitly deferred the
+  default-recipe wiring check to this issue.
+- **`tests/test_guide_examples.py`**: prior art for doc-mirroring tests — and
+  the demonstration of why mirroring by hand is insufficient (already drifted;
+  see Problem).
+
+## Research
+
+No relevant external findings — purely internal work (stdlib `ast` + existing
+popoto APIs); proceeding with codebase context.
+
+## Spike Results
+
+### spike-1: Doc-parsing + exec + mode resolution works end-to-end
+- **Assumption**: "The quickstart's fenced python blocks can be parsed with
+  `ast`, filtered to Import/ImportFrom/ClassDef nodes, exec'd cumulatively, and
+  the resulting `Memory` class drives ContextAssembler auto-resolution."
+- **Method**: prototype (scratchpad script against the real doc, DB 13)
+- **Finding**: 5 python blocks precede the Level 5 heading; 4 define
+  `class Memory` (Levels 1–4). Level 1 has no BM25Field; Levels 2–4 each have
+  `content_bm25`. The last pre-Level-5 recipe resolves to
+  `_effective_mode == "lexical"`. `ContextAssembler.__init__` requires
+  `score_weights` positionally — pass the quickstart's own
+  `{"relevance": 0.6, "confidence": 0.3}`.
+- **Confidence**: high
+- **Impact on plan**: design confirmed exactly as specified in Technical
+  Approach; no fallback needed.
+
+## Data Flow
+
+1. **Entry point**: pytest collects `tests/test_default_recipe_wiring.py`.
+2. **Doc parser**: reads `docs/guides/agent-memory-quickstart.md`, splits on
+   `## ` headings, collects fenced ```python blocks that precede the Level 5
+   (ContextAssembler) section.
+3. **AST filter**: per block, keeps only `Import`/`ImportFrom`/`ClassDef`
+   nodes (no doc runtime statements execute — no saves, no LLM/embedding
+   calls), exec's them cumulatively in one namespace, recording each
+   successive `Memory` class definition.
+4. **Assertion layer**: the recipe in effect at Level 5 (last `Memory` defined
+   before the ContextAssembler section) is checked for a declared `BM25Field`
+   and passed to `ContextAssembler(model_class=..., score_weights=...)` with
+   default `retrieval_mode="auto"`.
+5. **Output**: assertions on `_effective_mode` — must be in
+   `{"lexical", "hybrid"}` and explicitly `!= "composite"`.
+
+## Architectural Impact
+
+None at runtime — test-only. New test depends only on stdlib (`ast`, `re`,
+`pathlib`) and public popoto imports (`ContextAssembler`, `BM25Field` from the
+top-level package, per the quickstart's own import cheat sheet). It reads but
+never edits `src/popoto/fields/bm25_field.py`, so no conflict surface with the
+parallel #446 pipeline.
+
+## Appetite
+
+**Size:** Small
+
+**Team:** Solo dev (single agent pipeline)
+
+**Interactions:**
+- PM check-ins: 0 (scope fixed by issue #445 acceptance criteria)
+- Review rounds: 1 (do-pr-review)
+
+## Prerequisites
+
+| Requirement | Check Command | Purpose |
+|-------------|---------------|---------|
+| Redis on localhost:6379 | `redis-cli ping` | pytest plugin flushes the test DB |
+| POPOTO_TEST_DB=13 for all runs | `echo $POPOTO_TEST_DB` | avoid clashing with the parallel #446 pipeline on DB 15 |
+
+## Solution
+
+### Key Elements
+
+- **Quickstart recipe extractor** (test-local helper): pulls the successive
+  `Memory` class definitions out of the quickstart's python blocks, in
+  document order, stopping at the Level 5 (ContextAssembler) heading. Because
+  it reads the shipped doc, editing the doc *is* editing the recipe — the test
+  cannot drift the way the hand-copied mirrors did.
+- **Wiring assertions**: (a) the Level-5-effective recipe declares a
+  `BM25Field`; (b) `ContextAssembler` with default `retrieval_mode="auto"`
+  resolves that recipe to a query-sensitive mode (`lexical` or `hybrid`),
+  asserted both positively (membership) and negatively (`!= "composite"`);
+  (c) structural guard — the parser found the Level 5 heading and ≥ 2 `Memory`
+  definitions, so a doc restructure fails loudly instead of vacuously passing.
+
+### Flow
+
+Doc edit removing `BM25Field` from the recipe → test parses doc → recipe class
+built without BM25 → auto resolves to `composite` → assertion fails with a
+message naming the doc, the missing field, and the query-blind consequence.
+
+### Technical Approach
+
+- New file `tests/test_default_recipe_wiring.py`; no existing files modified.
+- Parse `docs/guides/agent-memory-quickstart.md` relative to the test file
+  (`Path(__file__).resolve().parent.parent / "docs" / ...`) so it works from
+  any checkout/worktree.
+- Section split on `^## ` headings; the ContextAssembler section is identified
+  by "ContextAssembler" in the `## Level 5` heading text (matching on the
+  stable "Level 5" prefix, asserting it mentions ContextAssembler).
+- Exec only `Import`/`ImportFrom`/`ClassDef` nodes via
+  `ast.parse` → filter → `compile` → `exec` into a shared namespace. Class
+  definitions do not write to Redis at class-creation time; instances are
+  never created and nothing is saved, so the test performs no Redis writes of
+  its own (the plugin's flushdb isolation still applies).
+- `_effective_mode` is the established assertion surface — already used by
+  `tests/test_context_assembler_hybrid.py` and the CSR harness; no new API.
+- `score_weights` is a required constructor arg; pass the quickstart Level 5
+  values `{"relevance": 0.6, "confidence": 0.3}` (ignored by lexical/hybrid
+  paths; harmless).
+- Tests (one behavior per test):
+  1. `test_quickstart_has_context_assembler_level` — structural guard (Level 5
+     heading found; ≥ 2 Memory definitions precede it). Prevents vacuous pass.
+  2. `test_default_recipe_declares_bm25_field` — the Level-5-effective recipe
+     declares exactly ≥ 1 `BM25Field` (checked via `_meta.fields` +
+     `isinstance`).
+  3. `test_default_recipe_auto_mode_is_query_sensitive` — resolved
+     `_effective_mode in {"lexical", "hybrid"}` and `!= "composite"` for
+     `retrieval_mode="auto"` (the default — construct without passing
+     `retrieval_mode`, so the test also guards the default value itself).
+  4. `test_recipe_levels_after_attention_keep_bm25` — every `Memory` from the
+     second definition onward (Levels 2–4) declares `BM25Field`, pinning the
+     doc's "query-sensitive from Level 2 on" narrative.
+
+## Failure Path Test Strategy
+
+### Exception Handling Coverage
+- No exception handlers in scope — the new test contains none, and no source
+  files are touched.
+
+### Empty/Invalid Input Handling
+- Structural-guard test (test 1) covers "doc restructured / heading renamed /
+  blocks vanished": the extractor raises or the guard assertion fails rather
+  than skipping silently. No `pytest.skip` on parse failure — a missing or
+  unparseable quickstart is a hard failure by design.
+
+### Error State Rendering
+- Assertion messages name the doc path, the missing `BM25Field`, and the
+  query-blind `composite` consequence so a future red run is self-explaining.
+
+## Test Impact
+
+No existing tests affected — the change is purely additive (one new test
+file). The pre-existing drift in `tests/test_guide_examples.py` /
+`tests/test_adoption_ladder.py` mirrors is intentionally **not** fixed here
+(see No-Gos).
+
+## Rabbit Holes
+
+- **Fixing the drifted mirror tests** (adding `BM25Field` to `GuideL*Memory` /
+  `AttentionMemory` etc.): touches many tests, adds Redis index behavior to
+  their runs, and is orthogonal to the wiring guard. Separate cleanup.
+- **Executing doc blocks verbatim** (imports + statements): Level 2+ blocks
+  save records, Level 5 calls `assemble()`, Level 6 needs a Voyage API key.
+  Class-defs-only extraction is the deliberate, sufficient scope.
+- **Parsing `docs/features/context-assembler.md` code blocks too**: its
+  examples reference `Memory` without defining it — not materializable. The
+  quickstart is the canonical recipe source; the feature doc's mode table is
+  already covered by unit tests in `test_context_assembler_hybrid.py`.
+- **Generalizing into a doc-example test framework**: out of scope; one
+  focused test file.
+
+## Risks
+
+### Risk 1: Quickstart restructures (headings renamed, levels reordered)
+**Impact:** Extractor could bind to the wrong recipe or find nothing.
+**Mitigation:** Structural-guard test fails loudly (explicit assertion on the
+Level 5 heading and Memory-definition count); assertion messages tell the doc
+editor exactly what invariant the doc must keep.
+
+### Risk 2: Exec'ing doc-derived class definitions has import side effects
+**Impact:** A future doc edit adding an exotic import could slow or break the test.
+**Mitigation:** Only blocks before Level 5 are exec'd (Level 6's
+`VoyageProvider` import never runs); imports in scope are all top-level
+popoto names per the doc's own cheat sheet.
+
+### Risk 3: Model class name collision (`Memory` defined 4×)
+**Impact:** Popoto keys by class name; duplicate definitions could interact.
+**Mitigation:** Spike confirmed class creation is side-effect-free in Redis;
+no instances are saved; each definition simply rebinds the namespace entry.
+The pytest plugin flushes DB 13/15 per test regardless.
+
+## Race Conditions
+
+No race conditions identified — the test is synchronous, single-threaded, and
+performs no Redis writes. Cross-pipeline contention with #446 is handled by
+`POPOTO_TEST_DB=13` (they run on a different DB index).
+
+## No-Gos (Out of Scope)
+
+- [SEPARATE-SLUG #446] Any edit to `src/popoto/fields/bm25_field.py` — owned
+  by the parallel #446 pipeline; this plan only imports the class via the
+  top-level `popoto` package.
+- Runtime behavior changes of any kind — the issue mandates test-only; the
+  Verification table carries an anti-criterion asserting `src/` is untouched.
+- Fixing the drifted `GuideL*Memory`/`AttentionMemory` mirror models — noted
+  in this plan as evidence, but it is a separate cleanup with real blast
+  radius (BM25 on_save indexing changes those tests' Redis footprints). Not
+  filed as an issue by this plan; the PR description will flag it for the
+  maintainer to triage. (Tag rationale: candidate future work surfaced by this
+  plan, not a deferred obligation of it — issue #445's acceptance criteria do
+  not include mirror repair.)
+
+## Update System
+
+No update system changes required — test-only change inside the repo.
+
+## Agent Integration
+
+No agent integration required — pytest-collected regression guard.
+
+## Documentation
+
+No documentation changes required: the test asserts existing documented
+behavior (quickstart recipes + `retrieval_mode` docs already describe the
+auto-resolution rules and the composite trap at
+`docs/guides/agent-memory-quickstart.md:308` and
+`docs/features/context-assembler.md`). No new feature surface. The do-docs
+gate will verify the docs build and confirm no cascade is needed.
+
+## Success Criteria
+
+- [ ] A test fails if the quickstart's default recipe loses its `BM25Field`
+      (verified during build by red-proofing: temporarily strip
+      `content_bm25` from a copy of the doc text and confirm the assertion
+      trips — proof pasted into the PR description).
+- [ ] The test asserts resolved `_effective_mode != "composite"` (and
+      membership in `{"lexical", "hybrid"}`) under default/auto mode — not
+      merely field presence.
+- [ ] No files under `src/` modified; no existing test files modified.
+- [ ] Full suite green locally: `POPOTO_TEST_DB=13 scripts/ci-local.sh --fast`.
+- [ ] Docs gate run (`/do-docs`) — expected no-op, recorded.
+
+## Team Orchestration
+
+Single-agent pipeline (this SDLC session): the lead agent implements directly;
+do-pr-review provides the independent review pass. No subagent team needed for
+a one-file test change.
+
+## Step by Step Tasks
+
+### 1. Write the wiring test
+- **Task ID**: build-wiring-test
+- **Depends On**: none
+- **Validates**: `tests/test_default_recipe_wiring.py` (create)
+- **Informed By**: spike-1 (confirmed: parser+exec+resolution works; score_weights required)
+- Create `tests/test_default_recipe_wiring.py` with extractor helper + 4 tests
+  per Technical Approach.
+- Run `black` on the new file.
+
+### 2. Red-proof the guard
+- **Task ID**: validate-red
+- **Depends On**: build-wiring-test
+- Feed the extractor a doc variant with `content_bm25` lines stripped
+  (in-memory string, not a file edit) and demonstrate the mode assertion
+  fails → capture output for the PR description. Implement as a fifth test
+  (`test_guard_trips_when_bm25_removed`) so the red-proof is permanent, not a
+  one-off.
+
+### 3. Full local verification
+- **Task ID**: validate-all
+- **Depends On**: validate-red
+- `POPOTO_TEST_DB=13 pytest tests/test_default_recipe_wiring.py -q` green.
+- `POPOTO_TEST_DB=13 scripts/ci-local.sh --fast` green.
+- Confirm `git diff --stat main` touches only `tests/test_default_recipe_wiring.py`
+  and `docs/plans/default_recipe_bm25_wiring.md`.
+
+### 4. Ship
+- **Task ID**: ship
+- **Depends On**: validate-all
+- Commit on `feature/445-default-recipe-bm25-wiring`, push, open PR with
+  `Closes #445`, red-proof output, and the mirror-drift flag for maintainer
+  triage.
+
+## Verification
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| New wiring tests pass | `POPOTO_TEST_DB=13 pytest tests/test_default_recipe_wiring.py -q` | exit code 0 |
+| Full fast suite passes | `POPOTO_TEST_DB=13 scripts/ci-local.sh --fast` | exit code 0 |
+| Mode assertion present | `grep -c 'composite' tests/test_default_recipe_wiring.py` | output > 0 |
+| Test-only: no src changes | `git diff --name-only main...HEAD -- src/ \| wc -l` | match count == 0 |
+| bm25_field.py untouched (anti-criterion, #446 conflict guard) | `git diff --name-only main...HEAD -- src/popoto/fields/bm25_field.py \| wc -l` | match count == 0 |
+| No new xfails | `grep -c 'xfail' tests/test_default_recipe_wiring.py` | match count == 0 |
+
+## Critique Results
+
+| Severity | Critic | Finding | Addressed By | Implementation Note |
+|----------|--------|---------|--------------|---------------------|
+| | | (populated by /do-plan-critique) | | |
+
+---
+
+## Open Questions
+
+None — scope is fully determined by issue #445's acceptance criteria, and
+spike-1 resolved the single technical unknown (extractor feasibility). The one
+judgment call (which `Memory` is "the default recipe") is resolved as: the
+recipe in effect when the quickstart reaches its ContextAssembler step, i.e.
+the last `Memory` defined before Level 5 — matching the doc's progressive
+narrative ("Use any Memory model from Levels 1-4", with Level 2+ adding
+query-sensitivity precisely for this purpose).

--- a/tests/test_default_recipe_wiring.py
+++ b/tests/test_default_recipe_wiring.py
@@ -1,0 +1,255 @@
+"""Default recipe BM25 wiring check (query-sensitivity regression guard).
+
+Guards issue #445: the *shipped* default agent-memory recipe — the model
+users are steered toward by `docs/guides/agent-memory-quickstart.md` — must
+declare a `BM25Field` so `ContextAssembler(retrieval_mode="auto")` resolves
+to a query-sensitive mode (`lexical` or `hybrid`), never the query-blind
+`composite` path.
+
+The CSR harness (#418, `tests/benchmarks/csr/`) validates the mode-resolution
+*mechanism* with per-case model classes that hardcode `BM25Field` — lexical
+mode is guaranteed by construction there. This test instead parses the real
+quickstart doc and materializes the recipe it actually ships, so a doc edit
+that drops `BM25Field` fails this test the way it would silently regress
+production retrieval otherwise.
+
+This is a test-only file: it reads `docs/guides/agent-memory-quickstart.md`
+and performs no writes of its own (class definitions do not touch Redis).
+"""
+
+import ast
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+from src.popoto import BM25Field  # noqa: E402
+from src.popoto.recipes.context_assembler import ContextAssembler  # noqa: E402
+
+QUICKSTART_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "guides"
+    / "agent-memory-quickstart.md"
+)
+
+# The quickstart's own Level 5 score_weights, used unchanged so the assembler
+# is constructed exactly as the doc constructs it (harmless for lexical/hybrid
+# paths, which ignore score_weights for the pull path).
+LEVEL5_SCORE_WEIGHTS = {"relevance": 0.6, "confidence": 0.3}
+
+
+def _extract_pre_level5_memory_classes():
+    """Parse the quickstart doc and materialize each `Memory` class defined
+    in a fenced python block before the `## Level 5` heading.
+
+    Returns a list of `Memory` classes in document order (one per fenced
+    python block that defines `class Memory`). Only `Import`/`ImportFrom`/
+    `ClassDef` AST nodes are executed — no doc runtime statements (saves,
+    LLM/embedding calls) ever run.
+
+    Level 5 is identified **solely** by matching `^## Level 5\\b` against the
+    heading line — never by a substring match against "ContextAssembler" in
+    the heading text, since the real heading
+    ("## Level 5: Cognition — LLM-Ready Context Assembly") contains no such
+    substring.
+    """
+    text = QUICKSTART_PATH.read_text()
+    lines = text.splitlines()
+
+    level5_line_idx = None
+    for i, line in enumerate(lines):
+        if re.match(r"^## Level 5\b", line):
+            level5_line_idx = i
+            break
+
+    assert level5_line_idx is not None, (
+        f"Structural guard failed: no '## Level 5' heading found in "
+        f"{QUICKSTART_PATH}. The quickstart doc may have been restructured; "
+        f"update the extractor's heading anchor if Level 5 was renamed."
+    )
+
+    # Semantic anchor: "ContextAssembler" must appear in the Level 5 section
+    # BODY (never required in the heading itself).
+    next_heading_idx = len(lines)
+    for i in range(level5_line_idx + 1, len(lines)):
+        if lines[i].startswith("## "):
+            next_heading_idx = i
+            break
+    level5_body = "\n".join(lines[level5_line_idx + 1 : next_heading_idx])
+    assert "ContextAssembler" in level5_body, (
+        "Structural guard failed: the Level 5 section body no longer "
+        "mentions ContextAssembler. The quickstart's Cognition level may "
+        "have been restructured."
+    )
+
+    pre_level5_text = "\n".join(lines[:level5_line_idx])
+    code_blocks = re.findall(r"```python\n(.*?)```", pre_level5_text, re.DOTALL)
+
+    namespace = {}
+    memory_classes = []
+    for block in code_blocks:
+        tree = ast.parse(block)
+        keep_nodes = [
+            node
+            for node in tree.body
+            if isinstance(node, (ast.Import, ast.ImportFrom, ast.ClassDef))
+        ]
+        if not keep_nodes:
+            continue
+        filtered_module = ast.Module(body=keep_nodes, type_ignores=[])
+        ast.fix_missing_locations(filtered_module)
+        code = compile(filtered_module, filename=str(QUICKSTART_PATH), mode="exec")
+        exec(code, namespace)  # noqa: S102 - controlled doc-derived AST, defs only
+
+        for node in keep_nodes:
+            if isinstance(node, ast.ClassDef) and node.name == "Memory":
+                memory_classes.append(namespace["Memory"])
+
+    return memory_classes
+
+
+@pytest.fixture(scope="module")
+def pre_level5_memory_classes():
+    return _extract_pre_level5_memory_classes()
+
+
+@pytest.fixture(scope="module")
+def default_recipe(pre_level5_memory_classes):
+    """The recipe in effect when the quickstart reaches ContextAssembler:
+    the last `Memory` defined before the Level 5 heading."""
+    return pre_level5_memory_classes[-1]
+
+
+def _has_bm25_field(model_class):
+    return any(
+        isinstance(field, BM25Field) for field in model_class._meta.fields.values()
+    )
+
+
+class TestQuickstartStructure:
+    def test_quickstart_has_context_assembler_level(self, pre_level5_memory_classes):
+        """Structural guard: the Level 5 heading was found (see fixture setup
+        assertions) and at least 2 `Memory` definitions precede it. Prevents
+        a doc restructure from causing this suite to pass vacuously."""
+        assert len(pre_level5_memory_classes) >= 2, (
+            f"Expected at least 2 'Memory' class definitions before the "
+            f"'## Level 5' heading in {QUICKSTART_PATH}, found "
+            f"{len(pre_level5_memory_classes)}. The quickstart's progressive "
+            f"levels (1-4) may have been restructured."
+        )
+
+
+class TestDefaultRecipeWiring:
+    def test_default_recipe_declares_bm25_field(self, default_recipe):
+        assert _has_bm25_field(default_recipe), (
+            f"The default agent-memory recipe from "
+            f"{QUICKSTART_PATH} no longer declares a BM25Field. "
+            f"ContextAssembler(retrieval_mode='auto') will silently fall "
+            f"back to the query-blind 'composite' path for every user "
+            f"following the quickstart."
+        )
+
+    def test_default_recipe_auto_mode_is_query_sensitive(self, default_recipe):
+        # Construct without passing retrieval_mode, so this also guards the
+        # default value of retrieval_mode itself ("auto").
+        assembler = ContextAssembler(
+            model_class=default_recipe,
+            score_weights=LEVEL5_SCORE_WEIGHTS,
+        )
+        assert assembler._effective_mode in {"lexical", "hybrid"}, (
+            f"Default recipe from {QUICKSTART_PATH} resolved to "
+            f"'{assembler._effective_mode}' under retrieval_mode='auto' "
+            f"(the default). Expected a query-sensitive mode "
+            f"('lexical' or 'hybrid'). This means BM25Field is missing or "
+            f"misconfigured on the default recipe."
+        )
+        assert assembler._effective_mode != "composite", (
+            f"Default recipe from {QUICKSTART_PATH} resolved to the "
+            f"query-blind 'composite' path under retrieval_mode='auto' "
+            f"(the default). Production retrieval for every user following "
+            f"the quickstart would rank results independent of query text "
+            f"(#409-class regression: P@10 ~= random)."
+        )
+
+    def test_recipe_levels_after_attention_keep_bm25(self, pre_level5_memory_classes):
+        """Every Memory definition from the second one onward (Levels 2-4,
+        i.e. everything after Level 1's pure recall recipe) declares
+        BM25Field. Pins the doc's 'query-sensitive from Level 2 on'
+        narrative; deliberately redundant with the default-recipe check
+        above since the default recipe IS one of these classes."""
+        for idx, model_class in enumerate(pre_level5_memory_classes[1:], start=2):
+            assert _has_bm25_field(model_class), (
+                f"Memory definition #{idx} (document order) in "
+                f"{QUICKSTART_PATH} does not declare a BM25Field. Levels "
+                f"2-4 of the quickstart are documented as query-sensitive; "
+                f"this recipe regressed that guarantee."
+            )
+
+
+class TestGuardTripsWhenBM25Removed:
+    def test_guard_trips_when_bm25_removed(self, default_recipe):
+        """Red-proof: feed the extractor a doc variant with BM25Field lines
+        stripped (in-memory string, never a file edit) and confirm the mode
+        assertion fails. Kept as a permanent test so the red-proof isn't a
+        one-off manual check."""
+        doc_text = QUICKSTART_PATH.read_text()
+        stripped_text = re.sub(
+            r"^\s*content_bm25\s*=\s*BM25Field\([^)]*\).*$",
+            "",
+            doc_text,
+            flags=re.MULTILINE,
+        )
+        assert stripped_text != doc_text, (
+            "Red-proof setup failed: stripping 'content_bm25 = BM25Field(...)' "
+            "lines had no effect on the doc text, so this red-proof would not "
+            "actually exercise the failure path."
+        )
+
+        lines = stripped_text.splitlines()
+        level5_line_idx = next(
+            i for i, line in enumerate(lines) if re.match(r"^## Level 5\b", line)
+        )
+        pre_level5_text = "\n".join(lines[:level5_line_idx])
+        code_blocks = re.findall(r"```python\n(.*?)```", pre_level5_text, re.DOTALL)
+
+        namespace = {}
+        memory_classes = []
+        for block in code_blocks:
+            tree = ast.parse(block)
+            keep_nodes = [
+                node
+                for node in tree.body
+                if isinstance(node, (ast.Import, ast.ImportFrom, ast.ClassDef))
+            ]
+            if not keep_nodes:
+                continue
+            filtered_module = ast.Module(body=keep_nodes, type_ignores=[])
+            ast.fix_missing_locations(filtered_module)
+            code = compile(filtered_module, filename=str(QUICKSTART_PATH), mode="exec")
+            exec(code, namespace)  # noqa: S102 - controlled doc-derived AST, defs only
+            for node in keep_nodes:
+                if isinstance(node, ast.ClassDef) and node.name == "Memory":
+                    memory_classes.append(namespace["Memory"])
+
+        stripped_default_recipe = memory_classes[-1]
+        assert not _has_bm25_field(stripped_default_recipe), (
+            "Red-proof setup failed: BM25Field is still present on the "
+            "recipe after stripping content_bm25 lines from the doc text."
+        )
+
+        assembler = ContextAssembler(
+            model_class=stripped_default_recipe,
+            score_weights=LEVEL5_SCORE_WEIGHTS,
+        )
+        assert assembler._effective_mode == "composite", (
+            "Red-proof failed: expected the BM25-stripped recipe to resolve "
+            "to 'composite' under retrieval_mode='auto', but it resolved to "
+            f"'{assembler._effective_mode}'. The guard would not actually "
+            "catch a #409-class regression."
+        )


### PR DESCRIPTION
## Summary
- Adds `tests/test_default_recipe_wiring.py`, a narrow regression guard mandated as a follow-up in the #418 CSR harness plan's No-Gos.
- The CSR harness (#418) validates the `ContextAssembler` mode-resolution *mechanism* with per-case model classes that hardcode `BM25Field` — lexical mode is guaranteed by construction there. Nothing previously bound the *shipped default recipe* (the model `docs/guides/agent-memory-quickstart.md` steers users toward) to a query-sensitive retrieval mode.
- The new test parses the real quickstart doc, materializes the `Memory` recipe in effect at the Level 5 (ContextAssembler) step, and asserts it declares a `BM25Field` and resolves `retrieval_mode="auto"` (the default) to `lexical`/`hybrid` — never the query-blind `composite` path that a #409-class regression would silently produce.

## Changes
- New file `tests/test_default_recipe_wiring.py` (5 tests):
  1. `test_quickstart_has_context_assembler_level` — structural guard (Level 5 heading found via `^## Level 5\b`, never a heading-substring match on "ContextAssembler"; ≥2 `Memory` defs precede it).
  2. `test_default_recipe_declares_bm25_field` — the Level-5-effective recipe declares a `BM25Field`.
  3. `test_default_recipe_auto_mode_is_query_sensitive` — resolved `_effective_mode in {"lexical","hybrid"}` and `!= "composite"` under default `retrieval_mode="auto"`.
  4. `test_recipe_levels_after_attention_keep_bm25` — every Memory def from Level 2 onward keeps `BM25Field`.
  5. `test_guard_trips_when_bm25_removed` — permanent red-proof: strips `content_bm25 = BM25Field(...)` from an in-memory copy of the doc text and confirms the recipe then resolves to `composite`.
- No `src/` files touched. `docs/plans/default_recipe_bm25_wiring.md` is the only other file in the diff (plan doc, migrated by `/do-merge` after merge).

## Red-proof (test 5, `test_guard_trips_when_bm25_removed`)
Confirmed the guard actually trips: stripping `content_bm25` lines from the quickstart text causes the extracted recipe to resolve to `_effective_mode == "composite"` under `retrieval_mode="auto"` — exactly the regression this test guards against. This is implemented as a permanent test, not a one-off manual check.

## Testing
- [x] `POPOTO_TEST_DB=13 pytest tests/test_default_recipe_wiring.py -q` — 5 passed
- [x] Full suite (`pytest -q`, no `POPOTO_TEST_DB` override, isolating from CPU contention): only 1 pre-existing failure (`test_isolated_db_subprocess`, a known redis-py version-compat issue unrelated to this change — no source files touched by this PR)
- [x] Under `POPOTO_TEST_DB=13` the full suite shows 5 additional failures in `tests/test_pytest_plugin.py`, all from a hardcoded `assert current_db == 15` — expected since the plan's own Prerequisites table mandates `POPOTO_TEST_DB=13` to isolate from the parallel #446 pipeline running on DB 15; not a regression from this change.
- [x] `black --check tests/test_default_recipe_wiring.py` clean
- [x] `git diff --name-only main...HEAD -- src/` — 0 files (test-only change)
- [x] `git diff --name-only main...HEAD -- src/popoto/fields/bm25_field.py` — 0 files (no conflict with parallel #446 pipeline)

## Documentation
- No documentation changes required — the test asserts existing documented behavior (quickstart recipes + `retrieval_mode` auto-resolution already documented). No new feature surface.

## Note for maintainer
Per the plan's No-Gos, the pre-existing drift in `tests/test_guide_examples.py` (`GuideL2Memory`...`GuideCAMemory`) and `tests/test_adoption_ladder.py` (`AttentionMemory` et al.) — hand-copied `Memory` mirrors that do **not** declare `BM25Field`, unlike the real quickstart recipe — is intentionally **not** fixed here. It's flagged as candidate follow-up cleanup, not a deferred obligation of this PR.

## Definition of Done
- [x] Built: test-only change implemented and working
- [x] Tested: new wiring tests passing; full suite has no new failures
- [x] Documented: no doc changes required per plan (test asserts already-documented behavior)
- [x] Quality: black clean

Closes #445