### PR TITLE
Retrieval-arm diagnostics: harness-local vector-only baseline (#455)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,9 @@ Pipfile
 
 *.dump
 settings/local.py
+
+# Benchmark byproducts (e.g. data/doc_embeddings.json — large, regenerated)
+data/
 /src/popoto/_archive/
 .claude/hooks/
 .claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@
 pip install popoto
 ```
 
+## Running
+
+Popoto is a library, not a standalone service. It runs inside your application and talks to a Redis or Valkey server. To exercise it locally (and to run the test suite) you need a Redis/Valkey server listening on `localhost:6379`.
+
+```bash
+# 1. Start Redis (or Valkey), e.g. on macOS via Homebrew:
+redis-server                     # or: brew services start redis
+
+# 2. Install Popoto with dev dependencies:
+uv venv && source .venv/bin/activate && uv pip install -e ".[dev]"
+
+# 3. Run the test suite (auto-isolated on Redis DB 15):
+pytest
+```
+
+By default Popoto connects to `localhost:6379`; set `REDIS_URL` to point at a different server. The pytest plugin isolates tests on Redis DB 15 (override with `POPOTO_TEST_DB=<n>`).
+
 ## Basic Usage
 
 ``` python

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -96,7 +96,7 @@ python -m tests.benchmarks.run_external \
 | `--limit N` | all | Evaluate at most N questions (sampled per `--sample`) |
 | `--sample MODE` | `stride` | How `--limit` selects: `stride` (even spread, representative), `stratified` (proportional per `question_type`), `shuffle` (seeded random), `head` (legacy contiguous prefix). Ignored without `--limit`. |
 | `--seed N` | 0 | Seed for `shuffle`/`stratified` sampling |
-| `--retrieval-mode MODE` | `lexical` | `lexical` (BM25 only) or `hybrid` (BM25 + vector via RRF). See [Retrieval Modes](#retrieval-modes). |
+| `--retrieval-mode MODE` | `lexical` | `lexical` (BM25 only), `hybrid` (BM25 + vector via RRF), or `vector` (`EmbeddingField` only, pure cosine — diagnostic). See [Retrieval Modes](#retrieval-modes). |
 | `--dry-run` | off | Print results without saving report files |
 | `--fixture PATH` | download | Load dataset from a local JSON file |
 | `--output DIR` | `results/external/` | Override output directory |
@@ -133,19 +133,28 @@ Each JSON report includes:
 
 ### Retrieval Modes
 
-`--retrieval-mode` selects how the harness retrieves candidates. Both modes drive
-`ContextAssembler.assemble()`; field presence on the per-item model determines the
-effective mode (`retrieval_mode="auto"`):
+`--retrieval-mode` selects how the harness retrieves candidates. `lexical` and
+`hybrid` drive `ContextAssembler.assemble()`; field presence on the per-item model
+determines the effective mode (`retrieval_mode="auto"`). `vector` is a harness-local
+diagnostic that **bypasses** the assembler and ranks by pure cosine directly:
 
-| Mode | Fields | Fusion | Cost |
+| Mode | Fields | Method | Cost |
 |------|--------|--------|------|
 | `lexical` (default) | `BM25Field` | none (BM25 ranking) | no model download; fast |
 | `hybrid` | `BM25Field` + `EmbeddingField` | BM25 + vector via **RRF (k=60)** | one-time ~90 MB `all-MiniLM-L6-v2` download; slower (CPU embedding) |
+| `vector` | `EmbeddingField` only | pure cosine (no BM25, no RRF) | same ~90 MB `all-MiniLM-L6-v2` download as hybrid; slower (CPU embedding) |
 
 Hybrid is **Valkey-safe**: vector similarity is computed in-process with numpy
 cosine over `EmbeddingField` `.npy` files — no RediSearch, no vector-search modules,
 no `FT.*` / `BF.*` commands. The vector signal uses the local
 [`SentenceTransformersProvider`](fields.md#sentencetransformersprovider) (no API key).
+
+`vector` is a **harness-local diagnostic** (issue #455): it bypasses
+`ContextAssembler` entirely — auto-mode would resolve an embedding-only model to the
+query-blind `composite` path, so the harness ranks by raw cosine over the
+`EmbeddingField` directly. It isolates **only** the dense arm; it does **not**
+exercise the graph / co-occurrence arm that also lives inside `hybrid`. Use it to
+diagnose the vector signal's standalone strength, not as a production retrieval path.
 
 ```bash
 # Lexical (default) — BM25 only, no model download:
@@ -154,6 +163,9 @@ python -m tests.benchmarks.run_external --dataset longmemeval-s
 # Hybrid — BM25 + vector (downloads MiniLM on first run):
 pip install -e ".[benchmark]"
 python -m tests.benchmarks.run_external --dataset longmemeval-s --retrieval-mode hybrid
+
+# Vector — pure cosine over EmbeddingField only (diagnostic; downloads MiniLM):
+python -m tests.benchmarks.run_external --dataset longmemeval-s --retrieval-mode vector
 ```
 
 **LongMemEval-S, 500 questions (any-hit Recall):**

--- a/docs/plans/retrieval_arm_diagnostics_vector_baseline.md
+++ b/docs/plans/retrieval_arm_diagnostics_vector_baseline.md
@@ -120,7 +120,9 @@ the harness cannot currently produce.
 - **#409 / PR #426** — "make BM25 a first-class retrieval mode"; the reason
   `composite` is query-blind. Directly relevant: an Embedding-only model under
   `auto` mode falls into that same query-blind `composite` bucket, which is
-  *why* vector needs to be first-class rather than auto-resolved. **Succeeded.**
+  *why* the harness ranks by cosine directly rather than routing an
+  embedding-only model through the assembler (which would resolve to the
+  query-blind `composite` path, not vector search). **Succeeded.**
 - **#457** — the downstream consumer (weighted/query-adaptive fusion). This plan
   is its unblocking gate. **Open.**
 
@@ -196,9 +198,10 @@ build:
   `load_embeddings(model_class)`, returns sorted `(redis_key, score)`. It is
   Valkey-safe (no `FT.*`), already used by the hybrid arm, and needs no RRF.
 - **Confidence**: high.
-- **Impact on plan**: `_pull_path_vector` is a thin wrapper — call
-  `_get_vector_scores`, hydrate records in cosine order, done. No new similarity
-  code.
+- **Impact on plan**: the harness calls `QueryBuilder._get_vector_scores`
+  directly in `ExternalScenario.run()` — the returned `(redis_key, score)` pairs
+  are already sorted by cosine descending, so the redis keys ARE the ranked
+  retrieval. No new similarity code and no assembler involvement.
 
 ### spike-3: Does auto-mode already give us vector-only for free?
 - **Assumption**: "An EmbeddingField-only model under `retrieval_mode='auto'`
@@ -209,10 +212,11 @@ build:
   matches *neither* and resolves to `composite` (query-blind — wrong). So vector
   must be an **explicit** first-class mode.
 - **Confidence**: high.
-- **Impact on plan**: Add `"vector"` to `_VALID_MODES` and drive it via
-  **explicit** `retrieval_mode="vector"` (the scenario passes it explicitly).
-  Leave `auto` resolution untouched so no production default behavior changes
-  (see No-Gos).
+- **Impact on plan**: the CLI exposes `--retrieval-mode vector` and the harness
+  drives it entirely — `ExternalScenario` builds an EmbeddingField-only model and
+  `run()` ranks by pure cosine, bypassing the assembler. `ContextAssembler` is
+  **not** touched (no `_VALID_MODES` entry, no `auto` change), so no production
+  default behavior changes (see No-Gos).
 
 ## Data Flow
 
@@ -221,13 +225,16 @@ build:
 2. **Adapter**: `iter_locomo` / `iter_longmemeval` yield `BenchmarkItem`s
    (unchanged).
 3. **Scenario setup** (`external_base.py`): `_build_external_model_class(prefix,
-   embedding_only=True)` builds a model with **EmbeddingField only, no
-   BM25Field**; `ContextAssembler(model_class, retrieval_mode="vector")`.
+   with_bm25=False, with_embedding=True)` builds a model with **EmbeddingField
+   only, no BM25Field**; `setup()` sets `self._assembler = None` (no assembler is
+   constructed for vector mode).
 4. **Ingest**: one record per non-empty turn (unchanged); embeddings written to
    the per-class `.npy` dir.
-5. **Retrieve** (`ContextAssembler.assemble` → `_pull_path` →
-   **`_pull_path_vector`**): `_get_vector_scores(query_text, limit)` → cosine
-   ranking → hydrate records in score order. No BM25, no RRF, no graph.
+5. **Retrieve** (`ExternalScenario.run()`, assembler bypassed):
+   `QueryBuilder(model_class.query)._get_vector_scores(query_text, limit)` →
+   cosine ranking → the returned `(redis_key, score)` pairs are already sorted by
+   similarity descending, so the redis keys ARE the ranked retrieval. No BM25, no
+   RRF, no graph, no assembler.
 6. **Score** (`run_item`): `recall_at_k` (1/5/10) + `mean_reciprocal_rank`
    (unchanged; optionally + `ndcg_at_k` — see Open Questions).
 7. **Aggregate + report** (`compute_aggregate`, `build_markdown_report`,
@@ -241,15 +248,18 @@ build:
 
 - **New dependencies**: none. Reuses `SentenceTransformersProvider`
   (all-MiniLM-L6-v2), existing numpy cosine, existing artifact plumbing.
-- **Interface changes**: `ContextAssembler` gains one valid mode
-  (`"vector"`) + one method (`_pull_path_vector`). `_VALID_MODES` grows by one
-  entry. `run_external.py` CLI choice grows by one. All **purely additive** —
-  no existing branch signature changes.
+- **Interface changes** (harness-local — Open Question 1): `ContextAssembler` is
+  **not** modified — no `_VALID_MODES` entry, no `_pull_path_vector`, no `auto`
+  change. Only the benchmark harness changes: `run_external.py` CLI choice grows
+  by one, and `ExternalScenario` gains an embedding-only model variant + a
+  cosine-ranking branch in `run()`. All harness-local and additive.
 - **Coupling**: unchanged. Vector mode reuses `_get_vector_scores`, already a
-  dependency of the hybrid path.
+  dependency of the hybrid path — but now the harness calls it directly rather
+  than through the assembler.
 - **Data ownership**: unchanged.
-- **Reversibility**: high — the mode is additive and gated behind an explicit
-  opt-in; removing it deletes one branch + one method + one CLI choice.
+- **Reversibility**: high — the change is confined to the benchmark harness;
+  removing it deletes one CLI choice + the `run()`/`setup()` vector branch and
+  the embedding-only model variant. No production surface to unwind.
 
 ## Appetite
 
@@ -284,15 +294,19 @@ appetite is the two long detached benchmark runs and their interpretation.
   with the spike-1 citations, that BM25 and the embedding arm rank identical
   per-turn units at both the model and retrieval layers. Recorded in the plan
   (above) and summarized in `docs/benchmarks.md` / the PR. No code.
-- **First-class `vector` retrieval mode** in `ContextAssembler`: additive
-  `_VALID_MODES` entry, explicit-mode validation (requires EmbeddingField),
-  and `_pull_path_vector` (pure cosine via `_get_vector_scores`, no BM25 / RRF /
-  graph). `auto` resolution is **not** changed.
+- **Harness-local vector ranking** (Open Question 1 → harness-local):
+  `ContextAssembler` is **NOT** modified. `ExternalScenario.run()` ranks by pure
+  cosine directly via `QueryBuilder(model_class.query)._get_vector_scores(
+  query_text, limit)` (no BM25 / RRF / graph, no `_pull_path_vector`, no
+  `_VALID_MODES` change). The assembler is bypassed entirely for vector mode
+  because auto-mode would resolve an embedding-only model to the query-blind
+  `composite` path.
 - **Harness plumbing**: `--retrieval-mode vector` CLI choice; an
-  `embedding_only` model variant in `_build_external_model_class` (EmbeddingField
-  only, no BM25Field); vector-mode notes in `compute_aggregate` /
-  `build_markdown_report`; `_vector` artifact suffix (already generic in
-  `save_reports`).
+  embedding-only model variant in `_build_external_model_class`
+  (`with_bm25=False, with_embedding=True` → EmbeddingField only, no BM25Field);
+  `setup()` sets `self._assembler = None` for vector mode; vector-mode notes in
+  `compute_aggregate` / `build_markdown_report`; `_vector` artifact suffix
+  (already generic in `save_reports`).
 - **Two diagnostic runs**: vector-only on LongMemEval-S (500 q) and LoCoMo
   (1986 q), launched detached, artifacts committed.
 - **Docs update**: vector-only R@1/5/10/MRR folded into `docs/benchmarks.md`
@@ -301,36 +315,39 @@ appetite is the two long detached benchmark runs and their interpretation.
 ### Flow
 
 `run_external.py --retrieval-mode vector` → ExternalScenario builds
-EmbeddingField-only model → `ContextAssembler(retrieval_mode="vector")` →
-`_pull_path_vector` (cosine) → R@1/5/10/MRR → `{slug}_{date}_vector.*` artifacts
-→ `docs/benchmarks.md` table row.
+EmbeddingField-only model (no BM25Field) → `setup()` sets `_assembler = None`
+(assembler bypassed) → `run()` calls
+`QueryBuilder(model_class.query)._get_vector_scores(query_text, limit)` (cosine)
+→ maps `(redis_key, score)` pairs to ground-truth IDs → R@1/5/10/MRR →
+`{slug}_{date}_vector.*` artifacts → `docs/benchmarks.md` table row.
 
-### Technical Approach
+### Technical Approach (harness-local — Open Question 1 resolved)
 
-- **`_VALID_MODES`** (`context_assembler.py:937`): add `"vector"`.
-- **Explicit-mode validation** (mirror the `lexical` elif at 969-977): a
-  `retrieval_mode == "vector"` branch that requires an EmbeddingField
-  (`self._embedding_field is not None`), else `QueryException`; sets
-  `self._effective_mode = "vector"`.
-- **Dispatch** (`_pull_path`, 1165-1178): add
-  `elif self._effective_mode == "vector": return self._pull_path_vector(...)`.
-- **`_pull_path_vector`**: build a `QueryBuilder`, call
-  `_get_vector_scores(query_text, limit=self.max_items * HYBRID_CANDIDATE_MULTIPLIER)`,
-  take the top `self.max_items * 2` keys in cosine order, hydrate to records
-  (reuse the hydration `fuse()`/lexical paths use), return
-  `(candidates, all_candidates)`. Empty vector signal → return `[], []` (do
-  **not** fall back to composite: a vector-only baseline must not silently
-  become query-blind — that would corrupt the diagnostic).
-- **Harness — `_build_external_model_class`**: add an `embedding_only: bool`
-  path (or a 3-way `mode` arg) that declares the EmbeddingField but **omits**
-  `content_index = BM25Field(...)`. `setup()` (`external_base.py:206-217`)
-  selects it when `retrieval_mode == "vector"` and constructs the assembler with
-  `retrieval_mode="vector"` (not `"auto"`).
+- **No `context_assembler.py` change.** `_VALID_MODES`, `_pull_path`, and the
+  assembler's `auto`/lexical/hybrid resolution are **untouched**. The briefly
+  committed first-class `_pull_path_vector` (65b36ea) is reverted so
+  `git diff main -- src/popoto/recipes/context_assembler.py` is empty.
+- **Harness — `_build_external_model_class`** (`external_base.py`): a
+  `with_bm25` / `with_embedding` pair. Vector mode passes
+  `with_bm25=False, with_embedding=True` → EmbeddingField only, **no**
+  `content_index = BM25Field(...)`.
+- **Harness — `setup()`**: for `retrieval_mode == "vector"` sets
+  `self._assembler = None` (no assembler is constructed); lexical/hybrid still
+  build `ContextAssembler(retrieval_mode="auto")` as before.
+- **Harness — `run()`**: for vector mode, build a `QueryBuilder` from
+  `self._model_class.query` and call
+  `_get_vector_scores(self.item.query, limit=MAX_ITEMS)` (`query.py:995-1067`).
+  The returned `(redis_key, score)` pairs are already sorted by cosine
+  descending, so the redis keys ARE the ranked retrieval — no hydration and no
+  `fuse()`/RRF are needed. Empty vector signal → empty retrieved_ids (R@k = 0),
+  never a composite fallback (a vector-only baseline must not silently become
+  query-blind — that would corrupt the diagnostic).
 - **`run_external.py`**: add `"vector"` to the `--retrieval-mode` choices
-  (496-505) and its help text; thread through `run_item` /
-  `compute_aggregate` / `save_reports` (all already parameterized on
-  `retrieval_mode`); add a `vector` branch to the `mode_notes` (240-253) and the
-  `build_markdown_report` mode blurb (373-384).
+  and its help text; thread through `run_item` / `compute_aggregate` /
+  `save_reports` (all already parameterized on `retrieval_mode`); add a `vector`
+  branch to the `mode_notes` and the `build_markdown_report` mode blurb. The
+  `_vector` artifact suffix already falls out of the generic
+  `suffix = "" if retrieval_mode == "lexical" else f"_{retrieval_mode}"`.
 - **Runs**: `nohup python -m tests.benchmarks.run_external --dataset <d>
   --retrieval-mode vector … & disown` per the #442/#447 ops lesson; the
   inherited `stop_invalidation_listeners()` teardown prevents the connection
@@ -344,13 +361,14 @@ EmbeddingField-only model → `ContextAssembler(retrieval_mode="vector")` →
 ## Failure Path Test Strategy
 
 ### Exception Handling Coverage
-- The existing hybrid/vector code paths wrap failures in
+- The existing hybrid/lexical assembler paths wrap failures in
   `logger.warning(...)` + fallback (e.g. `context_assembler.py:1293,1311,1362`).
-  `_pull_path_vector` must **not** copy the composite fallback — a vector-only
-  baseline that silently degrades to query-blind composite would produce a
-  misleading number. Add a test asserting that when `_get_vector_scores`
-  returns `[]`, `_pull_path_vector` returns `([], [])` (empty), **not** a
-  composite result.
+  The harness-local vector path must **not** copy that composite fallback — a
+  vector-only baseline that silently degrades to query-blind composite would
+  produce a misleading number. Because the vector path bypasses the assembler
+  entirely and ranks by raw cosine in `ExternalScenario.run()`, when
+  `_get_vector_scores` returns `[]` the run yields empty retrieved_ids (R@k = 0),
+  **never** a composite result.
 - `_get_vector_scores` already returns `[]` (not raise) on missing
   provider/embeddings/numpy (`query.py:1025-1046`); assert the vector mode
   surfaces that as an empty ScenarioResult, not an error crash.
@@ -416,9 +434,10 @@ disown`) and watch the progress log.
 ### Risk 2: Empty vector signal silently falls back to composite, corrupting the baseline
 **Impact:** A "vector-only" number that is really query-blind composite would
 mislead the #457 decision.
-**Mitigation:** `_pull_path_vector` returns empty on no signal (no composite
-fallback), with an explicit test asserting it. Documented in Failure Path
-Strategy.
+**Mitigation:** The harness-local vector path (`ExternalScenario.run()`) ranks by
+raw cosine and returns empty retrieved_ids on no signal — the assembler is
+bypassed, so there is no composite fallback to fall into. An explicit test
+asserts it. Documented in Failure Path Strategy.
 
 ### Risk 3: nDCG scope creep forces a full three-mode re-benchmark
 **Impact:** The cheap diagnostic turns into re-running lexical + hybrid on both
@@ -476,25 +495,36 @@ is no MCP/tool surface to wire.
 - [ ] `mkdocs build --strict` passes (the docs deploy gate).
 
 ### Inline Documentation
-- [ ] Docstring for `_pull_path_vector` and the `vector` mode in
-  `ContextAssembler`'s class/`assemble` docstrings (mirror the existing
-  lexical/hybrid docstrings).
-- [ ] Update `external_base.py` module docstring (the "Retrieval mode" section,
-  lines 25-38) to describe the vector mode.
+- [ ] ~~Docstring for `_pull_path_vector` in `ContextAssembler`~~ — VOID
+  (harness-local; the assembler is not modified).
+- [ ] Update `external_base.py` module docstring (the "Retrieval mode" section)
+  and `ExternalScenario.run()` docstring to describe the harness-local vector
+  mode (pure cosine, assembler bypassed).
 
 ## Success Criteria
 
 - [ ] Granularity-parity audit is written with citations and its conclusion
   (parity holds → weak-arm hypothesis elevated) recorded in `docs/benchmarks.md`
-  + PR.
-- [ ] `ContextAssembler` accepts `retrieval_mode="vector"` (EmbeddingField
-  required), dispatches to `_pull_path_vector` (pure cosine, no BM25/RRF/graph),
-  and rejects vector mode on a BM25-only / no-embedding model with
-  `QueryException`.
-- [ ] `_pull_path_vector` returns empty (not composite) on empty vector signal —
-  asserted by a test.
+  + PR. **The audit isolates only the dense arm** — not the graph /
+  co-occurrence arm that also lives inside hybrid's `_pull_path_hybrid` — so the
+  conclusion is scoped to the vector signal's standalone strength.
+- [ ] **Harness-local (Open Question 1):** `git diff main -- src/popoto/recipes/context_assembler.py`
+  is **empty** — no first-class `vector` mode, no `_pull_path_vector`, no
+  `_VALID_MODES` change ship to production.
+- [ ] `ExternalScenario.run()` ranks vector mode by pure cosine via
+  `QueryBuilder._get_vector_scores` (no BM25/RRF/graph, assembler bypassed) and
+  yields empty retrieved_ids (R@k = 0), not a composite fallback, on empty
+  vector signal.
+- [ ] **Decision rule for #457 (the diagnostic's core deliverable):**
+  vector-only LoCoMo R@1 **substantially below lexical** R@1 (mirroring the
+  hybrid<lexical LoCoMo regression) confirms the **weak-arm / RRF-dilution**
+  hypothesis and greenlights #457's weighted/query-adaptive fusion; vector-only
+  **competitive with hybrid** instead reopens the **fusion-mechanism**
+  hypothesis (the fix is in how the arms combine, not in the dense arm). This
+  rule is recorded in `docs/benchmarks.md` so #457 proceeds without a fresh
+  interpretation debate.
 - [ ] `run_external.py --retrieval-mode vector` runs end-to-end on a smoke
-  subset (`--limit 20 --dry-run`).
+  subset (`--limit 20 --dry-run` / fixture).
 - [ ] Full vector-only runs committed for **both** datasets as
   `{slug}_{date}_vector.{json,md}` + `{slug}_latest_vector.*`, never
   overwriting lexical/hybrid artifacts.
@@ -512,10 +542,12 @@ builds directly.
 
 ### Team Members
 
-- **Builder (assembler-vector-mode)**
+- **Builder (assembler-vector-mode)** — **VOID** (Open Question 1 → harness-local;
+  see Task 1). No `ContextAssembler` changes ship; the vector ranking lives in
+  the harness (`harness-builder`, below).
   - Name: `vector-mode-builder`
-  - Role: Add `"vector"` to `ContextAssembler` (`_VALID_MODES`, validation,
-    `_pull_path_vector`, dispatch) + unit tests.
+  - Role: ~~Add `"vector"` to `ContextAssembler` (`_VALID_MODES`, validation,
+    `_pull_path_vector`, dispatch) + unit tests.~~ VOID.
   - Agent Type: builder
   - Domain: Redis/Popoto data + retrieval
   - Resume: true
@@ -549,39 +581,34 @@ builds directly.
 
 ## Step by Step Tasks
 
-### 1. Add first-class `vector` mode to ContextAssembler
+### 1. ~~Add first-class `vector` mode to ContextAssembler~~ — VOID (Open Question 1 → harness-local)
 - **Task ID**: build-vector-mode
-- **Depends On**: none
-- **Validates**: `tests/recipes/test_context_assembler*.py` (extend/create)
-- **Informed By**: spike-2 (reuse `_get_vector_scores`), spike-3 (must be
-  explicit, not auto)
-- **Assigned To**: vector-mode-builder
-- **Agent Type**: builder
-- **Parallel**: true
-- Add `"vector"` to `_VALID_MODES` (`context_assembler.py:937`).
-- Add a `retrieval_mode == "vector"` validation branch (requires EmbeddingField,
-  else `QueryException`; set `_effective_mode = "vector"`).
-- Add `_pull_path_vector`: cosine via `_get_vector_scores`, hydrate top
-  `max_items*2` in score order, return `(candidates, all_candidates)`; empty
-  signal → `([], [])` (NO composite fallback).
-- Add dispatch in `_pull_path`.
-- Unit tests: resolution, missing-field rejection, empty-signal-no-fallback.
+- **Status**: **VOID.** Open Question 1 resolved harness-local, so `ContextAssembler`
+  is not modified. The briefly-committed `_VALID_MODES` entry + `_pull_path_vector`
+  (65b36ea) are reverted; `git diff main -- src/popoto/recipes/context_assembler.py`
+  must be empty. The pure-cosine ranking lives in the harness (Task 2), calling
+  `QueryBuilder._get_vector_scores` directly.
 
-### 2. Harness plumbing for `--retrieval-mode vector`
+### 2. Harness-local vector ranking + plumbing for `--retrieval-mode vector`
 - **Task ID**: build-harness
 - **Depends On**: none
 - **Validates**: `tests/benchmarks/test_external.py`
+- **Informed By**: spike-2 (reuse `_get_vector_scores`), spike-3 (auto-mode
+  gives composite, not vector — so bypass the assembler)
 - **Assigned To**: harness-builder
 - **Agent Type**: builder
 - **Parallel**: true
 - Add `"vector"` to the `--retrieval-mode` choices + help (`run_external.py`).
-- Add `embedding_only` model variant in `_build_external_model_class`
-  (EmbeddingField only, no BM25Field).
-- Wire `setup()` to select it and construct
-  `ContextAssembler(retrieval_mode="vector")` when
-  `retrieval_mode == "vector"`.
+- Add an embedding-only model variant in `_build_external_model_class`
+  (`with_bm25=False, with_embedding=True` → EmbeddingField only, no BM25Field).
+- Wire `setup()` to set `self._assembler = None` for vector mode (no assembler).
+- Wire `run()` to rank by pure cosine via
+  `QueryBuilder(self._model_class.query)._get_vector_scores(query_text, MAX_ITEMS)`
+  and map `(redis_key, score)` pairs to ground-truth IDs; empty signal → empty
+  retrieved_ids (NO composite fallback).
 - Add `vector` branch to `mode_notes` + `build_markdown_report` blurb.
-- Tests: `save_reports`/`compute_aggregate` vector suffix + notes.
+- Tests: `save_reports`/`compute_aggregate` vector suffix + notes; cosine-path
+  smoke via fixture.
 
 ### 3. Validate additive-only + failure paths
 - **Task ID**: validate-vector
@@ -628,33 +655,50 @@ builds directly.
 | Check | Command | Expected |
 |-------|---------|----------|
 | Tests pass | `pytest tests/ -q` | exit code 0 |
-| Vector is a valid mode | `grep -c '"vector"' src/popoto/recipes/context_assembler.py` | output > 0 |
-| Vector pull path exists | `grep -c '_pull_path_vector' src/popoto/recipes/context_assembler.py` | output > 0 |
+| Assembler untouched (harness-local, anti-criterion) | `git diff main -- src/popoto/recipes/context_assembler.py` | empty diff |
+| No first-class vector mode leaked to production | `grep -c '_pull_path_vector' src/popoto/recipes/context_assembler.py` | output == 0 |
+| Harness ranks vector by cosine | `grep -c '_get_vector_scores' tests/benchmarks/scenarios/external_base.py` | output > 0 |
 | CLI exposes vector | `grep -c 'vector' tests/benchmarks/run_external.py` | output > 0 |
-| RRF constant unchanged (anti-criterion: no fusion tuning) | `grep -c 'RRF_K = 60' src/popoto/recipes/context_assembler.py` | output > 0 |
-| No composite fallback in vector path (anti-criterion) | `awk '/def _pull_path_vector/,/def [a-z]/' src/popoto/recipes/context_assembler.py \| grep -c '_pull_path_composite'` | match count == 0 |
 | Vector artifacts committed (LoCoMo) | `ls tests/benchmarks/results/external/locomo_latest_vector.json` | exit code 0 |
 | Vector artifacts committed (LongMemEval-S) | `ls tests/benchmarks/results/external/longmemeval_s_latest_vector.json` | exit code 0 |
 | Docs build | `mkdocs build --strict` | exit code 0 |
 
 ## Critique Results
 
-<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
-| Severity | Critic | Finding | Addressed By | Implementation Note |
-|----------|--------|---------|--------------|---------------------|
+**Verdict: NEEDS REVISION** — 1 blocker must be resolved before build. Critics:
+Risk & Robustness, Scope & Value, History & Consistency (FULL depth). 4 findings
+(1 blocker, 3 concerns, 0 nits). All three critics independently flagged Open
+Question 1 as unresolved-yet-committed; cross-validation + live working-tree
+divergence elevated it to BLOCKER.
+
+| Severity | Critic(s) | Finding | Addressed By | Implementation Note |
+|----------|-----------|---------|--------------|---------------------|
+| **BLOCKER** | All 3 | Open Question 1 (first-class production `vector` mode vs harness-local) is unresolved, but Solution (287-290), Technical Approach (310-323), Tasks 1-2 (552-584), Success Criteria (490-493) and Verification (631-632) all commit to first-class. The in-progress branch has already diverged: harness went harness-local (`external_base.py` cosine bypass), assembler got first-class `_pull_path_vector`. Build is split across both approaches. | Resolve Q1 (PM check-in) and reconcile with divergent in-progress code before dispatching Tasks 1-2. | Add `Depends On: open-question-1-resolved` to `build-vector-mode` and `build-harness`. If harness-local chosen, Task 1, `_VALID_MODES`/`_pull_path` edits, and the two `context_assembler.py` verification greps (631-632) become void — `ExternalScenario.run()` calls `QueryBuilder(model_class)._get_vector_scores(query_text, limit)` (query.py:995-1067) and hydrates itself, no `context_assembler.py` diff. |
+| CONCERN | Risk & Robustness, History & Consistency | `_pull_path_vector` "reuse the hydration `fuse()` path" contradicts the no-RRF vector-only guarantee. `_get_vector_scores` returns raw `(redis_key, score)` tuples, not records; hydration in hybrid is done by `fuse()`, which IS the RRF fusion function. Routing vector-only candidates back through `fuse()` re-invokes RRF — contradicting Data Flow's "No BM25, no RRF, no graph" (228-230) and Risk 2 (416-421). | Name the exact hydration primitive to reuse, or confirm one must be factored out of `fuse()`, before Task 1. | Either call `fuse()` with only `vector=` populated and verify single-arm input preserves cosine order, or extract the hydrate-by-redis_key sub-step and reuse directly. Add a unit assertion that `_pull_path_vector` never invokes `RRF_K`-weighted scoring. |
+| CONCERN | Risk & Robustness | "Weak-arm vs broken-fusion" is a false binary — vector-only cannot isolate the graph arm inside hybrid. `_pull_path_hybrid` fuses a THIRD graph/co-occurrence arm seeded from BM25 top-5. A weak vector-only number cannot distinguish "vector arm weak" from "graph arm is the confound." Concluding it "elevates the weak-arm/RRF hypothesis" (spike-1, 183-188) overstates what a vector-vs-everything comparison proves. | Scope the audit's conclusion language, or add a graph-arm-off ablation as a follow-up candidate in Open Questions before #457 commits to a fix. | In `docs/benchmarks.md` interpretation guide, state that the vector-only run isolates only the dense arm — not the graph/co-occurrence arm in `_pull_path_hybrid`. |
+| CONCERN | Scope & Value | Success Criteria (485-506) are all mechanical — none define the "decisive" result that unblocks #457. Every criterion is a mechanical check; none state the decision rule (threshold/pattern) that lets #457 proceed without a fresh interpretation debate. The plan's purpose is to unblock #457, so the deliverable's core value is undefined. | Add a Success Criterion stating the decision rule. | Docs-only change to Success Criteria + `docs/benchmarks.md` interpretation guide. E.g. "vector-only LoCoMo R@1 substantially below lexical R@1 (mirroring hybrid<lexical) confirms weak-arm/RRF; competitive with hybrid reopens the fusion-mechanism hypothesis." |
 
 ---
 
 ## Open Questions
 
-1. **Vector-mode implementation surface.** Recommended: add a first-class
-   explicit `retrieval_mode="vector"` to production `ContextAssembler`
-   (additive; `auto`/lexical/hybrid untouched) and have the harness pass it
-   explicitly. Alternative: keep it harness-local (scenario calls
-   `_get_vector_scores` directly, zero production change). The recommended path
-   keeps `assemble()` as the primary retrieval path (the #437 architecture) at
-   the cost of one additive production branch. **Approve the recommended
-   first-class approach, or prefer harness-local?**
+1. **Vector-mode implementation surface.** ✅ **RESOLVED (2026-07-13):
+   harness-local.** The maintainer chose the **harness-local** alternative: the
+   vector-only baseline lives entirely in the benchmark harness and
+   `ContextAssembler` is **NOT** modified. `ExternalScenario.run()` calls
+   `QueryBuilder(model_class.query)._get_vector_scores(query_text, limit)`
+   (`query.py:995-1067`) directly and maps the returned `(redis_key, score)`
+   pairs back to ground-truth IDs — no `context_assembler.py` diff, no
+   `_pull_path_vector`, no new `_VALID_MODES` entry, no `retrieval_mode="vector"`
+   branch in the assembler. The first-class production `vector` mode (the
+   originally-recommended path, briefly committed in 65b36ea) is **rejected and
+   reverted**: shipping a production `retrieval_mode="vector"` was deemed
+   unwarranted for a diagnostic, and auto-mode resolving an embedding-only model
+   to the query-blind `composite` path stays a #457/#409 concern, not this
+   measurement task. Rationale: the vector baseline is a one-off diagnostic to
+   unblock #457; it does not need to be a durable `assemble()` retrieval path.
+   The superseded first-class plan is preserved at
+   `docs/plans/vector_retrieval_mode.md` (status: Superseded) for history.
 2. **nDCG.** The issue says "consider adding nDCG across all three modes."
    Default here is **OFF** (headline R@1/5/10/MRR vector is the diagnostic).
    Wiring nDCG means binary-gain nDCG@{5,10} and, for a comparable three-mode

--- a/docs/plans/vector_retrieval_mode.md
+++ b/docs/plans/vector_retrieval_mode.md
@@ -1,0 +1,424 @@
+---
+status: Ready
+type: feature
+appetite: Small
+owner: valor
+created: 2026-07-10
+tracking: https://github.com/tomcounsell/popoto/issues/455
+last_comment_id: 0
+revision_applied: false
+---
+
+# Retrieval-arm diagnostics: vector-only baseline (`--retrieval-mode vector`)
+
+## Problem
+
+The full LoCoMo run (#447) found hybrid (BM25 + vector, RRF k=60)
+**underperforming** lexical on every metric (R@1 0.1667 vs 0.2986, MRR 0.2835 vs
+0.4124) — the inverse of LongMemEval-S, where hybrid wins on every metric. The
+working hypothesis is that on coreference-heavy multi-session dialogue the vector
+arm injects topically-similar-but-wrong candidates, and unweighted RRF gives that
+weak-but-confident arm equal say with BM25.
+
+**Current behavior:** `run_external.py` supports `--retrieval-mode lexical`
+(BM25 only) and `--retrieval-mode hybrid` (BM25 + vector via RRF). There is **no
+way to measure the vector arm in isolation.** Without a vector-only baseline we
+cannot tell whether the LoCoMo regression comes from the *arm* (vector recall is
+genuinely weak on dialogue) or from the *fusion* (RRF blends two comparable arms
+badly).
+
+**Desired outcome:** a third `--retrieval-mode vector` that ranks by pure cosine
+over the `EmbeddingField` `.npy` embeddings — no BM25, no RRF — with artifacts
+suffixed `_vector` so they never touch the committed lexical or hybrid baselines.
+Running it on both datasets isolates the vector arm and confirms or refutes the
+weak-arm hypothesis. **Measurement only — no retrieval tuning, no changes to the
+hybrid/lexical paths.**
+
+## Freshness Check
+
+**Baseline commit:** `3855053` (`docs(plans): adopt 2026-07-10 benchmarking
+strategy as roadmap of record for epic #456`) — current `origin/main` HEAD.
+**Issue filed at:** 2026-07-03 (reshaped under epic #456, 2026-07-10 review).
+**Disposition:** Unchanged — premise intact.
+
+**File:line references re-verified against `origin/main` (`3855053`):**
+- `tests/benchmarks/run_external.py:113` — `run_item(item, retrieval_mode=...)`
+  threads the mode into `ExternalScenario`. **Confirmed.**
+- `tests/benchmarks/run_external.py:240-253` — `compute_aggregate` branches
+  `mode_notes` on `"hybrid"` vs else(lexical). Needs a `"vector"` branch.
+  **Confirmed.**
+- `tests/benchmarks/run_external.py:373-384` — `build_markdown_report` closing
+  paragraph branches `hybrid` vs else. Needs a `"vector"` branch. **Confirmed.**
+- `tests/benchmarks/run_external.py:419-452` — `save_reports` suffix logic:
+  `suffix = "" if retrieval_mode == "lexical" else f"_{retrieval_mode}"`. Already
+  generic — `vector` → `_vector` with **no change**. **Confirmed.**
+- `tests/benchmarks/run_external.py:495-505` — `--retrieval-mode` `choices=
+  ("lexical", "hybrid")`. Needs `"vector"` added. **Confirmed.**
+- `tests/benchmarks/scenarios/external_base.py:100-159` —
+  `_build_external_model_class(safe_prefix, with_embedding=...)` builds BM25-only
+  (lexical) or BM25+Embedding (hybrid). Needs an **Embedding-only** shape for
+  vector. **Confirmed.**
+- `tests/benchmarks/scenarios/external_base.py:195-217` — `setup()` builds the
+  model and a `ContextAssembler(retrieval_mode="auto")`. For vector we skip the
+  assembler (see Data Flow / Solution). **Confirmed.**
+- `tests/benchmarks/scenarios/external_base.py:257-356` — `run()` drives
+  `assemble()`. Needs a vector branch that ranks by pure cosine. **Confirmed.**
+- `src/popoto/models/query.py:995-1067` — `QueryBuilder._get_vector_scores(
+  query_text, limit)` returns `[(redis_key, cosine), ...]` sorted descending,
+  positive similarities only, via `matrix @ query_vec` over
+  `EmbeddingField.load_embeddings()`. This is the **exact pure-cosine primitive**
+  the hybrid vector arm uses (`context_assembler.py:1308`). Reuse it verbatim so
+  vector-only numbers are directly comparable to the hybrid vector arm.
+  **Confirmed.**
+- `src/popoto/recipes/context_assembler.py:946-954` — `auto` mode resolution:
+  BM25+Embedding→hybrid, BM25-only→lexical, **neither** (incl. embedding-only)→
+  `composite` (query-blind). So an EmbeddingField-only model routed through the
+  assembler's `auto` mode would resolve to **composite (query-blind)**, NOT
+  vector search. This is why vector mode **bypasses the assembler** and calls the
+  cosine primitive directly. **Confirmed — load-bearing design constraint.**
+- `docs/benchmarks.md:99, 136-147, 176-194` — CLI table, Retrieval Modes section,
+  and the LoCoMo tables. Need a `vector` row/paragraph and result slots.
+  **Confirmed.**
+
+**Cited sibling issues/PRs re-checked:**
+- #442/#443 — shared MiniLM provider (`_get_shared_provider`) + listener teardown
+  (`stop_invalidation_listeners()`). **On main.** Vector mode declares an
+  `EmbeddingField` and so relies on both fixes; both are already present on the
+  shared `ExternalScenario` path.
+- #447/#452 — full LoCoMo lexical + hybrid baselines committed; this run adds the
+  missing vector arm to the same tables. **On main.**
+- #457 — weighted/query-adaptive fusion. This diagnostic **unblocks** it; it is
+  not implemented here.
+
+**Notes:** No drift. MiniLM (`all-MiniLM-L6-v2`) is already in the local HF cache,
+so no download on the smoke tests or the runs.
+
+## Research
+
+No external research required. The cosine primitive, the shared provider, and the
+mode-suffix artifact convention already exist. The only external dependency is the
+datasets themselves (LongMemEval-S cleaned JSON already cached; LoCoMo downloads
+`snap-research/locomo`/`locomo10.json` on first run — already exercised by #447).
+
+## Prior Art
+
+- **#447/#452 (`locomo_full_benchmark_run.md`, shipped):** committed the full
+  lexical + hybrid LoCoMo baselines and the `_hybrid` mode-suffix artifact
+  convention. This plan is the vector twin — same harness, same artifact naming,
+  one new mode.
+- **#442/#443 (`benchmark_hybrid_full_run.md`, shipped):** added the shared MiniLM
+  provider and the listener-teardown fix that make a full embedding run practical.
+  Vector mode reuses both with zero new plumbing.
+- **#437/#395 (ContextAssembler `auto` mode / effective-mode reporting):** defines
+  the assembler's field-presence→mode resolution. This plan works **with** that
+  design by recognizing that embedding-only resolves to composite (query-blind)
+  under the assembler, and therefore routes vector retrieval around the assembler
+  to the raw cosine primitive instead.
+
+No prior vector-only run exists — this is the first.
+
+## Data Flow
+
+1. **Entry point:** `python -m tests.benchmarks.run_external --dataset {locomo,
+   longmemeval-s} --retrieval-mode vector`. `main()` threads
+   `retrieval_mode="vector"` into `run_item` → `ExternalScenario`.
+2. **setup():** `_build_external_model_class(prefix, with_bm25=False,
+   with_embedding=True)` builds an **EmbeddingField-only** per-item model (no
+   `BM25Field`). Each non-empty turn is saved as one record; `EmbeddingField`
+   writes one `.npy` per turn (same per-turn granularity as BM25 — see Risks §1).
+   The `ContextAssembler` is **not** constructed in vector mode.
+3. **run() (vector branch):** build `QueryBuilder(model_class.query)` and call
+   `_get_vector_scores(item.query, limit=max_items)` → `[(redis_key, cosine)]`
+   sorted descending. Take the redis_keys in rank order as `retrieved_keys`. This
+   is pure cosine — no BM25, no RRF, no graph. `retrieval_method="vector"` is
+   recorded in metadata.
+4. **Scoring:** the existing `redis_key → session_id/turn_id` reverse map
+   (unchanged) converts `retrieved_keys` to ground-truth ids; `run_item` computes
+   R@1/5/10 + MRR exactly as for the other modes.
+5. **teardown():** unchanged — deletes records, scans by class/agent prefix,
+   removes the per-class embedding dir, and calls `stop_invalidation_listeners()`
+   (the #442 connection-leak fix). Runs for vector mode because an EmbeddingField
+   is present.
+6. **Artifacts:** `save_reports(..., retrieval_mode="vector")` writes
+   `{slug}_{date}_vector.{json,md}` and `{slug}_latest_vector.{json,md}` via the
+   already-generic suffix logic — never touches lexical/hybrid artifacts.
+
+## Appetite
+
+**Size:** Small. **Team:** Solo dev + code reviewer. **Interactions:** 1 review
+round; 0-1 PM check-ins (only for run wall-clock).
+
+Code surface is small and confined to `tests/benchmarks/`: one new mode string
+threaded through the CLI + aggregate + report, one new model-builder branch
+(embedding-only), one new `run()` retrieval branch (reuse the existing cosine
+primitive), plus tests and a docs table. The long pole is the **LoCoMo vector run
+wall-clock** (CPU MiniLM embedding of ~26k turns) — launched detached, not on the
+PR critical path.
+
+## Prerequisites
+
+| Requirement | Check Command | Purpose | Status |
+|-------------|---------------|---------|--------|
+| `[benchmark]` extra installed | `python -c "import huggingface_hub, sentence_transformers, numpy"` | embedding + cosine | expected ✅ |
+| Redis/Valkey on :6379 | `redis-cli ping` | ingestion target | expected ✅ |
+| MiniLM cached (~90MB) | `try_to_load_from_cache('sentence-transformers/all-MiniLM-L6-v2', 'config.json')` | vector signal | ✅ present locally |
+| LoCoMo dataset | adapter downloads on first run | ~1986 QA over 10 dialogues | ✅ exercised by #447 |
+
+## Solution
+
+### Key Elements
+
+- **CLI:** add `"vector"` to `--retrieval-mode` `choices`; extend the help text.
+- **Model builder:** generalize `_build_external_model_class(safe_prefix,
+  with_bm25=True, with_embedding=False)` so vector mode gets `with_bm25=False,
+  with_embedding=True` → an **EmbeddingField-only** model. Lexical
+  (`with_bm25=True, with_embedding=False`) and hybrid (`True, True`) are
+  byte-behavior-unchanged.
+- **Scenario:** in `setup()`, choose field flags from `retrieval_mode` and skip
+  the `ContextAssembler` when mode is `vector`. In `run()`, add a `vector` branch
+  that ranks via `QueryBuilder._get_vector_scores(query, limit=max_items)` (pure
+  cosine) and records `retrieval_method="vector"`. Lexical/hybrid paths untouched.
+- **Aggregate + report:** add a `"vector"` branch to `compute_aggregate`'s
+  `mode_notes` and to `build_markdown_report`'s closing paragraph. R@1/5/10 + MRR
+  are already computed uniformly, so the full metric vector is reported for vector
+  mode with no extra work (satisfies the addendum's "full metric-vector
+  reporting").
+- **Artifacts:** none — `save_reports`' `suffix = "" if lexical else f"_{mode}"`
+  already yields `_vector`.
+- **Runs:** launch both datasets detached (`nohup … & disown`); commit artifacts
+  and fill `docs/benchmarks.md` when they land. The PR merges on the code +
+  methodology; numbers slot in after.
+
+### Granularity-parity audit (addendum, read-only)
+
+The 2026-07-10 review flagged BM25/embedding **granularity mismatch** as the
+leading suspect for the LoCoMo hybrid regression. Read-only finding from the
+harness: in `_build_external_model_class`, both `BM25Field(source="content")` and
+`EmbeddingField(source="content")` are declared on the **same** per-turn
+`ExternalBenchmarkMemory`, and `setup()` saves **one instance per non-empty
+turn**. So both arms index exactly one unit per turn, from the identical
+`content` string — **parity confirmed, no mismatch.** The hybrid regression is
+therefore not a granularity artifact; the vector-only run tests the remaining
+(weak-arm / fusion) hypotheses. This finding is recorded in the plan, the issue,
+and `docs/benchmarks.md` — it is documentation, not a code change.
+
+### Technical Approach
+
+- Reuse `_get_vector_scores` (the hybrid vector arm's own primitive) rather than
+  `semantic_search()` — the latter blends memory signals (composite), which would
+  contaminate a "pure cosine" baseline. Using the identical primitive keeps the
+  vector-only numbers directly comparable to the vector contribution inside
+  hybrid.
+- Retrieve `limit=max_items` (20, matching the assembler's `max_items`) so R@10 is
+  well-defined and the candidate depth matches the other modes.
+- Detached runs: `nohup python -m tests.benchmarks.run_external --dataset X
+  --retrieval-mode vector > logs/… 2>&1 & disown`. Monitor progress (the harness
+  logs every 10 items). Do not commit a `--limit` partial as the headline.
+- Commit hygiene: stage only `tests/benchmarks/results/external/*_vector.*` and
+  `docs/benchmarks.md`; never `data/`, `.embeddings/`, or the cached dataset.
+
+### Flow
+
+`--retrieval-mode vector` → embedding-only model per item → per-turn `.npy` →
+`_get_vector_scores(query)` pure cosine → ranked redis_keys → map to session/turn
+ids → R@1/5/10 + MRR → `save_reports(..., "vector")` writes `_vector` artifacts →
+fill `docs/benchmarks.md` → `mkdocs build --strict`.
+
+## Rabbit Holes
+
+- **Adding a `vector` effective mode to `ContextAssembler`.** Out of scope and
+  higher-risk (core library API, its own test surface). Vector-only retrieval is a
+  measurement concern; keep it in the benchmark harness and reuse the existing
+  cosine primitive.
+- **Tuning to improve the vector numbers** (weighted fusion, RRF_K, different
+  model, normalization changes). Explicitly out of scope — #457 owns fusion.
+- **Adding nDCG.** The addendum says "consider"; deferred to keep the metric set
+  identical to the already-committed lexical/hybrid artifacts (which have no
+  nDCG). Adding it would require recomputing all three modes for parity — a
+  separate change.
+- **Refactoring `save_reports` / artifact layout.** Already generic; touch
+  nothing.
+- **Re-running or altering lexical/hybrid.** Leave the committed baselines byte-
+  identical.
+- **Committing run byproducts** (`data/`, `.embeddings/` `.npy`, cached dataset).
+
+## Risks
+
+### Risk 1: Granularity mismatch invalidates the comparison
+**Impact:** If BM25 and embedding indexed different units, the vector-only numbers
+would not be comparable to lexical/hybrid.
+**Mitigation:** Audited (see Granularity-parity audit) — both arms index one
+per-turn record from the same `content` source. Parity confirmed; documented.
+
+### Risk 2: Embedding-only model routed through the assembler silently degrades to composite
+**Impact:** `ContextAssembler(auto)` resolves embedding-only → `composite`
+(query-blind), which would produce meaningless "vector" numbers.
+**Mitigation:** Vector mode **bypasses the assembler** and calls
+`_get_vector_scores` directly. A test asserts `retrieval_method == "vector"` and
+that the returned records actually rank the query-relevant turn first, guarding
+against an accidental composite fallback.
+
+### Risk 3: Vector run wall-clock (LoCoMo ~26k turns, CPU embedding)
+**Impact:** An interactive timeout could kill a multi-hour run.
+**Mitigation:** Launch detached (`nohup … & disown`), monitor via the per-10-item
+progress log. The PR does not block on the run; numbers land afterward.
+
+### Risk 4: Connection-pool exhaustion from per-item embedding listeners
+**Impact:** Each `EmbeddingField` starts a PubSubWorkerThread holding a pool
+connection; a fresh class per item would exhaust the pool (~item 120) as it did
+pre-#442.
+**Mitigation:** `teardown()` already calls `stop_invalidation_listeners()` per
+item (the #442 fix); vector mode runs the same teardown. No new plumbing.
+
+### Risk 5: Valkey-compatibility regression
+**Impact:** Any `FT.*`/`BF.*`/vector-module dependency breaks Valkey.
+**Mitigation:** `_get_vector_scores` is in-process numpy cosine over `.npy`
+files — the same substrate hybrid uses. A verification grep confirms no module
+commands are introduced.
+
+## Race Conditions
+
+None. Ingestion and retrieval are synchronous, single-threaded, one item at a
+time. The shared MiniLM provider is read-only after its one-time load. Each turn
+is ingested in `setup()` before `run()` queries; `teardown()` releases the
+listener connection per item.
+
+## No-Gos (Out of Scope)
+
+- Any retrieval-quality change to lexical or hybrid (tuning, fields, fusion
+  weights, RRF_K, metric semantics).
+- Adding a `vector` mode to `ContextAssembler` or any `src/popoto/` change.
+- nDCG (deferred).
+- Committing run byproducts or the cached dataset.
+- Implementing #457 (weighted/query-adaptive fusion) — this only unblocks it.
+
+## Update System
+
+No update/deploy-system changes. Internal benchmark harness + docs only; the
+vector path lives behind the already-declared `[benchmark]` extra, exactly like
+hybrid.
+
+## Agent Integration
+
+None. The benchmark harness is a developer CLI; no agent/MCP tool surface is
+touched.
+
+## Documentation
+
+### Feature Documentation
+- [ ] `docs/benchmarks.md` — add `vector` to the CLI `--retrieval-mode` row
+  (line ~99), add a `vector` row to the Retrieval Modes field-presence table
+  (lines ~142-143) with the EmbeddingField-only / pure-cosine / no-RRF
+  description, and add a run example.
+- [ ] `docs/benchmarks.md` — add a vector column/row to the LongMemEval-S and
+  LoCoMo Retrieval Modes comparison tables; record the granularity-parity finding
+  as a note. Populate numbers when the detached runs finish (placeholder + "run
+  pending" note at merge time is acceptable per the ops lesson).
+
+### External Documentation Site
+- [ ] `mkdocs build --strict` passes (`scripts/ci-local.sh docs`).
+
+### Inline Documentation
+- [ ] Docstrings on `_build_external_model_class`, `ExternalScenario`, and
+  `run_item` updated to describe the three modes including vector (pure cosine,
+  EmbeddingField-only, assembler-bypassed).
+
+## Success Criteria
+
+- [ ] `--retrieval-mode vector` accepted by the CLI; help text describes it.
+- [ ] Vector mode builds an **EmbeddingField-only** per-item model (no BM25Field)
+  and ranks by pure cosine via `_get_vector_scores`; `retrieval_method ==
+  "vector"` in metadata.
+- [ ] `save_reports(..., "vector")` writes `{slug}_{date}_vector.{json,md}` and
+  `{slug}_latest_vector.{json,md}`; a vector save leaves any pre-existing
+  lexical/hybrid artifact byte-identical.
+- [ ] Lexical and hybrid paths are behavior-unchanged (existing contract tests
+  still pass).
+- [ ] Granularity-parity finding documented (both arms = one per-turn record from
+  `content`).
+- [ ] New narrow tests pass: vector-mode smoke contract (skipif MiniLM absent) +
+  `_vector` artifact naming + no-clobber.
+- [ ] Full-dataset vector runs launched detached on both datasets; artifacts +
+  `docs/benchmarks.md` numbers land when they finish (may post-date the merge).
+- [ ] No Redis/Valkey module commands introduced (verification grep passes).
+- [ ] `mkdocs build --strict` passes.
+
+## Step by Step Tasks
+
+### 1. Model builder: embedding-only shape
+- **Task ID**: model-builder
+- Generalize `_build_external_model_class` to `with_bm25`/`with_embedding` flags;
+  add the BM25-absent + Embedding-present branch. Keep lexical/hybrid identical.
+
+### 2. Scenario: vector retrieval branch
+- **Task ID**: scenario-vector
+- **Depends On**: model-builder
+- In `setup()`, pick field flags from `retrieval_mode`; skip the assembler for
+  vector. In `run()`, add the vector branch (pure cosine via `_get_vector_scores`,
+  `retrieval_method="vector"`). Update docstrings.
+
+### 3. CLI + aggregate + report
+- **Task ID**: cli-report
+- **Depends On**: scenario-vector
+- Add `"vector"` to `--retrieval-mode` choices + help; add `vector` `mode_notes`
+  and report closing paragraph. Update `run_item` docstring.
+
+### 4. Tests
+- **Task ID**: tests
+- **Depends On**: cli-report
+- Add `test_vector_effective_mode_and_records` (skipif MiniLM absent) asserting
+  `retrieval_method == "vector"`, embedding-only model, relevant turn retrieved.
+  Add `test_vector_names_are_suffixed` + `test_vector_save_does_not_clobber_
+  lexical_baseline` to `TestSaveReportsArtifactNaming`. Run the benchmark test
+  module only.
+
+### 5. Docs
+- **Task ID**: docs
+- **Depends On**: tests
+- Update `docs/benchmarks.md` (CLI row, Retrieval Modes table, comparison tables,
+  granularity-parity note). `scripts/ci-local.sh docs`.
+
+### 6. Detached full runs
+- **Task ID**: runs
+- **Depends On**: tests
+- Launch `--retrieval-mode vector` on both datasets detached. Do not block the PR.
+  Commit `_vector` artifacts + fill the docs numbers when they finish.
+
+### 7. Final validation
+- **Task ID**: validate-all
+- **Depends On**: docs
+- Valkey-safety grep; `git status` stages only harness code + tests + docs (+
+  `_vector` artifacts when present); confirm Success Criteria.
+
+## Verification
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| CLI accepts vector | `python -m tests.benchmarks.run_external --dataset longmemeval-s --retrieval-mode vector --help` | exit 0, lists `vector` |
+| Vector smoke contract | `pytest tests/benchmarks/test_external.py -k vector -q` | pass (or skip if MiniLM absent) |
+| Artifact suffix | `pytest tests/benchmarks/test_external.py -k "vector and (suffix or clobber)" -q` | pass |
+| Lexical/hybrid contract intact | `pytest tests/benchmarks/test_external.py -k "Contract or ArtifactNaming" -q` | pass |
+| No harness src change | `git status --porcelain src/popoto/` | empty |
+| No Redis module commands | `grep -rEn "FT\.\|BF\.\|CMS\." docs/benchmarks.md tests/benchmarks/scenarios/external_base.py tests/benchmarks/run_external.py` | 0 matches |
+| Docs build | `mkdocs build --strict` | exit 0 |
+
+## Critique Results
+
+<!-- Populated by critique (war room). Leave empty until critique is run. -->
+| Severity | Critic | Finding | Addressed By | Implementation Note |
+|----------|--------|---------|--------------|---------------------|
+
+---
+
+## Decisions
+
+1. **Retrieval primitive.** DECIDED: reuse `QueryBuilder._get_vector_scores`
+   (pure cosine, the hybrid vector arm's own primitive) rather than
+   `semantic_search` (blends memory signals). Keeps vector-only comparable to the
+   hybrid vector arm.
+2. **Assembler vs bypass.** DECIDED: bypass `ContextAssembler` for vector mode —
+   its `auto` resolution sends embedding-only to composite (query-blind). Vector
+   retrieval calls the cosine primitive directly.
+3. **nDCG.** DECIDED: deferred (parity with existing artifacts; separate change).
+4. **Candidate depth.** DECIDED: `limit=max_items` (20), matching the assembler's
+   `max_items`, so R@10 is well-defined and depth matches other modes.

--- a/docs/plans/vector_retrieval_mode.md
+++ b/docs/plans/vector_retrieval_mode.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: Superseded
 type: feature
 appetite: Small
 owner: valor
@@ -8,6 +8,15 @@ tracking: https://github.com/tomcounsell/popoto/issues/455
 last_comment_id: 0
 revision_applied: false
 ---
+
+> **SUPERSEDED** by the harness-local decision on Open Question 1 (see
+> [`retrieval_arm_diagnostics_vector_baseline.md`](retrieval_arm_diagnostics_vector_baseline.md)).
+> The first-class ContextAssembler `vector` mode described here (new
+> `_VALID_MODES` entry + `_pull_path_vector`, briefly committed in 65b36ea) was
+> **rejected and reverted**; the vector-only baseline is **harness-local**
+> (`ExternalScenario.run()` ranks by pure cosine via
+> `QueryBuilder._get_vector_scores`, the assembler is not modified). Retained for
+> history — do not build from this plan.
 
 # Retrieval-arm diagnostics: vector-only baseline (`--retrieval-mode vector`)
 

--- a/src/popoto/recipes/context_assembler.py
+++ b/src/popoto/recipes/context_assembler.py
@@ -791,17 +791,25 @@ class ContextAssembler:
     CyclicDecayField) retrieval, applies token budgets, and formats output
     for LLM context injection.
 
-    The pull path supports two modes selected by ``retrieval_mode``:
+    The pull path supports these modes selected by ``retrieval_mode``:
 
     * ``"hybrid"`` — BM25 (lexical) + vector (semantic) signals fused via
       Reciprocal Rank Fusion (RRF, k=60) followed by optional CoOccurrence
       graph propagation. Requires ``BM25Field`` and ``EmbeddingField`` on the
       model.
+    * ``"lexical"`` — BM25 (query-sensitive) + graph, no embeddings. Requires
+      ``BM25Field``.
+    * ``"vector"`` — pure cosine over the ``EmbeddingField`` (no BM25, no RRF,
+      no graph). Requires ``EmbeddingField``. An **explicit-only** diagnostic
+      mode that measures the dense arm in isolation (issue #455); an empty
+      cosine signal returns no records rather than falling back to composite.
     * ``"composite"`` — original CompositeScoreQuery weighted-sum (unchanged
       from pre-v1.7 behaviour). Requires ``score_weights``.
     * ``"auto"`` *(default)* — selects ``"hybrid"`` when both ``BM25Field``
-      and ``EmbeddingField`` are detected on the model, otherwise falls back
-      to ``"composite"``.
+      and ``EmbeddingField`` are detected, ``"lexical"`` when only ``BM25Field``
+      is present, otherwise falls back to ``"composite"``. ``auto`` never
+      resolves to ``"vector"`` — an embedding-only model routes to
+      ``"composite"``; use explicit ``retrieval_mode="vector"``.
 
     Args:
         model_class: Popoto Model class to query.
@@ -834,12 +842,14 @@ class ContextAssembler:
             ``DeprecationWarning`` at construction. Default: a stdlib
             character-class heuristic over the serialized text
             (``_estimate_tokens``).
-        retrieval_mode: ``"auto"`` (default), ``"hybrid"``, or
-            ``"composite"``. See class docstring for semantics.
+        retrieval_mode: ``"auto"`` (default), ``"hybrid"``, ``"lexical"``,
+            ``"vector"``, or ``"composite"``. See class docstring for semantics.
 
     Raises:
-        QueryException: If ``retrieval_mode="hybrid"`` is requested but the
-            model lacks ``BM25Field`` or ``EmbeddingField``.
+        QueryException: If a mode is requested but the model lacks its required
+            field(s) — ``"hybrid"`` needs ``BM25Field`` and ``EmbeddingField``,
+            ``"lexical"`` needs ``BM25Field``, ``"vector"`` needs
+            ``EmbeddingField``.
     """
 
     def __init__(
@@ -934,7 +944,13 @@ class ContextAssembler:
         #   - neither                     → "composite" (query-blind)
         # Adding an EmbeddingField to a BM25-only model flips lexical → hybrid
         # automatically.
-        _VALID_MODES = {"auto", "lexical", "hybrid", "composite"}
+        #
+        # "vector" is an EXPLICIT-only mode (never auto-resolved): pure cosine
+        # over the EmbeddingField, no BM25/RRF/graph. It is the diagnostic
+        # baseline that measures the dense arm in isolation (issue #455).
+        # ``auto`` deliberately routes an embedding-only model to "composite"
+        # (not "vector") so no production default behavior changes.
+        _VALID_MODES = {"auto", "lexical", "hybrid", "composite", "vector"}
         if retrieval_mode not in _VALID_MODES:
             from ..exceptions import QueryException
 
@@ -975,6 +991,15 @@ class ContextAssembler:
                     f"on {model_class.__name__}"
                 )
             self._effective_mode = "lexical"
+        elif retrieval_mode == "vector":
+            if self._embedding_field is None:
+                from ..exceptions import QueryException
+
+                raise QueryException(
+                    f"retrieval_mode='vector' requires EmbeddingField "
+                    f"on {model_class.__name__}"
+                )
+            self._effective_mode = "vector"
         else:
             self._effective_mode = "composite"
 
@@ -1175,6 +1200,8 @@ class ContextAssembler:
             # hybrid body. Because _embedding_field is None in lexical mode, the
             # vector branch is gated off inside _pull_path_hybrid.
             return self._pull_path_hybrid(query_cues, filters)
+        elif self._effective_mode == "vector":
+            return self._pull_path_vector(query_cues, filters)
         return self._pull_path_composite(query_cues, filters)
 
     def _pull_path_composite(self, query_cues, filters):
@@ -1319,9 +1346,11 @@ class ContextAssembler:
                 "reindex caveat). Falling back to composite (query-blind).",
                 self._effective_mode,
                 self.model_class.__name__,
-                " and the vector search returned none"
-                if self._embedding_field is not None
-                else "",
+                (
+                    " and the vector search returned none"
+                    if self._embedding_field is not None
+                    else ""
+                ),
             )
             return self._pull_path_composite(query_cues, filters)
 
@@ -1364,6 +1393,86 @@ class ContextAssembler:
 
         all_candidates = list(candidates)
         return candidates, all_candidates
+
+    def _pull_path_vector(self, query_cues, filters):
+        """Pure-cosine, vector-only pull path (issue #455).
+
+        Ranks records solely by embedding cosine similarity via
+        ``QueryBuilder._get_vector_scores`` — the identical dense primitive the
+        hybrid path uses for its vector arm — with **no** BM25, RRF fusion, or
+        graph propagation. This is the diagnostic baseline that measures the
+        dense arm in isolation (the missing measurement for the LoCoMo
+        hybrid-vs-lexical regression, #447 → #457).
+
+        Unlike ``_pull_path_hybrid``, an empty vector signal returns
+        ``([], [])`` rather than falling back to the query-blind composite
+        path: a vector-only baseline must never silently degrade to composite,
+        or the measurement is corrupted.
+
+        Valkey-safe: cosine is computed in-process with numpy over the
+        ``EmbeddingField`` ``.npy`` files (no ``FT.*`` / vector modules), the
+        same substrate as the hybrid vector arm.
+
+        Returns:
+            Tuple of (selected_records, all_candidates), records hydrated in
+            descending cosine-similarity order.
+        """
+        from ..models.encoding import decode_popoto_model_hashmap
+        from ..models.query import QueryBuilder as _QueryBuilder
+
+        query_text = " ".join(str(v) for v in query_cues.values())
+
+        # ExistenceFilter pre-check (same short-circuit as the other pull paths).
+        if self._existence_filter is not None:
+            all_missing = all(
+                self._existence_filter.definitely_missing(self.model_class, str(v))
+                for v in query_cues.values()
+            )
+            if all_missing:
+                logger.debug(
+                    "ExistenceFilter: all cues definitely missing, skipping vector pull"
+                )
+                return [], []
+
+        candidate_limit = self.max_items * HYBRID_CANDIDATE_MULTIPLIER
+
+        _q = self.model_class.query
+        _qb = _q.filter(**filters) if filters else _QueryBuilder(_q)
+
+        try:
+            vector_results = _qb._get_vector_scores(query_text, limit=candidate_limit)
+        except Exception as e:
+            logger.warning("Vector search failed in vector path: %s", e)
+            vector_results = []
+
+        if not vector_results:
+            # Vector-only baseline: NO composite fallback. Degrading to the
+            # query-blind composite path would make a "vector" run silently
+            # non-vector and corrupt the diagnostic (issue #455).
+            logger.debug(
+                "Vector pull for %s collected no cosine signal; returning empty "
+                "(no composite fallback in vector-only mode).",
+                self.model_class.__name__,
+            )
+            return [], []
+
+        # Hydrate the top max_items*2 records in cosine order (same pipeline +
+        # decode mechanics as QueryBuilder.fuse(), minus the RRF re-ranking so
+        # the pure cosine order is preserved).
+        top = vector_results[: self.max_items * 2]
+        pipe = POPOTO_REDIS_DB.pipeline()
+        for key, _score in top:
+            pipe.hgetall(key)
+        hashes = pipe.execute()
+
+        records = []
+        for (key, score), data in zip(top, hashes):
+            if data:
+                instance = decode_popoto_model_hashmap(self.model_class, data)
+                instance._vector_score = score
+                records.append(instance)
+
+        return records, records
 
     def _push_path(self, filters):
         """Execute push-path retrieval via CyclicDecayField.

--- a/src/popoto/recipes/context_assembler.py
+++ b/src/popoto/recipes/context_assembler.py
@@ -791,25 +791,17 @@ class ContextAssembler:
     CyclicDecayField) retrieval, applies token budgets, and formats output
     for LLM context injection.
 
-    The pull path supports these modes selected by ``retrieval_mode``:
+    The pull path supports two modes selected by ``retrieval_mode``:
 
     * ``"hybrid"`` — BM25 (lexical) + vector (semantic) signals fused via
       Reciprocal Rank Fusion (RRF, k=60) followed by optional CoOccurrence
       graph propagation. Requires ``BM25Field`` and ``EmbeddingField`` on the
       model.
-    * ``"lexical"`` — BM25 (query-sensitive) + graph, no embeddings. Requires
-      ``BM25Field``.
-    * ``"vector"`` — pure cosine over the ``EmbeddingField`` (no BM25, no RRF,
-      no graph). Requires ``EmbeddingField``. An **explicit-only** diagnostic
-      mode that measures the dense arm in isolation (issue #455); an empty
-      cosine signal returns no records rather than falling back to composite.
     * ``"composite"`` — original CompositeScoreQuery weighted-sum (unchanged
       from pre-v1.7 behaviour). Requires ``score_weights``.
     * ``"auto"`` *(default)* — selects ``"hybrid"`` when both ``BM25Field``
-      and ``EmbeddingField`` are detected, ``"lexical"`` when only ``BM25Field``
-      is present, otherwise falls back to ``"composite"``. ``auto`` never
-      resolves to ``"vector"`` — an embedding-only model routes to
-      ``"composite"``; use explicit ``retrieval_mode="vector"``.
+      and ``EmbeddingField`` are detected on the model, otherwise falls back
+      to ``"composite"``.
 
     Args:
         model_class: Popoto Model class to query.
@@ -842,14 +834,12 @@ class ContextAssembler:
             ``DeprecationWarning`` at construction. Default: a stdlib
             character-class heuristic over the serialized text
             (``_estimate_tokens``).
-        retrieval_mode: ``"auto"`` (default), ``"hybrid"``, ``"lexical"``,
-            ``"vector"``, or ``"composite"``. See class docstring for semantics.
+        retrieval_mode: ``"auto"`` (default), ``"hybrid"``, or
+            ``"composite"``. See class docstring for semantics.
 
     Raises:
-        QueryException: If a mode is requested but the model lacks its required
-            field(s) — ``"hybrid"`` needs ``BM25Field`` and ``EmbeddingField``,
-            ``"lexical"`` needs ``BM25Field``, ``"vector"`` needs
-            ``EmbeddingField``.
+        QueryException: If ``retrieval_mode="hybrid"`` is requested but the
+            model lacks ``BM25Field`` or ``EmbeddingField``.
     """
 
     def __init__(
@@ -944,13 +934,7 @@ class ContextAssembler:
         #   - neither                     → "composite" (query-blind)
         # Adding an EmbeddingField to a BM25-only model flips lexical → hybrid
         # automatically.
-        #
-        # "vector" is an EXPLICIT-only mode (never auto-resolved): pure cosine
-        # over the EmbeddingField, no BM25/RRF/graph. It is the diagnostic
-        # baseline that measures the dense arm in isolation (issue #455).
-        # ``auto`` deliberately routes an embedding-only model to "composite"
-        # (not "vector") so no production default behavior changes.
-        _VALID_MODES = {"auto", "lexical", "hybrid", "composite", "vector"}
+        _VALID_MODES = {"auto", "lexical", "hybrid", "composite"}
         if retrieval_mode not in _VALID_MODES:
             from ..exceptions import QueryException
 
@@ -991,15 +975,6 @@ class ContextAssembler:
                     f"on {model_class.__name__}"
                 )
             self._effective_mode = "lexical"
-        elif retrieval_mode == "vector":
-            if self._embedding_field is None:
-                from ..exceptions import QueryException
-
-                raise QueryException(
-                    f"retrieval_mode='vector' requires EmbeddingField "
-                    f"on {model_class.__name__}"
-                )
-            self._effective_mode = "vector"
         else:
             self._effective_mode = "composite"
 
@@ -1200,8 +1175,6 @@ class ContextAssembler:
             # hybrid body. Because _embedding_field is None in lexical mode, the
             # vector branch is gated off inside _pull_path_hybrid.
             return self._pull_path_hybrid(query_cues, filters)
-        elif self._effective_mode == "vector":
-            return self._pull_path_vector(query_cues, filters)
         return self._pull_path_composite(query_cues, filters)
 
     def _pull_path_composite(self, query_cues, filters):
@@ -1346,11 +1319,9 @@ class ContextAssembler:
                 "reindex caveat). Falling back to composite (query-blind).",
                 self._effective_mode,
                 self.model_class.__name__,
-                (
-                    " and the vector search returned none"
-                    if self._embedding_field is not None
-                    else ""
-                ),
+                " and the vector search returned none"
+                if self._embedding_field is not None
+                else "",
             )
             return self._pull_path_composite(query_cues, filters)
 
@@ -1393,86 +1364,6 @@ class ContextAssembler:
 
         all_candidates = list(candidates)
         return candidates, all_candidates
-
-    def _pull_path_vector(self, query_cues, filters):
-        """Pure-cosine, vector-only pull path (issue #455).
-
-        Ranks records solely by embedding cosine similarity via
-        ``QueryBuilder._get_vector_scores`` — the identical dense primitive the
-        hybrid path uses for its vector arm — with **no** BM25, RRF fusion, or
-        graph propagation. This is the diagnostic baseline that measures the
-        dense arm in isolation (the missing measurement for the LoCoMo
-        hybrid-vs-lexical regression, #447 → #457).
-
-        Unlike ``_pull_path_hybrid``, an empty vector signal returns
-        ``([], [])`` rather than falling back to the query-blind composite
-        path: a vector-only baseline must never silently degrade to composite,
-        or the measurement is corrupted.
-
-        Valkey-safe: cosine is computed in-process with numpy over the
-        ``EmbeddingField`` ``.npy`` files (no ``FT.*`` / vector modules), the
-        same substrate as the hybrid vector arm.
-
-        Returns:
-            Tuple of (selected_records, all_candidates), records hydrated in
-            descending cosine-similarity order.
-        """
-        from ..models.encoding import decode_popoto_model_hashmap
-        from ..models.query import QueryBuilder as _QueryBuilder
-
-        query_text = " ".join(str(v) for v in query_cues.values())
-
-        # ExistenceFilter pre-check (same short-circuit as the other pull paths).
-        if self._existence_filter is not None:
-            all_missing = all(
-                self._existence_filter.definitely_missing(self.model_class, str(v))
-                for v in query_cues.values()
-            )
-            if all_missing:
-                logger.debug(
-                    "ExistenceFilter: all cues definitely missing, skipping vector pull"
-                )
-                return [], []
-
-        candidate_limit = self.max_items * HYBRID_CANDIDATE_MULTIPLIER
-
-        _q = self.model_class.query
-        _qb = _q.filter(**filters) if filters else _QueryBuilder(_q)
-
-        try:
-            vector_results = _qb._get_vector_scores(query_text, limit=candidate_limit)
-        except Exception as e:
-            logger.warning("Vector search failed in vector path: %s", e)
-            vector_results = []
-
-        if not vector_results:
-            # Vector-only baseline: NO composite fallback. Degrading to the
-            # query-blind composite path would make a "vector" run silently
-            # non-vector and corrupt the diagnostic (issue #455).
-            logger.debug(
-                "Vector pull for %s collected no cosine signal; returning empty "
-                "(no composite fallback in vector-only mode).",
-                self.model_class.__name__,
-            )
-            return [], []
-
-        # Hydrate the top max_items*2 records in cosine order (same pipeline +
-        # decode mechanics as QueryBuilder.fuse(), minus the RRF re-ranking so
-        # the pure cosine order is preserved).
-        top = vector_results[: self.max_items * 2]
-        pipe = POPOTO_REDIS_DB.pipeline()
-        for key, _score in top:
-            pipe.hgetall(key)
-        hashes = pipe.execute()
-
-        records = []
-        for (key, score), data in zip(top, hashes):
-            if data:
-                instance = decode_popoto_model_hashmap(self.model_class, data)
-                instance._vector_score = score
-                records.append(instance)
-
-        return records, records
 
     def _push_path(self, filters):
         """Execute push-path retrieval via CyclicDecayField.

--- a/tests/benchmarks/run_external.py
+++ b/tests/benchmarks/run_external.py
@@ -115,8 +115,9 @@ def run_item(item: BenchmarkItem, retrieval_mode: str = "lexical") -> QuestionRe
 
     Args:
         item: BenchmarkItem from a dataset adapter.
-        retrieval_mode: ``"lexical"`` (BM25 only) or ``"hybrid"`` (BM25 +
-            vector via RRF). Threaded into the scenario.
+        retrieval_mode: ``"lexical"`` (BM25 only), ``"hybrid"`` (BM25 +
+            vector via RRF), or ``"vector"`` (EmbeddingField-only, pure
+            cosine — harness-local diagnostic). Threaded into the scenario.
 
     Returns:
         QuestionResult with recall metrics and latency.
@@ -204,8 +205,9 @@ def compute_aggregate(
             reproducibility).
         seed: RNG seed used for this run (recorded for reproducibility).
         limit: ``--limit`` value used for this run (``None`` = full dataset).
-        retrieval_mode: ``"lexical"`` or ``"hybrid"`` — the retrieval mode the
-            run was executed in (recorded and surfaced in the report).
+        retrieval_mode: ``"lexical"``, ``"hybrid"``, or ``"vector"`` — the
+            retrieval mode the run was executed in (recorded and surfaced in
+            the report).
 
     Returns:
         Dict with aggregate metrics, per-``question_type`` breakdown, the
@@ -243,6 +245,15 @@ def compute_aggregate(
             "primary path; effective mode resolves to 'hybrid'.",
             "Hybrid fuses BM25 (lexical) + vector (all-MiniLM-L6-v2, 384-dim, "
             "in-process numpy cosine) via Reciprocal Rank Fusion (k=60).",
+        ]
+    elif retrieval_mode == "vector":
+        mode_notes = [
+            "Retrieval mode: vector — pure cosine over the EmbeddingField "
+            "(all-MiniLM-L6-v2, 384-dim, in-process numpy cosine); "
+            "ContextAssembler is BYPASSED (auto-mode would resolve an "
+            "embedding-only model to 'composite', which is query-blind, so "
+            "the harness ranks by raw cosine directly). No BM25, no RRF, no "
+            "graph.",
         ]
     else:
         mode_notes = [
@@ -376,6 +387,15 @@ def build_markdown_report(aggregate: dict) -> str:
             "fused via RRF, k=60). Compare Recall@5/Recall@10 above against the "
             "BM25-only baseline and the agentmemory hybrid reference."
         )
+    elif retrieval_mode == "vector":
+        lines.append(
+            "This run used **vector** retrieval (all-MiniLM-L6-v2, pure cosine, "
+            "no BM25/RRF) — a harness-local diagnostic that bypasses "
+            "ContextAssembler and isolates ONLY the dense arm. Vector-only "
+            "LoCoMo R@1 substantially below lexical confirms a weak vector arm / "
+            "RRF-dilution effect; competitive with hybrid reopens the "
+            "fusion-mechanism hypothesis."
+        )
     else:
         lines.append(
             "This run used **lexical** retrieval (BM25 only). Re-run with "
@@ -494,13 +514,16 @@ def main():
     )
     parser.add_argument(
         "--retrieval-mode",
-        choices=("lexical", "hybrid"),
+        choices=("lexical", "hybrid", "vector"),
         default="lexical",
         help=(
             "Retrieval mode (default: lexical). 'lexical' uses BM25 only and "
             "needs no model download; 'hybrid' adds an all-MiniLM-L6-v2 vector "
             "signal fused with BM25 via RRF (k=60) and requires the "
-            "[benchmark] extra plus a one-time ~90MB model download."
+            "[benchmark] extra plus a one-time ~90MB model download; 'vector' "
+            "uses the EmbeddingField only (same ~90MB all-MiniLM-L6-v2 download "
+            "as hybrid) and ranks by pure cosine with no BM25/RRF — a "
+            "harness-local diagnostic that bypasses ContextAssembler."
         ),
     )
     parser.add_argument(

--- a/tests/benchmarks/scenarios/external_base.py
+++ b/tests/benchmarks/scenarios/external_base.py
@@ -15,18 +15,18 @@ Model class used:
     - importance: FloatField (fixed at 0.5 for baseline)
     - relevance: DecayingSortedField (scored via CompositeScoreQuery)
     - certainty: ConfidenceField (initial 0.5)
-    - content_index: BM25Field (lexical signal — always present)
-    - embedding: EmbeddingField (vector signal — present only in hybrid mode)
+    - content_index: BM25Field (lexical signal — present in lexical/hybrid)
+    - embedding: EmbeddingField (vector signal — present in hybrid/vector)
 
     Class is re-created per benchmark item with a unique name prefix to
     ensure Redis key isolation between items. teardown() scans and deletes
     all keys matching the class prefix (and the per-class embedding dir).
 
-Retrieval mode (issue #437):
-    Retrieval is driven through ``ContextAssembler.assemble()`` as the
-    **primary** path. The assembler is constructed with
-    ``retrieval_mode="auto"`` so field presence drives mode resolution
-    (issue #395):
+Retrieval mode (issue #437, #455):
+    For ``lexical``/``hybrid`` retrieval is driven through
+    ``ContextAssembler.assemble()`` as the **primary** path. The assembler is
+    constructed with ``retrieval_mode="auto"`` so field presence drives mode
+    resolution (issue #395):
     - Model has BM25Field + EmbeddingField → ``"hybrid"`` (BM25 + vector via RRF)
     - Model has BM25Field only → ``"lexical"`` (query-sensitive BM25, no vector)
     - Model has neither → ``"composite"`` (query-blind)
@@ -36,6 +36,13 @@ Retrieval mode (issue #437):
     ``ExternalScenario(retrieval_mode="hybrid")`` additionally declares an
     EmbeddingField with a local SentenceTransformersProvider, so auto-mode
     resolves to ``"hybrid"`` and the RRF fusion (k=60) runs.
+
+    ``ExternalScenario(retrieval_mode="vector")`` is a harness-local diagnostic
+    (issue #455): it declares an EmbeddingField and NO BM25Field, and
+    **bypasses** the assembler entirely — ``run()`` ranks by pure cosine over
+    the EmbeddingField (auto-mode would resolve an embedding-only model to the
+    query-blind ``"composite"`` path, not vector search). No BM25, no RRF, no
+    graph — it isolates only the dense arm.
 
 This module is text-only: turns without content are silently skipped.
 """
@@ -68,6 +75,10 @@ logger = logging.getLogger("POPOTO.Benchmark.ExternalScenario")
 # Score weights — used by composite path when no BM25/embedding fields present
 BASELINE_SCORE_WEIGHTS = {"relevance": 1.0}
 
+# Number of records the assembler / vector diagnostic returns per query. Sized
+# to cover Recall@10 with headroom.
+MAX_ITEMS = 20
+
 # Shared embedding provider, lazily constructed once per process.
 #
 # ``_build_external_model_class`` is called once per benchmark item (from
@@ -97,30 +108,44 @@ def _get_shared_provider():
     return _SHARED_PROVIDER
 
 
-def _build_external_model_class(safe_prefix: str, with_embedding: bool = False):
+def _build_external_model_class(
+    safe_prefix: str,
+    with_bm25: bool = True,
+    with_embedding: bool = False,
+):
     """Build a fresh Popoto Model class for one benchmark item.
 
     Uses a unique class name derived from ``safe_prefix`` so each item
     gets its own Redis key namespace. This prevents cross-item contamination
     when running multiple items sequentially.
 
-    Always includes a BM25Field for the lexical signal. When
-    ``with_embedding`` is True, also declares an EmbeddingField backed by a
-    local SentenceTransformersProvider (all-MiniLM-L6-v2), so that
-    ``ContextAssembler(retrieval_mode="auto")`` resolves to the ``"hybrid"``
-    (RRF) pull path. With BM25 only, auto-mode resolves to ``"lexical"``.
+    The declared retrieval fields select which retrieval arm the benchmark
+    exercises. All three benchmark modes save **one record per turn** from the
+    same ``content`` source, so the BM25 and embedding arms index the identical
+    per-turn units (no granularity mismatch between arms):
+
+    - ``with_bm25=True, with_embedding=False`` → **lexical** — BM25 only. Under
+      ``ContextAssembler(retrieval_mode="auto")`` this resolves to ``"lexical"``.
+    - ``with_bm25=True, with_embedding=True`` → **hybrid** — BM25 + vector
+      (all-MiniLM-L6-v2) fused via RRF; auto-mode resolves to ``"hybrid"``.
+    - ``with_bm25=False, with_embedding=True`` → **vector** — EmbeddingField
+      only. NOTE: auto-mode would resolve an embedding-only model to
+      ``"composite"`` (query-blind), so the vector benchmark path does **not**
+      route through the assembler; it ranks by pure cosine directly (see
+      ``ExternalScenario.run()``).
 
     Args:
         safe_prefix: Short alphanumeric prefix (e.g., "a3f9b2c1").
-        with_embedding: If True, add an EmbeddingField for hybrid retrieval.
+        with_bm25: If True, declare a BM25Field (lexical signal).
+        with_embedding: If True, declare an EmbeddingField (vector signal)
+            backed by the shared SentenceTransformersProvider.
 
     Returns:
-        A new Popoto Model class with agent_id, content, importance,
-        relevance, certainty, content_index, and (in hybrid mode) embedding
-        fields.
+        A new Popoto Model class with agent_id, content, importance, relevance,
+        certainty, and the selected retrieval field(s).
     """
 
-    if with_embedding:
+    if with_bm25 and with_embedding:
 
         class ExternalBenchmarkMemory(popoto.Model):
             turn_id = popoto.AutoKeyField()
@@ -134,6 +159,26 @@ def _build_external_model_class(safe_prefix: str, with_embedding: bool = False):
             )
             certainty = ConfidenceField(initial_confidence=0.5)
             content_index = BM25Field(source="content")
+            embedding = EmbeddingField(
+                source="content",
+                provider=_get_shared_provider(),
+            )
+
+    elif with_embedding:
+
+        # Vector-only: EmbeddingField, no BM25Field. Ranked by pure cosine in
+        # ExternalScenario.run() (the assembler is bypassed for this mode).
+        class ExternalBenchmarkMemory(popoto.Model):
+            turn_id = popoto.AutoKeyField()
+            agent_id = popoto.KeyField()
+            content = popoto.StringField(default="")
+            importance = popoto.FloatField(default=0.5)
+            relevance = DecayingSortedField(
+                decay_rate=0.5,
+                base_score_field="importance",
+                partition_by="agent_id",
+            )
+            certainty = ConfidenceField(initial_confidence=0.5)
             embedding = EmbeddingField(
                 source="content",
                 provider=_get_shared_provider(),
@@ -169,9 +214,13 @@ class ExternalScenario(Scenario):
         item: BenchmarkItem from a dataset adapter.
         overrides: Optional override dict (unused in baseline; present for
             API compatibility with sweep infrastructure).
-        retrieval_mode: ``"lexical"`` (default, BM25 only) or ``"hybrid"``
-            (BM25 + vector via RRF). Hybrid additionally declares an
-            EmbeddingField on the model so auto-mode resolves to hybrid.
+        retrieval_mode: ``"lexical"`` (default, BM25 only), ``"hybrid"``
+            (BM25 + vector via RRF), or ``"vector"`` (EmbeddingField-only,
+            pure cosine). Hybrid additionally declares an EmbeddingField on
+            the model so auto-mode resolves to hybrid. Vector declares an
+            EmbeddingField and no BM25Field, and ``run()`` ranks by raw
+            cosine directly (the assembler is bypassed — a harness-local
+            diagnostic).
     """
 
     name = "external_base"
@@ -203,18 +252,29 @@ class ExternalScenario(Scenario):
             ConnectionError: If Redis is unavailable.
         """
         safe_prefix = uuid.uuid4().hex[:8]
+        # Field presence per mode:
+        #   lexical → BM25 only; hybrid → BM25 + embedding; vector → embedding only.
         self._model_class = _build_external_model_class(
-            safe_prefix, with_embedding=self.retrieval_mode == "hybrid"
+            safe_prefix,
+            with_bm25=self.retrieval_mode != "vector",
+            with_embedding=self.retrieval_mode in ("hybrid", "vector"),
         )
-        # retrieval_mode="auto": field presence drives resolution (issue #395).
-        # BM25 + EmbeddingField (hybrid mode) → "hybrid" (RRF k=60); BM25 only
-        # (lexical mode) → "lexical". assemble() is the primary retrieval path.
-        self._assembler = ContextAssembler(
-            model_class=self._model_class,
-            score_weights=BASELINE_SCORE_WEIGHTS,
-            max_items=20,
-            retrieval_mode="auto",
-        )
+        # lexical/hybrid drive ContextAssembler.assemble() as the primary path with
+        # retrieval_mode="auto": field presence resolves the mode (issue #395) —
+        # BM25 + EmbeddingField → "hybrid" (RRF k=60); BM25 only → "lexical".
+        #
+        # vector mode is EmbeddingField-only. auto-mode would resolve that to
+        # "composite" (query-blind), NOT vector search, so vector mode does NOT
+        # build an assembler — run() ranks by pure cosine directly.
+        if self.retrieval_mode == "vector":
+            self._assembler = None
+        else:
+            self._assembler = ContextAssembler(
+                model_class=self._model_class,
+                score_weights=BASELINE_SCORE_WEIGHTS,
+                max_items=MAX_ITEMS,
+                retrieval_mode="auto",
+            )
 
         for turn in self.item.history:
             content = turn.get("content", "")
@@ -257,12 +317,21 @@ class ExternalScenario(Scenario):
     def run(self) -> ScenarioResult:
         """Run retrieval and return ScenarioResult.
 
-        Drives retrieval through ``ContextAssembler.assemble()`` as the
-        **primary** path (issue #437). The assembler's effective mode is
-        resolved from field presence: ``"lexical"`` (BM25 only) or
-        ``"hybrid"`` (BM25 + vector fused via RRF). The selected records are
-        mapped to their Redis keys, then back to ground-truth session/turn
-        IDs via ``_session_key_map``.
+        For ``lexical``/``hybrid`` modes, retrieval is driven through
+        ``ContextAssembler.assemble()`` as the **primary** path (issue #437).
+        The assembler's effective mode is resolved from field presence:
+        ``"lexical"`` (BM25 only) or ``"hybrid"`` (BM25 + vector fused via RRF).
+
+        For the ``vector`` mode the assembler is **bypassed** entirely: the
+        harness ranks by pure cosine over the EmbeddingField via
+        ``QueryBuilder._get_vector_scores()`` (all-MiniLM-L6-v2, 384-dim,
+        in-process numpy cosine). ``ContextAssembler`` auto-mode would resolve
+        an embedding-only model to ``"composite"`` (query-blind), which is not
+        vector search, so this harness-local diagnostic scores raw cosine
+        directly. No BM25, no RRF, no graph.
+
+        In every mode the selected records' Redis keys are mapped back to
+        ground-truth session/turn IDs via ``_session_key_map``.
 
         Measures latency of the retrieval call only (not ingestion).
 
@@ -271,7 +340,7 @@ class ExternalScenario(Scenario):
             relevant_ids from ground truth (same key space, via the
             session_id/turn_id -> redis_keys mapping built during setup).
         """
-        if not self._assembler:
+        if self._model_class is None:
             return ScenarioResult(
                 scenario_name=self.name,
                 status="error",
@@ -287,31 +356,51 @@ class ExternalScenario(Scenario):
 
         t0 = time.monotonic()
 
-        # Primary retrieval: ContextAssembler.assemble(). With both BM25 and
-        # EmbeddingField present (hybrid mode) this runs _pull_path_hybrid()
-        # (RRF k=60); with BM25 only it runs the lexical pull path.
         retrieved_keys: List[str] = []
-        try:
-            assembly_result = self._assembler.assemble(
-                query_cues={"topic": self.item.query},
-                agent_id=self._agent_id,
-            )
-            for record in assembly_result.records:
-                try:
-                    retrieved_keys.append(record.db_key.redis_key)
-                except Exception:
-                    retrieved_keys.append(str(id(record)))
-        except Exception as e:
-            return ScenarioResult(
-                scenario_name=self.name,
-                status="error",
-                error_message=f"assemble() failed: {e}",
-            )
+        if self.retrieval_mode == "vector":
+            # Vector-only diagnostic: pure cosine over the EmbeddingField, no
+            # ContextAssembler. _get_vector_scores() returns (redis_key, cosine)
+            # pairs sorted by similarity descending, so the redis keys are
+            # already the ranked retrieval and no hydration is needed to map
+            # them back to ground-truth IDs.
+            try:
+                from src.popoto.models.query import QueryBuilder
 
-        # The assembler's effective mode (e.g. "lexical" / "hybrid").
-        retrieval_method = getattr(
-            self._assembler, "_effective_mode", self.retrieval_mode
-        )
+                qb = QueryBuilder(self._model_class.query)
+                scored_pairs = qb._get_vector_scores(self.item.query, limit=MAX_ITEMS)
+                retrieved_keys = [redis_key for redis_key, _score in scored_pairs]
+            except Exception as e:
+                return ScenarioResult(
+                    scenario_name=self.name,
+                    status="error",
+                    error_message=f"vector cosine ranking failed: {e}",
+                )
+            retrieval_method = "vector"
+        else:
+            # Primary retrieval: ContextAssembler.assemble(). With both BM25 and
+            # EmbeddingField present (hybrid mode) this runs _pull_path_hybrid()
+            # (RRF k=60); with BM25 only it runs the lexical pull path.
+            try:
+                assembly_result = self._assembler.assemble(
+                    query_cues={"topic": self.item.query},
+                    agent_id=self._agent_id,
+                )
+                for record in assembly_result.records:
+                    try:
+                        retrieved_keys.append(record.db_key.redis_key)
+                    except Exception:
+                        retrieved_keys.append(str(id(record)))
+            except Exception as e:
+                return ScenarioResult(
+                    scenario_name=self.name,
+                    status="error",
+                    error_message=f"assemble() failed: {e}",
+                )
+
+            # The assembler's effective mode (e.g. "lexical" / "hybrid").
+            retrieval_method = getattr(
+                self._assembler, "_effective_mode", self.retrieval_mode
+            )
 
         retrieval_ms = (time.monotonic() - t0) * 1000
 

--- a/tests/benchmarks/test_external.py
+++ b/tests/benchmarks/test_external.py
@@ -812,3 +812,103 @@ class TestSaveReportsArtifactNaming:
         # No unsuffixed lexical _latest pointers were created by the hybrid run.
         assert not (results_dir / "longmemeval_s_latest.json").exists()
         assert not (results_dir / "longmemeval_s_latest.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Vector-only retrieval mode (issue #455)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _minilm_cached(),
+    reason="all-MiniLM-L6-v2 not cached; skipping vector diagnostic tests",
+)
+class TestVectorRetrievalMode:
+    """Harness-local vector-only diagnostic (issue #455).
+
+    Vector mode declares an EmbeddingField and NO BM25Field, **bypasses**
+    ContextAssembler entirely, and ranks by pure cosine via
+    ``QueryBuilder._get_vector_scores()``. Its artifacts are ``_vector``-suffixed
+    so a vector run never clobbers the committed lexical baseline. All three
+    tests share the hybrid tests' MiniLM-cache skip guard so the suite never
+    triggers a model download when the ``[benchmark]`` extra is absent.
+    """
+
+    @pytest.fixture
+    def results_dir(self, tmp_path, monkeypatch):
+        """Point run_external.RESULTS_DIR at a scratch dir for the test."""
+        import tests.benchmarks.run_external as run_external
+
+        monkeypatch.setattr(run_external, "RESULTS_DIR", tmp_path)
+        return tmp_path
+
+    def test_vector_effective_mode_and_records(self):
+        """Vector run: EmbeddingField-only model, assembler bypassed, cosine rank."""
+        from src.popoto.fields.bm25_field import BM25Field
+        from src.popoto.fields.embedding_field import EmbeddingField
+        from tests.benchmarks.scenarios.external_base import ExternalScenario
+
+        scenario = ExternalScenario(item=_dog_item(), retrieval_mode="vector")
+        try:
+            result = scenario.execute()
+        except Exception as e:  # model load/runtime hiccup → skip, don't fail
+            pytest.skip(f"vector model unavailable at runtime: {e}")
+
+        assert result.status == "ok"
+        # The per-item model declares an EmbeddingField and NO BM25Field.
+        fields = list(scenario._model_class._meta.fields.values())
+        assert any(isinstance(f, EmbeddingField) for f in fields)
+        assert not any(isinstance(f, BM25Field) for f in fields)
+        # The assembler is bypassed entirely for vector mode.
+        assert scenario._assembler is None
+        # Effective retrieval method is pure cosine vector (not lexical/hybrid).
+        assert result.metadata.get("retrieval_method") == "vector"
+        # Records are retrieved and mapped back to the ground-truth session ID.
+        assert "s1" in result.retrieved_ids
+
+    def test_vector_names_are_suffixed(self, results_dir):
+        """Vector mode suffixes _vector into dated AND _latest artifacts."""
+        import tests.benchmarks.run_external as run_external
+        from datetime import datetime, timezone
+
+        json_path, md_path = run_external.save_reports(
+            _minimal_aggregate("vector"),
+            "longmemeval_s",
+            retrieval_mode="vector",
+        )
+
+        date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
+        assert json_path.name == f"longmemeval_s_{date_str}_vector.json"
+        assert md_path.name == f"longmemeval_s_{date_str}_vector.md"
+        assert (results_dir / "longmemeval_s_latest_vector.json").exists()
+        assert (results_dir / "longmemeval_s_latest_vector.md").exists()
+
+    def test_vector_save_does_not_clobber_lexical_baseline(self, results_dir):
+        """A vector save leaves pre-existing lexical artifacts byte-identical."""
+        import tests.benchmarks.run_external as run_external
+        from datetime import datetime, timezone
+
+        date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
+        # Plant a fake committed lexical baseline (both json + md).
+        baseline_json = results_dir / f"longmemeval_s_{date_str}.json"
+        baseline_md = results_dir / f"longmemeval_s_{date_str}.md"
+        original_json = b'{"committed": "lexical baseline"}'
+        original_md = b"# committed lexical baseline\n"
+        baseline_json.write_bytes(original_json)
+        baseline_md.write_bytes(original_md)
+
+        run_external.save_reports(
+            _minimal_aggregate("vector"),
+            "longmemeval_s",
+            retrieval_mode="vector",
+        )
+
+        # Lexical baseline artifacts are untouched, byte-for-byte.
+        assert baseline_json.read_bytes() == original_json
+        assert baseline_md.read_bytes() == original_md
+        # Distinct _vector artifacts were created alongside them.
+        assert (results_dir / f"longmemeval_s_{date_str}_vector.json").exists()
+        assert (results_dir / f"longmemeval_s_{date_str}_vector.md").exists()
+        # No unsuffixed lexical _latest pointers were created by the vector run.
+        assert not (results_dir / "longmemeval_s_latest.json").exists()
+        assert not (results_dir / "longmemeval_s_latest.md").exists()


### PR DESCRIPTION
Closes #455. Unblocks #457 (weighted/query-adaptive hybrid fusion).

## What this is

A **vector-only retrieval baseline** for the LoCoMo hybrid-vs-lexical regression investigation. It measures the dense (embedding) arm in isolation so #457 can decide whether the hybrid regression is a weak-arm problem or a fusion-mechanism problem.

## Key decision: harness-local (resolves Open Question 1 / the critique BLOCKER)

The prior in-progress branch split across two contradictory approaches. This PR commits to **harness-local**:

- The vector baseline lives entirely in the benchmark harness and ranks by **pure cosine** (`QueryBuilder._get_vector_scores`, in-process numpy), bypassing `ContextAssembler`.
- **No first-class `retrieval_mode="vector"` ships in `ContextAssembler`** — the +131-line first-class change from `65b36ea` is reverted; `context_assembler.py` is byte-identical to `main`. This avoids introducing a query-blind production retrieval mode we'd have to support.

Rationale: the diagnostic only needs to isolate the dense arm; routing an embedding-only model through the assembler would resolve to the query-blind `composite` path, and shipping a supported `vector` mode is scope the investigation doesn't need.

## Changes

- `run_external.py` — `--retrieval-mode vector` (EmbeddingField-only, pure cosine; same ~90MB all-MiniLM-L6-v2 download as hybrid).
- `scenarios/external_base.py` — vector scenario builds an EmbeddingField-only model, leaves the assembler unbuilt, ranks by cosine in `run()`. Fixed two latent bugs found during build: an undefined `MAX_ITEMS` (`NameError` on every run) and a `run()` guard that never executed the vector path.
- `test_external.py` — `TestVectorRetrievalMode`: effective-mode/records, artifact `_vector` suffixing, and no-clobber of the lexical baseline (skips when MiniLM absent).
- `docs/benchmarks.md` — documents vector mode and notes it isolates **only** the dense arm, not the graph/co-occurrence arm inside hybrid.
- Plans — Open Question 1 resolved to harness-local in the diagnostics plan; the first-class `vector_retrieval_mode.md` marked **superseded**.
- `.gitignore` — ignore `data/` (benchmark embedding byproduct).

## Verification

- **524 passed, 2 pre-existing skips, 0 regressions** across benchmark + assembler suites.
- Assembler regression guard (`test_context_assembler_hybrid.py`): **38 passed** — confirms the revert matches `main`.
- Vector smoke run (fixture): `Retrieval mode: vector`, 0 errors, cosine path executes end-to-end.
- Valkey-safe: in-process numpy cosine, no `FT.*`/`BF.*`.

## Scope note

Isolates the dense arm only. A weak vector-only number does **not** distinguish "vector arm weak" from "graph arm is the confound" inside `_pull_path_hybrid` — a graph-arm-off ablation remains a candidate follow-up for #457.