### PR TITLE
fix(#465): isolate external benchmark harness from live db0

### DIFF
--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -59,6 +59,9 @@ python -m tests.benchmarks.run_sweeps --tier all --interactions
 python -m tests.benchmarks.run_external --dataset longmemeval-s
 python -m tests.benchmarks.run_external --dataset locomo
 
+# Point the external harness at a different bench DB (default 14):
+POPOTO_BENCH_DB=13 python -m tests.benchmarks.run_external --dataset locomo
+
 # Deterministic CSR harness (no network, no model download):
 pytest tests/benchmarks/test_csr.py -q          # CI gate
 python -m tests.benchmarks.csr.run_csr          # write report artifact
@@ -80,6 +83,50 @@ python -m tests.benchmarks.run_external --dataset longmemeval-s --limit 12 --sam
 # Run all tests
 pytest tests/benchmarks/ -x -q
 ```
+
+## External-harness DB isolation & residue (issue #465)
+
+The external harness (`run_external.py`) is a **benchmark, not a pytest test**,
+so the pytest db15 test-isolation plugin does **not** apply to it. Each
+benchmark item writes `ExternalBenchmarkMemory` / `ExtMem<hash>` model keys (and
+`$BM25:ExtMem<hash>*` BM25 index keys) to Redis. `ExternalScenario.teardown()`
+deletes them per-item, but a **killed / interrupted / wedged** run leaves that
+residue behind permanently — and if the harness shares db0 with a live store,
+the residue pollutes it (a dogfood machine accumulated **1,825** leaked keys).
+
+Two belt-and-braces mitigations, both scoped to the `run_external.py`
+entrypoint (they activate only at run start — never at import time, so pytest
+collection and the db15 plugin are unaffected):
+
+1. **Dedicated bench DB.** At startup the harness points the Popoto connection
+   at a dedicated non-default DB (**default 14**, mirroring the plugin's db15
+   posture: tests → 15, benchmarks → 14). Override with `POPOTO_BENCH_DB=<n>`.
+   `POPOTO_BENCH_DB=0` is **rejected** — db0 is typically production — so a
+   misconfiguration can't repollute the live database. Host/port/auth from
+   `REDIS_URL` are preserved.
+2. **Startup sweep.** Before any ingestion the harness `SCAN`s (non-blocking,
+   Valkey-safe) and `DEL`s any stale `ExternalBenchmarkMemory:*` / `ExtMem*` /
+   `$BM25:ExtMem*` keys left by a prior run on the bench DB, logging the count.
+
+### Cleaning existing db0 pollution
+
+If earlier runs (before this fix) leaked keys into db0, sweep them once with a
+non-blocking `SCAN`+`DEL` (works on both Redis and Valkey — no modules):
+
+```bash
+# Dry run first — list what would be deleted (per pattern):
+for p in 'ExternalBenchmarkMemory:*' 'ExtMem*' '$BM25:ExtMem*'; do
+  redis-cli -n 0 --scan --pattern "$p"
+done
+
+# Delete them (redis-cli --scan streams via SCAN, not the blocking KEYS):
+for p in 'ExternalBenchmarkMemory:*' 'ExtMem*' '$BM25:ExtMem*'; do
+  redis-cli -n 0 --scan --pattern "$p" | xargs -r -L 100 redis-cli -n 0 DEL
+done
+```
+
+Use `valkey-cli` in place of `redis-cli` for Valkey; adjust `-n 0` if the
+pollution is on another DB.
 
 ## Adding a New Constant
 

--- a/tests/benchmarks/run_external.py
+++ b/tests/benchmarks/run_external.py
@@ -40,6 +40,8 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+import redis
+
 # Ensure project root is on path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
@@ -59,6 +61,144 @@ logger = logging.getLogger("ExternalBenchmark")
 RESULTS_DIR = Path(__file__).parent / "results" / "external"
 
 DATASET_CHOICES = ("longmemeval-s", "locomo")
+
+# ---------------------------------------------------------------------------
+# Benchmark DB isolation (issue #465)
+# ---------------------------------------------------------------------------
+#
+# The external harness runs against the live default Popoto connection — db0 by
+# design, because it is a benchmark rather than a pytest test, so the db15
+# test-isolation plugin does not apply. Interrupted / killed / wedged runs
+# leaked ExternalBenchmarkMemory / ExtMem* / $BM25:ExtMem* keys into db0
+# permanently, polluting any store sharing db0 (a dogfood machine accumulated
+# 1,825 stale keys). Two belt-and-braces mitigations, both scoped to this
+# entrypoint (they activate only inside main(), never at import time, so pytest
+# collection and the db15 plugin are unaffected):
+#
+#   1. Point the connection at a dedicated bench DB (default 14), mirroring the
+#      plugin's db15 posture and its db0 rejection.
+#   2. Sweep any pre-existing residue at run start via SCAN+DEL.
+
+# Dedicated non-default DB for the external benchmark harness. 14 mirrors the
+# plugin's db15 isolation posture (tests → 15, benchmarks → 14). Operational,
+# overridable via POPOTO_BENCH_DB (like POPOTO_TEST_DB); db0 is rejected.
+BENCH_DB_DEFAULT = 14
+
+# Key patterns left behind by prior/interrupted runs. ExtMem* covers the
+# per-item model keys and their sorted-index keys (ExtMem<hash>:_relevance,
+# etc.); $BM25:ExtMem* covers the BM25 index keys; ExternalBenchmarkMemory:*
+# covers any keys written under the un-renamed base class name. All are literal
+# outside the trailing glob (``$`` is not a Redis SCAN metacharacter).
+_STALE_KEY_PATTERNS = (
+    "ExternalBenchmarkMemory:*",
+    "ExtMem*",
+    "$BM25:ExtMem*",
+)
+
+
+def _resolve_bench_db() -> int:
+    """Resolve the benchmark Redis DB number.
+
+    Priority: ``POPOTO_BENCH_DB`` env var > default (:data:`BENCH_DB_DEFAULT`,
+    14). Mirrors the pytest plugin's db0 rejection so a misconfigured
+    ``POPOTO_BENCH_DB=0`` cannot repollute production.
+
+    Returns:
+        The resolved bench DB number (non-zero int).
+
+    Raises:
+        ValueError: If the env value is non-integer or 0.
+    """
+    raw = os.environ.get("POPOTO_BENCH_DB", "").strip()
+    if not raw:
+        return BENCH_DB_DEFAULT
+    try:
+        bench_db = int(raw)
+    except (ValueError, TypeError):
+        raise ValueError(f"POPOTO_BENCH_DB must be an integer, got {raw!r}")
+    if bench_db == 0:
+        raise ValueError(
+            "POPOTO_BENCH_DB=0 is not allowed — DB 0 is typically production. "
+            "Use a non-zero DB (default: 14)."
+        )
+    return bench_db
+
+
+def _point_connection_at_db(target_db: int) -> None:
+    """Swap the Popoto connection pool in-place onto ``target_db``.
+
+    Mirrors ``popoto.pytest_plugin._swap_db``: it mutates the existing
+    ``POPOTO_REDIS_DB`` object rather than rebinding the global, so every module
+    that imported ``POPOTO_REDIS_DB`` at load time (e.g. the scenario module)
+    keeps using the correct connection. Host/port/auth are preserved from the
+    current pool so a ``REDIS_URL`` with credentials keeps working.
+
+    Called ONLY from the harness entrypoint (main()); never at import time, so
+    it cannot interfere with the pytest db15 plugin.
+    """
+    from src.popoto import redis_db
+
+    db_obj = redis_db.POPOTO_REDIS_DB
+    current_kwargs = dict(db_obj.connection_pool.connection_kwargs)
+    current_kwargs["db"] = target_db
+    current_kwargs.setdefault("socket_timeout", 5)
+    current_kwargs.setdefault("socket_connect_timeout", 5)
+    connection_class = db_obj.connection_pool.connection_class
+    new_pool = redis.ConnectionPool(connection_class=connection_class, **current_kwargs)
+    old_pool = db_obj.connection_pool
+    db_obj.connection_pool = new_pool
+    old_pool.disconnect()
+
+
+def _sweep_stale_benchmark_keys(redis_conn) -> int:
+    """SCAN + DEL any benchmark residue left by prior/interrupted runs.
+
+    Uses cursor-based SCAN (non-blocking, Valkey-safe — no Redis modules) to
+    enumerate keys matching :data:`_STALE_KEY_PATTERNS` and DELs them. Operates
+    on whatever connection it is handed, so it targets exactly the DB the
+    harness is pointed at.
+
+    Args:
+        redis_conn: A ``redis.Redis`` client (the live Popoto connection).
+
+    Returns:
+        The number of stale keys deleted.
+    """
+    deleted = 0
+    for pattern in _STALE_KEY_PATTERNS:
+        cursor = 0
+        while True:
+            cursor, keys = redis_conn.scan(cursor, match=pattern, count=500)
+            if keys:
+                deleted += redis_conn.delete(*keys)
+            if cursor == 0:
+                break
+    return deleted
+
+
+def _select_bench_db() -> int:
+    """Point the Popoto connection at the isolated bench DB and sweep residue.
+
+    Resolves the bench DB (env > default 14, db0 rejected), swaps the live
+    connection onto it, then sweeps any stale keys left by prior runs. Both
+    steps are scoped to the harness entrypoint. Returns the bench DB number.
+    """
+    from src.popoto.redis_db import POPOTO_REDIS_DB
+
+    bench_db = _resolve_bench_db()
+    _point_connection_at_db(bench_db)
+    logger.info(
+        "Benchmark isolation: Popoto connection pointed at DB %d "
+        "(override via POPOTO_BENCH_DB; db0 rejected).",
+        bench_db,
+    )
+    swept = _sweep_stale_benchmark_keys(POPOTO_REDIS_DB)
+    logger.info(
+        "Swept %d stale benchmark key(s) from DB %d at startup.",
+        swept,
+        bench_db,
+    )
+    return bench_db
 
 
 # ---------------------------------------------------------------------------
@@ -555,6 +695,12 @@ def main():
     if args.output:
         RESULTS_DIR = args.output
 
+    # Benchmark DB isolation (issue #465): point the live Popoto connection at a
+    # dedicated bench DB (default 14, db0 rejected) and sweep any residue left
+    # by prior/interrupted runs BEFORE any ingestion. Scoped to this entrypoint
+    # so it never affects import-time behavior or the pytest db15 plugin.
+    bench_db = _select_bench_db()
+
     # When --limit is combined with the legacy contiguous-prefix mode, warn:
     # 'head' benchmarks only the easiest on-disk category and is not
     # representative of the whole dataset.
@@ -588,13 +734,14 @@ def main():
 
     logger.info(
         "Starting benchmark: dataset=%s limit=%s sample=%s seed=%s "
-        "retrieval_mode=%s dry_run=%s",
+        "retrieval_mode=%s dry_run=%s bench_db=%d",
         args.dataset,
         args.limit or "all",
         args.sample,
         args.seed,
         args.retrieval_mode,
         args.dry_run,
+        bench_db,
     )
 
     total_start = time.monotonic()

--- a/tests/benchmarks/test_external.py
+++ b/tests/benchmarks/test_external.py
@@ -727,6 +727,101 @@ def _minimal_aggregate(retrieval_mode: str) -> dict:
     return compute_aggregate([], "longmemeval-s", retrieval_mode=retrieval_mode)
 
 
+class TestBenchDbSelection:
+    """Bench-DB isolation for the external harness (issue #465).
+
+    The harness runs against the live default connection (db0 by design — it
+    is a benchmark, not a pytest test). Interrupted runs leaked residue into
+    db0. ``_resolve_bench_db`` chooses a dedicated non-default DB (default 14),
+    mirroring the pytest plugin's db15 posture and its db0 rejection.
+
+    These tests exercise ONLY the pure resolution logic — they never call
+    ``_point_connection_at_db`` / ``_select_bench_db``, which would swap the
+    live connection off the pytest db15 and break isolation for later tests.
+    """
+
+    def test_default_is_14(self, monkeypatch):
+        """No POPOTO_BENCH_DB → default bench DB 14."""
+        from tests.benchmarks.run_external import _resolve_bench_db
+
+        monkeypatch.delenv("POPOTO_BENCH_DB", raising=False)
+        assert _resolve_bench_db() == 14
+
+    def test_env_override(self, monkeypatch):
+        """POPOTO_BENCH_DB overrides the default."""
+        from tests.benchmarks.run_external import _resolve_bench_db
+
+        monkeypatch.setenv("POPOTO_BENCH_DB", "13")
+        assert _resolve_bench_db() == 13
+
+    def test_blank_env_falls_back_to_default(self, monkeypatch):
+        """A blank/whitespace POPOTO_BENCH_DB falls back to the default."""
+        from tests.benchmarks.run_external import _resolve_bench_db
+
+        monkeypatch.setenv("POPOTO_BENCH_DB", "   ")
+        assert _resolve_bench_db() == 14
+
+    def test_rejects_db0(self, monkeypatch):
+        """POPOTO_BENCH_DB=0 is rejected — db0 is typically production."""
+        from tests.benchmarks.run_external import _resolve_bench_db
+
+        monkeypatch.setenv("POPOTO_BENCH_DB", "0")
+        with pytest.raises(ValueError, match="DB 0"):
+            _resolve_bench_db()
+
+    def test_rejects_non_integer(self, monkeypatch):
+        """A non-integer POPOTO_BENCH_DB fails loud."""
+        from tests.benchmarks.run_external import _resolve_bench_db
+
+        monkeypatch.setenv("POPOTO_BENCH_DB", "notanint")
+        with pytest.raises(ValueError, match="integer"):
+            _resolve_bench_db()
+
+
+class TestStaleKeySweep:
+    """Startup sweep of leaked benchmark residue (issue #465).
+
+    Interrupted/killed runs leave ExternalBenchmarkMemory / ExtMem* /
+    $BM25:ExtMem* keys behind permanently. The sweep SCAN+DELs them at run
+    start. It operates on whatever connection it is handed — here the pytest
+    db15 connection — so it never touches production and never fights the
+    plugin's isolation.
+    """
+
+    def test_sweeps_all_stale_patterns_and_reports_count(self):
+        """SCAN+DEL removes every leaked pattern; unrelated keys survive."""
+        from src.popoto.redis_db import POPOTO_REDIS_DB
+        from tests.benchmarks.run_external import _sweep_stale_benchmark_keys
+
+        stale = {
+            "ExternalBenchmarkMemory:abc": "1",
+            "ExtMem12345678:xyz": "1",
+            "ExtMem12345678:_relevance": "1",
+            "$BM25:ExtMem12345678:doc": "1",
+        }
+        keeper = "SomeOtherModel:keepme"
+        for k, v in stale.items():
+            POPOTO_REDIS_DB.set(k, v)
+        POPOTO_REDIS_DB.set(keeper, "1")
+
+        swept = _sweep_stale_benchmark_keys(POPOTO_REDIS_DB)
+
+        assert swept >= len(stale)
+        for k in stale:
+            assert POPOTO_REDIS_DB.exists(k) == 0
+        # Unrelated keys are untouched.
+        assert POPOTO_REDIS_DB.exists(keeper) == 1
+        POPOTO_REDIS_DB.delete(keeper)
+
+    def test_sweep_on_clean_db_returns_zero(self):
+        """A DB with no residue sweeps zero keys."""
+        from src.popoto.redis_db import POPOTO_REDIS_DB
+        from tests.benchmarks.run_external import _sweep_stale_benchmark_keys
+
+        # The per-test flush fixture guarantees a clean db15 here.
+        assert _sweep_stale_benchmark_keys(POPOTO_REDIS_DB) == 0
+
+
 class TestSaveReportsArtifactNaming:
     """save_reports suffixes non-lexical modes; lexical stays unsuffixed (#442)."""
 


### PR DESCRIPTION
Closes #465.

## Problem

Interrupted/wedged external benchmark runs left `ExternalBenchmarkMemory:*` and `$BM25:ExtMem*` keys **permanently in the live db0**, polluting any store sharing the default connection. A dogfood machine accumulated **1,825 leaked keys**. The external harness runs on db0 by design (it's a benchmark, not a pytest test, so the db15 isolation plugin doesn't apply), and per-item `teardown()` doesn't survive a killed run.

## Fix (belt-and-braces, harness-entrypoint-scoped)

Scoped entirely to the `run_external.py` `__main__` path — the **shipped library default connection is unchanged**, and pytest db15 isolation is untouched (DB selection never runs at import time):

1. **`POPOTO_BENCH_DB` (default 14)** — points the popoto connection at a dedicated benchmark DB, mirroring the pytest plugin's `_swap_db` (mutates `POPOTO_REDIS_DB` in place, rebuilds the pool). **db0 is rejected**, like the test plugin, so a misconfigured value can't repollute production.
2. **Startup sweep** — `SCAN`+`DEL` of stale `ExternalBenchmarkMemory:*` / `ExtMem*` / `$BM25:ExtMem*` keys before each run, so residue teardown misses is cleaned next run and never reaches db0. SCAN/DEL only — **Valkey-safe**.
3. **Docs** — `tests/benchmarks/README.md` documents the residue risk, the env var, and a redis-cli cleanup one-liner for existing db0 pollution.
4. **Tests** — `TestBenchDbSelection` + `TestStaleKeySweep` (7 new tests).

## Verification

- Smoke run points at db14 and sweeps there; **db0 DBSIZE unchanged (122918 → 122918)**.
- Full benchmark suite: **330 passed**. `black --check` clean.
- pytest db15 isolation unaffected (DB selection runs only inside `main()`, never at import).