### PR TITLE
audit(#454): cat-5 scoring audit — evidence matching, refusal-metric recommendation, leaderboard-parity slice

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -212,16 +212,77 @@ in the committed artifact
 (`tests/benchmarks/results/external/locomo_latest_hybrid.json` — 1986/1986
 questions, zero errors).
 
-The dataset's `by_question_type` breakdown (from the lexical run) is worth a
-factual note: LoCoMo's category 5 ("adversarial") questions carry an
-`adversarial_answer` field (n=446) and might be expected to score 0-by-
-construction if `evidence` were absent (the harness's `recall_at_k` treats an
-empty relevant-set as a special case). In this dataset snapshot, however,
-every one of the 1986 QA pairs — including all 446 category-5 items — has a
-populated `evidence` field, so that special case never triggers and category
-5 is scored normally. Its measured performance (n=446, Recall@1=0.3341,
-Recall@5=0.6031, Recall@10=0.6883, MRR=0.4581) is comparable to, or better
-than, the other categories, not zero.
+#### Category 5 ("adversarial") — evidence audit and leaderboard-parity slice
+
+LoCoMo's category 5 is historically the hardest category industry-wide (the
+original paper reports humans ≈89 F1 vs LLMs ≈2 F1), and most public
+leaderboards exclude it. Popoto scores it *comparably* to the other categories
+(n=446, Recall@1=0.3341, Recall@5=0.6031, Recall@10=0.6883, MRR=0.4581), which
+warranted an audit (issue #454) of whether that number means anything.
+
+**Audit finding — the cat-5 spans are genuinely meaningful for retrieval in
+this snapshot.** Direct inspection of all 446 category-5 items in the committed
+dataset (`snap-research/locomo10.json`) shows:
+
+- **446/446 carry a populated `evidence` field** (so the harness's empty-
+  relevant-set special case never fires — category 5 is scored as ordinary
+  retrieval, like every other category).
+- **444/446 have an answerable `adversarial_answer` whose evidence span
+  directly supports it.** For example, *"What did Caroline realize after her
+  charity race?"* → `adversarial_answer="self-care is important"`, evidence turn
+  D2:3 = *"I'm starting to realize that self-care is really important."* Only
+  **2/446** are refusal-style ("Not mentioned").
+
+So in **this** snapshot, category 5 is **not** a refusal category; it is a set
+of grounded, answerable retrieval questions. Scoring it as any-hit retrieval is
+measuring retrieval — the same thing measured for every category — not
+"measuring the wrong thing."
+
+**Why the apparent paradox (paper's ≈2 F1 vs our 0.33 Recall@1) dissolves:** it
+is a **metric-family difference**, not a scoring artifact. The paper's ≈2 F1 is
+*end-to-end judged-answer* accuracy (retrieve → generate → judge); Popoto's
+0.3341 is *retrieval any-hit recall* (did the evidence turn get retrieved).
+These families are not convertible (see the metric-family note above).
+Adversarial is hard to *answer/judge*, not hard to *retrieve* — so a normal
+retrieval-recall number on it is expected and honest.
+
+!!! warning "cat-5 is not a refusal-capability signal"
+    This snapshot's category 5 is answerable and evidence-grounded. Its recall
+    number is **not** evidence that Popoto refuses unanswerable queries, and it
+    is **not** comparable to systems that report a refusal-adversarial metric or
+    that drop the category. Refusal capability (confidence-gated retrieval) is
+    tracked separately in
+    [issue #463](https://github.com/tomcounsell/popoto/issues/463) and must be
+    evaluated on a dataset that actually contains unanswerable questions — a
+    "precision of no-answer decisions" metric has no signal on a snapshot where
+    only 2/446 items are unanswerable.
+
+**Leaderboard-parity slice (4-category, n=1540).** For apples-to-apples
+comparison with the common no-adversarial boards (1,540-QA, 4-category), the
+harness reports a parity slice that re-aggregates the run with category 5
+excluded — `1986 − 446 = 1540`, exactly the leaderboard variant count. The
+slice is computed from the committed `by_question_type` breakdown (no re-run
+needed) by `leaderboard_parity_slice()` and emitted into each LoCoMo report as
+a `leaderboard_parity` block:
+
+| Slice | n | Recall@1 | Recall@5 | Recall@10 | MRR |
+|------|--:|---------:|---------:|----------:|----:|
+| `lexical`, full 5-category | 1986 | 0.2986 | 0.5534 | 0.6400 | 0.4124 |
+| `lexical`, 4-category parity | 1540 | 0.2883 | 0.5390 | 0.6260 | 0.3991 |
+| `hybrid`, full 5-category | 1986 | 0.1667 | 0.4235 | 0.5403 | 0.2835 |
+| `hybrid`, 4-category parity | 1540 | 0.1552 | 0.4065 | 0.5181 | 0.2686 |
+
+Category 5 sits near the mean, so excluding it barely moves the numbers —
+further evidence it is neither anomalously easy nor a scoring artifact. (The
+slice re-aggregates 4-decimal per-category means, so it can differ from a raw
+re-aggregation in the 4th place; reproducibility from the committed artifact is
+the priority.)
+
+**Recommendation (pending maintainer sign-off — scoring semantics is
+policy-level).** Keep category 5 in the full 5-category aggregate (the evidence
+audit shows its spans are meaningful), publish the 4-category parity slice
+alongside it for leaderboard comparability, and always carry the caveat above.
+A refusal metric is not applicable to this dataset and is deferred to #463.
 
 ### Baseline Numbers (v1.6.3)
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -221,8 +221,10 @@ leaderboards exclude it. Popoto scores it *comparably* to the other categories
 warranted an audit (issue #454) of whether that number means anything.
 
 **Audit finding — the cat-5 spans are genuinely meaningful for retrieval in
-this snapshot.** Direct inspection of all 446 category-5 items in the committed
-dataset (`snap-research/locomo10.json`) shows:
+this snapshot.** Direct inspection of all 446 category-5 items in the cached
+LoCoMo dataset (the `snap-research/locomo` HuggingFace release, file
+`locomo10.json`, cached locally at `~/.cache/popoto_benchmarks/locomo.json` —
+downloaded on first run, not checked into the repo) shows:
 
 - **446/446 carry a populated `evidence` field** (so the harness's empty-
   relevant-set special case never fires — category 5 is scored as ordinary

--- a/docs/plans/adversarial_cat5_scoring_audit.md
+++ b/docs/plans/adversarial_cat5_scoring_audit.md
@@ -1,0 +1,189 @@
+---
+status: Planning
+type: investigation
+appetite: Small
+owner: valorengels
+created: 2026-07-14
+tracking: https://github.com/tomcounsell/popoto/issues/454
+last_comment_id: 4934211140
+---
+
+# Adversarial (cat-5) Scoring Audit — Evidence Matching, Refusal-Metric Recommendation, Leaderboard-Parity Slice
+
+## Problem
+
+In the full LoCoMo lexical run (#447, PR #452), category-5 ("adversarial")
+questions scored **comparably to other categories**: n=446, Recall@1=0.3341,
+Recall@5=0.6031, Recall@10=0.6883, MRR=0.4581. Adversarial is historically the
+*hardest* LoCoMo category industry-wide (paper: humans ≈89 F1 vs LLMs ≈2 F1),
+and most leaderboards exclude it entirely. The suspicion (§1.3 of
+`benchmarking_strategy_2026-07.md`): the category tests *refusal of
+unanswerable queries*, so scoring it as any-hit retrieval means "the harness is
+matching evidence spans instead of testing refusal — measuring the wrong
+thing, not a strength."
+
+The investigation must (per the 2026-07-10 addendum) end in a recommendation
+among three options, **presented for maintainer sign-off** (scoring-semantics is
+policy-level per the standing maintainer-decisions memo, not shippable
+unilaterally):
+
+1. Score cat-5 with a **refusal metric** (precision of "no-answer" decisions).
+2. **Exclude** cat-5 from the retrieval table and report it separately — and in
+   either case publish a 4-category **leaderboard-parity slice**.
+3. **Keep as-is with a caveat** — only if the evidence audit shows the spans
+   are genuinely meaningful for this category.
+
+Reshaped under epic #456 (Track A): the recommendation is the scoring
+foundation for #463 (confidence-gated retrieval), and the 4-category parity
+slice becomes a standing published artifact.
+
+## Freshness Check
+
+**Baseline commit:** 0b4c629 (origin/main HEAD, release v1.8.0 merge) at plan time.
+**Issue filed:** 2026-07-10; last comment 2026-07-10T10:03:52Z.
+**Disposition:** Unchanged — but the audit **refutes the issue's central
+suspicion** for this dataset snapshot (see Research).
+
+**File:line references re-verified:**
+- `tests/benchmarks/results/external/locomo_latest.json` (→ `locomo_20260708.json`) —
+  present; `by_question_type` carries per-category n + R@1/5/10 + MRR. Confirmed.
+- `tests/benchmarks/results/external/locomo_latest_hybrid.json` — present, same shape.
+- `tests/benchmarks/metrics/retrieval.py` — `recall_at_k` (any-hit),
+  `mean_reciprocal_rank`, pure functions, no Redis deps. The natural home for a
+  pure `leaderboard_parity_slice` helper.
+- `tests/benchmarks/run_external.py:306` `_by_question_type`, `:331`
+  `compute_aggregate`, `:422` emits `by_question_type` into the report — the
+  integration point to emit a forward-looking `leaderboard_parity` block.
+- `tests/benchmarks/datasets/locomo.py` — `is_adversarial = "evidence" not in qa`;
+  cat-5 items carry `adversarial_answer` and (in this snapshot) `evidence`.
+- `docs/benchmarks.md:214-224` — existing factual cat-5 paragraph to be
+  expanded with the audit finding + parity slice + sign-off recommendation.
+- `~/.cache/popoto_benchmarks/locomo.json` — the committed dataset snapshot
+  (10 dialogues, 1986 QA), audited directly.
+
+**Commits on main since issue filed touching these files:** #468 (harness DB-0
+isolation) and #466/#467 (docs publishing, vector baseline) — none change the
+committed LoCoMo artifacts or the retrieval metrics. No drift.
+
+## Prior Art
+
+- **#453 (PR #466)**: Published benchmark results on the docs site; established
+  the metric-family doctrine (never cross-compare recall vs judge-accuracy) and
+  the current caveated cat-5 paragraph in `docs/benchmarks.md`. This plan
+  extends that page.
+- **#455 (PR #467)**: Vector-only diagnostic baseline — sibling §1.4 item.
+- **benchmarking_strategy_2026-07.md §1.3 / §3.6**: source of the three options
+  and the #463 confidence-gated-retrieval tie-in.
+- No prior cat-5 evidence audit exists — this is the first.
+
+## Research (evidence audit — the load-bearing finding)
+
+Audit of all 446 cat-5 items in the committed snapshot
+(`~/.cache/popoto_benchmarks/locomo.json`):
+
+- **446/446 carry a populated `evidence` field** (1 dia_id: 432; 2 dia_ids: 14).
+  The adapter's empty-relevant-set special case never fires — confirmed.
+- **444/446 have an answerable `adversarial_answer` that the evidence span
+  directly supports.** Examples: *"What did Caroline realize after her charity
+  race?"* → `adversarial_answer="self-care is important"`, evidence D2:3 =
+  *"I'm starting to realize that self-care is really important."* The span is
+  the literal grounding for the answer.
+- **Only 2/446** have a refusal-style answer (`"Not mentioned"`, both pointing
+  at D18:2) — a negligible n.
+
+**Conclusion:** In this snapshot, cat-5 is **not** a refusal category. It is a
+set of grounded, answerable retrieval questions whose evidence spans are
+genuinely meaningful. Scoring them as any-hit retrieval is measuring retrieval —
+the same thing every other category measures — **not** "the wrong thing." The
+issue's suspicion is **not confirmed for this data**; the evidence audit
+supports **Option 3** (keep in the aggregate).
+
+**Why the apparent paradox (paper's ≈2 F1 vs our 0.33 R@1) dissolves:** it is a
+**metric-family difference**, not a scoring bug. The paper's ≈2 F1 is
+*end-to-end judged-answer* accuracy (generate → judge); our 0.3341 is
+*retrieval any-hit recall* (did the evidence turn get retrieved). Per the
+MEMTIER anchor / #453 doctrine these families are non-convertible. Adversarial
+is hard to *answer/judge*, not hard to *retrieve* — so a normal retrieval-recall
+number on cat-5 is expected and honest, not a red flag.
+
+**Parity slice (computed from committed `by_question_type`, no re-run):**
+excluding cat-5 (n=446) from the 1986-QA run leaves **exactly n=1540** — the
+common leaderboard variant count (1986 − 446 = 1540).
+
+| Slice | n | R@1 | R@5 | R@10 | MRR |
+|---|--:|--:|--:|--:|--:|
+| lexical, full 5-cat | 1986 | 0.2986 | 0.5534 | 0.6400 | 0.4124 |
+| lexical, 4-cat parity | 1540 | 0.2883 | 0.5390 | 0.6260 | 0.3991 |
+| hybrid, full 5-cat | 1986 | 0.1667 | 0.4235 | 0.5403 | 0.2835 |
+| hybrid, 4-cat parity | 1540 | 0.1552 | 0.4065 | 0.5181 | 0.2686 |
+
+cat-5 sits near the mean, so excluding it barely moves the numbers — further
+evidence it is neither anomalously easy nor a scoring artifact.
+
+## Recommendation (for maintainer sign-off)
+
+**Adopt Option 3 + the parity slice; do not build a refusal metric here.**
+
+1. **Keep cat-5 in the full 5-category aggregate**, because the evidence audit
+   shows its spans are genuinely meaningful for retrieval in this snapshot.
+2. **Publish the 4-category (n=1540) leaderboard-parity slice** alongside the
+   full aggregate, so readers can line Popoto up against the no-adversarial
+   boards without a re-run.
+3. **Mandatory caveat** (never a strength claim): this snapshot's cat-5 is
+   *answerable and evidence-grounded*, not the paper's refusal-style
+   adversarial; the number is **not** a refusal-capability signal and is **not**
+   comparable to systems that report refusal-adversarial or that drop the
+   category.
+4. **Option 1 (refusal metric) does not apply to this dataset** — only 2/446
+   items are genuinely unanswerable, so a "precision of no-answer decisions"
+   metric has no signal here. Refusal capability (confidence-gated retrieval)
+   belongs to **#463**, evaluated on a dataset that actually contains
+   unanswerable questions.
+
+## Scope / Implementation
+
+**In scope (this PR):**
+- `tests/benchmarks/metrics/retrieval.py`: add pure
+  `leaderboard_parity_slice(by_question_type, exclude_categories)` →
+  re-aggregate n-weighted R@1/5/10 + MRR over the retained categories. Single
+  source of truth, computed from the per-category breakdown so any reader can
+  reproduce it from the committed artifact.
+- `tests/benchmarks/run_external.py`: emit a forward-looking
+  `leaderboard_parity` block in the report **when the excluded category is
+  present** (LoCoMo cat-5), leaving LongMemEval reports unchanged. Committed
+  artifacts are **not** regenerated (would require a full multi-hour run); the
+  published numbers are derived from the same pure function over the committed
+  `by_question_type`.
+- Tests: unit test for the pure function (weighting, missing-category,
+  round-trip on full set) + a regression test asserting the slice against the
+  committed `locomo_latest.json` (n=1540 and the four values above).
+- `docs/benchmarks.md`: replace the current cat-5 paragraph with (a) the
+  evidence-audit finding, (b) the parity-slice table, (c) the sign-off
+  recommendation framing.
+- Docs cascade (`/do-docs`).
+
+**Explicitly out of scope (policy-level / other issues):**
+- Changing the headline aggregate to exclude cat-5, or implementing a refusal
+  metric in the harness — policy-level, requires maintainer sign-off; deferred
+  to #463 for the capability.
+- Re-running the benchmark / regenerating artifacts.
+- Any tuning of retrieval.
+
+## Risks
+
+- **Rounding:** the slice is re-aggregated from 4-decimal per-category means, so
+  it can differ from a raw re-aggregation in the 4th decimal. Acceptable and
+  documented — reproducibility from the committed artifact is the priority, and
+  the same pure function is the single source of truth.
+- **Forward-only report block:** committed artifacts won't carry
+  `leaderboard_parity` until the next full run. Mitigated: docs numbers are
+  derived via the shared pure function and pinned by the regression test.
+
+## Acceptance Criteria
+
+- [ ] Evidence audit documented (444/446 answerable-grounded; 2 refusal; metric-family explanation).
+- [ ] Recommendation (Option 3 + parity slice + caveat; Option 1 deferred to #463) stated for sign-off.
+- [ ] `leaderboard_parity_slice` pure function + tests; regression test pins n=1540 and the four values.
+- [ ] `run_external.py` emits `leaderboard_parity` for LoCoMo, LongMemEval unchanged.
+- [ ] `docs/benchmarks.md` updated; `mkdocs build --strict` passes.
+- [ ] `scripts/ci-local.sh` default gates pass.

--- a/tests/benchmarks/metrics/retrieval.py
+++ b/tests/benchmarks/metrics/retrieval.py
@@ -5,7 +5,7 @@ All functions are pure — no Redis or model dependencies.
 """
 
 import math
-from typing import Dict, List
+from typing import Dict, Iterable, List
 
 
 def precision_at_k(retrieved: List[str], relevant: set, k: int) -> float:
@@ -181,3 +181,60 @@ def mean_reciprocal_rank(retrieved: List[str], relevant: set) -> float:
         if item in relevant:
             return 1.0 / (i + 1)
     return 0.0
+
+
+def leaderboard_parity_slice(
+    by_question_type: Dict,
+    exclude_categories: Iterable = ("5",),
+) -> Dict:
+    """Re-aggregate a per-``question_type`` breakdown with categories excluded.
+
+    Given the ``by_question_type`` block a benchmark run emits (each category
+    mapping to ``n`` + ``recall_at_1/5/10`` + ``mrr``), recompute the aggregate
+    over only the *retained* categories, weighting each category's mean by its
+    ``n``. Every metric here is itself a mean over questions, so the n-weighted
+    mean of the per-category means equals the overall metric on the retained
+    subset — no per-question data needed, so the slice is reproducible from a
+    committed artifact's ``by_question_type`` alone.
+
+    The motivating use is LoCoMo's "leaderboard-parity" slice (issue #454):
+    excluding category 5 ("adversarial", n=446) from the 1986-QA run yields the
+    exact 1540-QA, 4-category configuration the common no-adversarial
+    leaderboards report, so Popoto lines up against them without a re-run.
+
+    Category keys are compared as strings, so this works whether the breakdown
+    keys are ints (a live in-process report) or strings (a JSON round-trip).
+
+    Args:
+        by_question_type: Mapping of category key → {"n", "recall_at_1",
+            "recall_at_5", "recall_at_10", "mrr"}.
+        exclude_categories: Category keys to drop before re-aggregating.
+            Compared by string value. Default drops LoCoMo's cat-5.
+
+    Returns:
+        Dict with ``excluded`` (sorted list of the excluded keys that were
+        actually present), ``n`` (retained question count), and the
+        re-aggregated ``recall_at_1/5/10`` + ``mrr`` (rounded to 4 places).
+        Recalls are ``0.0`` when no questions are retained.
+    """
+    excluded_set = {str(c) for c in exclude_categories}
+    excluded_present = sorted(
+        str(cat) for cat in by_question_type if str(cat) in excluded_set
+    )
+
+    total_n = 0
+    acc = {"recall_at_1": 0.0, "recall_at_5": 0.0, "recall_at_10": 0.0, "mrr": 0.0}
+    for cat, stats in by_question_type.items():
+        if str(cat) in excluded_set:
+            continue
+        n = stats["n"]
+        total_n += n
+        for metric in acc:
+            acc[metric] += n * stats[metric]
+
+    if total_n == 0:
+        result = {m: 0.0 for m in acc}
+    else:
+        result = {m: round(acc[m] / total_n, 4) for m in acc}
+
+    return {"excluded": excluded_present, "n": total_n, **result}

--- a/tests/benchmarks/run_external.py
+++ b/tests/benchmarks/run_external.py
@@ -48,7 +48,11 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from tests.benchmarks.datasets import BenchmarkItem
 from tests.benchmarks.datasets.longmemeval_s import iter_items as iter_longmemeval
 from tests.benchmarks.datasets.locomo import iter_items as iter_locomo
-from tests.benchmarks.metrics.retrieval import mean_reciprocal_rank, recall_at_k
+from tests.benchmarks.metrics.retrieval import (
+    leaderboard_parity_slice,
+    mean_reciprocal_rank,
+    recall_at_k,
+)
 from tests.benchmarks.scenarios.external_base import ExternalScenario
 
 logging.basicConfig(
@@ -403,8 +407,20 @@ def compute_aggregate(
             "signal is fused in this mode.",
         ]
 
+    by_qt = _by_question_type(ok)
+
+    # Leaderboard-parity slice (issue #454): re-aggregate with LoCoMo's cat-5
+    # ("adversarial") excluded, so the run lines up against the common
+    # no-adversarial 1540-QA boards. Emitted only when cat-5 is actually
+    # present (LoCoMo), so LongMemEval reports are unchanged. Derived from the
+    # per-category breakdown, so it is reproducible from the committed artifact
+    # without re-running. See docs/benchmarks.md for the audit and the caveat:
+    # this snapshot's cat-5 is answerable/evidence-grounded, not refusal-style.
+    parity = leaderboard_parity_slice(by_qt, exclude_categories=("5",))
+    include_parity = bool(parity["excluded"])
+
     now = datetime.now(timezone.utc)
-    return {
+    aggregate = {
         "dataset": dataset,
         "retrieval_mode": retrieval_mode,
         "run_date": now.strftime("%Y-%m-%d"),
@@ -419,7 +435,7 @@ def compute_aggregate(
             "platform": platform.platform(),
             "cpu_count": os.cpu_count(),
         },
-        "by_question_type": _by_question_type(ok),
+        "by_question_type": by_qt,
         "summary": {
             "n_total": n_total,
             "n_ok": n_ok,
@@ -438,6 +454,9 @@ def compute_aggregate(
         ],
         "questions": [r.to_dict() for r in results],
     }
+    if include_parity:
+        aggregate["leaderboard_parity"] = parity
+    return aggregate
 
 
 # ---------------------------------------------------------------------------
@@ -504,6 +523,31 @@ def build_markdown_report(aggregate: dict) -> str:
                 f"{m['recall_at_5']:.4f} | {m['recall_at_10']:.4f} | "
                 f"{m['mrr']:.4f} |"
             )
+        lines.append("")
+
+    parity = aggregate.get("leaderboard_parity")
+    if parity and parity.get("excluded"):
+        excluded = ", ".join(parity["excluded"])
+        lines.append("## Leaderboard-parity slice")
+        lines.append("")
+        lines.append(
+            f"Categories excluded: {excluded} "
+            f"(LoCoMo cat-5 'adversarial' — see docs/benchmarks.md for the "
+            f"evidence audit and caveat). Re-aggregated from the per-category "
+            f"breakdown; comparable to the no-adversarial leaderboard variant."
+        )
+        lines.append("")
+        lines.append("| Slice | n | Recall@1 | Recall@5 | Recall@10 | MRR |")
+        lines.append("|---|---|---|---|---|---|")
+        lines.append(
+            f"| Full ({retrieval_mode}) | {s['n_ok']} | {s['recall_at_1']:.4f} | "
+            f"{s['recall_at_5']:.4f} | {s['recall_at_10']:.4f} | {s['mrr']:.4f} |"
+        )
+        lines.append(
+            f"| Parity ({retrieval_mode}) | {parity['n']} | "
+            f"{parity['recall_at_1']:.4f} | {parity['recall_at_5']:.4f} | "
+            f"{parity['recall_at_10']:.4f} | {parity['mrr']:.4f} |"
+        )
         lines.append("")
 
     lines += [

--- a/tests/benchmarks/test_harness.py
+++ b/tests/benchmarks/test_harness.py
@@ -15,6 +15,7 @@ import pytest
 
 from tests.benchmarks.metrics.retrieval import (
     calibration_error,
+    leaderboard_parity_slice,
     mean_reciprocal_rank,
     ndcg_at_k,
     precision_at_k,
@@ -104,6 +105,113 @@ class TestMRR:
 
     def test_no_hit(self):
         assert mean_reciprocal_rank(["x", "y", "z"], {"a"}) == 0.0
+
+
+class TestLeaderboardParitySlice:
+    """Pure re-aggregation of a by_question_type breakdown (issue #454)."""
+
+    # A minimal 3-category breakdown; metric values chosen so the n-weighted
+    # means are exact and hand-checkable.
+    BREAKDOWN = {
+        1: {
+            "n": 100,
+            "recall_at_1": 0.4,
+            "recall_at_5": 0.6,
+            "recall_at_10": 0.7,
+            "mrr": 0.5,
+        },
+        4: {
+            "n": 300,
+            "recall_at_1": 0.2,
+            "recall_at_5": 0.4,
+            "recall_at_10": 0.5,
+            "mrr": 0.3,
+        },
+        5: {
+            "n": 100,
+            "recall_at_1": 0.9,
+            "recall_at_5": 0.9,
+            "recall_at_10": 0.9,
+            "mrr": 0.9,
+        },
+    }
+
+    def test_excludes_default_cat5_and_reweights(self):
+        # Retained cats 1 (n=100) + 4 (n=300): R@1 = (100*0.4 + 300*0.2)/400 = 0.25
+        out = leaderboard_parity_slice(self.BREAKDOWN)
+        assert out["excluded"] == ["5"]
+        assert out["n"] == 400
+        assert out["recall_at_1"] == pytest.approx(0.25)
+        assert out["recall_at_5"] == pytest.approx(0.45)
+        assert out["recall_at_10"] == pytest.approx(0.55)
+        assert out["mrr"] == pytest.approx(0.35)
+
+    def test_string_keys_match_int_keys(self):
+        # A JSON round-trip stringifies category keys; the slice must be stable.
+        str_breakdown = {str(k): v for k, v in self.BREAKDOWN.items()}
+        assert leaderboard_parity_slice(str_breakdown) == leaderboard_parity_slice(
+            self.BREAKDOWN
+        )
+
+    def test_no_excluded_category_present_is_full_aggregate(self):
+        # Excluding a category that is not present retains everyone.
+        no_cat5 = {k: v for k, v in self.BREAKDOWN.items() if k != 5}
+        out = leaderboard_parity_slice(no_cat5)
+        assert out["excluded"] == []
+        assert out["n"] == 400
+
+    def test_multiple_exclusions(self):
+        out = leaderboard_parity_slice(self.BREAKDOWN, exclude_categories=("4", "5"))
+        assert out["excluded"] == ["4", "5"]
+        assert out["n"] == 100
+        assert out["recall_at_1"] == pytest.approx(0.4)
+
+    def test_all_excluded_yields_zero(self):
+        out = leaderboard_parity_slice(
+            self.BREAKDOWN, exclude_categories=("1", "4", "5")
+        )
+        assert out["n"] == 0
+        assert out["recall_at_1"] == 0.0
+        assert out["mrr"] == 0.0
+
+
+class TestLoCoMoParityRegression:
+    """Pin the published LoCoMo leaderboard-parity numbers (issue #454).
+
+    The 4-category slice is the standing published artifact; these assertions
+    are the regression gate so the docs numbers cannot silently drift from the
+    committed benchmark artifacts.
+    """
+
+    RESULTS_DIR = os.path.join(SCRIPT_DIR, "results", "external")
+
+    def _slice(self, filename):
+        import json
+
+        path = os.path.join(self.RESULTS_DIR, filename)
+        if not os.path.exists(path):
+            pytest.skip(f"committed artifact missing: {filename}")
+        with open(path) as fh:
+            data = json.load(fh)
+        return leaderboard_parity_slice(data["by_question_type"])
+
+    def test_lexical_parity_slice_is_1540_qa(self):
+        out = self._slice("locomo_latest.json")
+        assert out["excluded"] == ["5"]
+        assert out["n"] == 1540  # 1986 full − 446 cat-5 = exact leaderboard variant
+        assert out["recall_at_1"] == pytest.approx(0.2883, abs=1e-4)
+        assert out["recall_at_5"] == pytest.approx(0.5390, abs=1e-4)
+        assert out["recall_at_10"] == pytest.approx(0.6260, abs=1e-4)
+        assert out["mrr"] == pytest.approx(0.3991, abs=1e-4)
+
+    def test_hybrid_parity_slice_is_1540_qa(self):
+        out = self._slice("locomo_latest_hybrid.json")
+        assert out["excluded"] == ["5"]
+        assert out["n"] == 1540
+        assert out["recall_at_1"] == pytest.approx(0.1552, abs=1e-4)
+        assert out["recall_at_5"] == pytest.approx(0.4065, abs=1e-4)
+        assert out["recall_at_10"] == pytest.approx(0.5181, abs=1e-4)
+        assert out["mrr"] == pytest.approx(0.2686, abs=1e-4)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #454.

## What this is

The adversarial (category-5) scoring audit for LoCoMo — an **investigation** issue under epic #456 (Track A) whose recommendation is the scoring foundation for #463 (confidence-gated retrieval).

## Evidence audit — the load-bearing finding

Direct inspection of all **446** cat-5 items in the committed snapshot (`snap-research/locomo10.json`):

- **446/446 carry a populated `evidence` field** — the harness's empty-relevant-set special case never fires, so cat-5 is scored as ordinary retrieval, like every other category.
- **444/446 have an answerable `adversarial_answer` whose evidence span directly supports it.** E.g. *"What did Caroline realize after her charity race?"* → `adversarial_answer="self-care is important"`, evidence D2:3 = *"I'm starting to realize that self-care is really important."*
- **Only 2/446** are refusal-style ("Not mentioned").

**Conclusion: the issue's suspicion is *not confirmed* for this snapshot.** Cat-5 here is a set of grounded, answerable retrieval questions; its spans are genuinely meaningful, so any-hit retrieval scoring is measuring retrieval — not "the wrong thing." The paper's ≈2 F1 vs Popoto's 0.33 R@1 is a **metric-family difference** (judged-answer accuracy vs retrieval recall), not a scoring artifact — adversarial is hard to *answer/judge*, not hard to *retrieve*.

## Recommendation (for maintainer sign-off — scoring semantics is policy-level)

1. **Keep cat-5 in the full 5-category aggregate** (its spans are meaningful).
2. **Publish the 4-category leaderboard-parity slice** (n=**1540** = 1986 − 446, the exact common no-adversarial variant count) alongside the full aggregate.
3. **Mandatory caveat:** this snapshot's cat-5 is answerable/evidence-grounded, *not* refusal-style — the number is not a refusal-capability signal and not comparable to systems that report refusal-adversarial or drop the category.
4. **Refusal metric (Option 1) does not apply here** — only 2/446 items are unanswerable, so a "precision of no-answer decisions" metric has no signal. Refusal capability is deferred to #463.

## Parity-slice numbers (computed from committed `by_question_type`, no re-run)

| Slice | n | R@1 | R@5 | R@10 | MRR |
|---|--:|--:|--:|--:|--:|
| lexical, full 5-cat | 1986 | 0.2986 | 0.5534 | 0.6400 | 0.4124 |
| lexical, 4-cat parity | 1540 | 0.2883 | 0.5390 | 0.6260 | 0.3991 |
| hybrid, full 5-cat | 1986 | 0.1667 | 0.4235 | 0.5403 | 0.2835 |
| hybrid, 4-cat parity | 1540 | 0.1552 | 0.4065 | 0.5181 | 0.2686 |

cat-5 sits near the mean, so excluding it barely moves the numbers.

## Changes

- `tests/benchmarks/metrics/retrieval.py`: pure `leaderboard_parity_slice()` — n-weighted re-aggregation of a `by_question_type` breakdown with categories excluded; int/str key-safe; reproducible from a committed artifact.
- `tests/benchmarks/run_external.py`: emit a forward-looking `leaderboard_parity` block (JSON + markdown) for LoCoMo runs only; LongMemEval reports unchanged. **Committed artifacts are not regenerated** (would need a multi-hour full run); published numbers derive from the same pure function over the committed breakdown.
- `tests/benchmarks/test_harness.py`: unit tests for the pure function + regression tests pinning the LoCoMo parity numbers (n=1540 and the four values above).
- `docs/benchmarks.md`: replace the cat-5 paragraph with the evidence audit, the parity-slice table, and the sign-off recommendation.
- `docs/plans/adversarial_cat5_scoring_audit.md`: investigation plan + findings.

## Tests

- `pytest tests/benchmarks/test_harness.py tests/benchmarks/test_external.py` → **125 passed**.
- `mkdocs build --strict` → exit 0.
- Stress gate intentionally not run: unrelated to this scoring/docs diff, and a full run collides with other active worktrees on Redis DB 15.

## Out of scope (policy-level / other issues)

Changing the headline aggregate to exclude cat-5, or implementing a refusal metric in the harness (deferred to #463); re-running benchmarks / regenerating artifacts; any retrieval tuning.