### PR TITLE
Release v1.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "popoto"
-version = "1.7.1"
+version = "1.8.0"
 description = "A Python Redis ORM"
 readme = "README.md"
 authors = [{ name = "Tom Counsell", email = "other@tomcounsell.com" }]


### PR DESCRIPTION
Bump version to 1.8.0.

Minor release: substantial new agent-memory substrate, no breaking changes. Full test suite green (2037 passed, 25 skipped) against pinned deps.