### PR TITLE
feat(#469): publish vector-mode benchmark results + warn on unmapped artifacts

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -120,8 +120,16 @@ tests/benchmarks/results/external/
 
 Non-lexical runs suffix the retrieval mode into both the dated and `_latest`
 filenames (e.g. `longmemeval_s_20260703_hybrid.json`,
-`longmemeval_s_latest_hybrid.json`), so a hybrid run never overwrites the
-lexical baseline artifacts or their symlinks.
+`longmemeval_s_latest_hybrid.json`; `vector` uses the `_vector` suffix), so a
+hybrid or vector run never overwrites the lexical baseline artifacts or their
+symlinks.
+
+Committing a `_latest` artifact (any mode) auto-publishes it to the
+[Benchmarks results pages](benchmarks/results/index.md) on the docs site on the
+next deploy — the `lexical`, `hybrid`, and `vector` pages per dataset are generated
+from these artifacts by `docs/scripts/gen_benchmark_pages.py`, with no
+hand-edited prose tables. An artifact for a mode nobody wired a page for is
+reported as a loud build-time warning rather than silently dropped.
 
 Each JSON report includes:
 - `summary` — aggregate Recall@1/5/10, MRR, p50/p95 latency

--- a/docs/plans/benchmark_docs_gen_vector_mode.md
+++ b/docs/plans/benchmark_docs_gen_vector_mode.md
@@ -1,0 +1,333 @@
+---
+status: Ready
+type: feature
+appetite: Small
+owner: valorengels
+created: 2026-07-14
+tracking: https://github.com/tomcounsell/popoto/issues/469
+last_comment_id: none
+---
+
+# Benchmark Docs Generator: Publish Vector-Mode Results (and stop the silent gap)
+
+## Problem
+
+The benchmark docs generator `docs/scripts/gen_benchmark_pages.py` decides which
+result artifacts get published to the docs site ([popoto.io](https://popoto.io/))
+from an **explicit hardcoded `SPECS` tuple**, not from directory auto-discovery.
+Today that list covers lexical + hybrid (LongMemEval-S, LoCoMo) + CSR only —
+there is **no vector-mode `Spec`**.
+
+The vector retrieval mode merged in #455 / PR #467 produces `_vector`-suffixed
+artifacts (`external/{dataset}_latest_vector.{json,md}`). Because no vector
+`Spec` exists, the moment such an artifact is committed it will **not** publish
+to the docs site — a maintainer must hand-add a `Spec`.
+
+**Current behavior:**
+- The generator degrades gracefully — a missing artifact is skipped, never
+  raised, so `mkdocs build --strict` stays green. This is deliberate.
+- The failure mode is therefore **silent**: a `_vector` artifact can exist in
+  the repo while its docs page never appears and nothing errors. Easy to forget,
+  hard to notice.
+- Verified 2026-07-14: no `_vector` artifact is currently committed under
+  `tests/benchmarks/results/external/`, so nothing is dropped *today* — this is a
+  latent gap that trips the moment vector artifacts land.
+
+**Desired outcome:**
+- A vector-mode results page publishes automatically the moment a
+  `{dataset}_latest_vector.{json,md}` artifact is committed — zero further
+  hand-editing, same as lexical/hybrid.
+- Any *future* unmapped `_latest` artifact (a new retrieval mode nobody wired a
+  `Spec` for) produces a **loud build-time warning** instead of silently
+  vanishing — the root complaint of this issue.
+- Deterministic page order, per-page titles, and per-dataset framing prose are
+  preserved (the deliberate #466 design choice); metric-family doctrine is
+  respected (never cross-compare recall vs. judge-accuracy; never fabricate
+  numbers).
+
+## Freshness Check
+
+**Baseline commit:** 0b4c629 (`git rev-parse origin/main` at plan time)
+**Issue filed at:** 2026-07-14 (same day as planning)
+**Disposition:** Unchanged
+
+**File:line references re-verified against current main:**
+- `docs/scripts/gen_benchmark_pages.py` — `SPECS: tuple[Spec, ...]` present
+  (`longmemeval_s_lexical`, `longmemeval_s_hybrid`, `locomo_lexical`,
+  `locomo_hybrid`, `csr`); none reference a `_vector` stem. `Spec` frozen
+  dataclass fields (`slug`, `title`, `nav_title`, `stem`, `kind`, `note`)
+  confirmed verbatim. `_write_page` skips a missing `.md` with a stderr note and
+  returns `None`; `main()` is called unconditionally at module bottom. Confirmed.
+- `tests/benchmarks/run_external.py:601-602` — non-lexical runs write
+  `{slug}_latest{suffix}.{json,md}` where `suffix` is `_vector` for vector mode.
+  So vector artifacts land as `external/{dataset}_latest_vector.{json,md}`.
+  Confirmed.
+- `tests/benchmarks/results/external/` — only `_latest` / `_latest_hybrid`
+  symlinks per dataset; no `_vector` artifact present. Confirmed (matches the
+  issue's 2026-07-14 verification).
+- `mkdocs.yml:124-128` — `gen-files` plugin runs `docs/scripts/gen_benchmark_pages.py`.
+  Confirmed. The plugin execs the script via `runpy.run_path`, which sets
+  `__name__ == "<run_path>"` (verified empirically), not `"__main__"`.
+
+**Cited sibling issues/PRs re-checked:**
+- PR #467 (#455, vector retrieval mode) — **merged** (commit 19bc96f). Produces
+  the `_vector` artifacts this plan publishes. Its `docs/benchmarks.md` framing
+  states vector isolates **only the dense arm**, not the graph/co-occurrence arm
+  inside hybrid — the framing note for the vector pages must echo this.
+- PR #466 (benchmark results docs publishing) — **merged** (commit 661168d).
+  Introduced this generator and the deliberate explicit-list (not-glob) design.
+- Issue #453 — parent (publish benchmark results). Plan
+  `benchmark_results_docs_publishing.md` present; this plan is a leaf extension.
+
+**Commits on main since issue filed (touching referenced files):** none since
+0b4c629 touch `docs/scripts/gen_benchmark_pages.py` or the external artifacts.
+
+**Active plans in `docs/plans/` overlapping this area:**
+- `benchmark_results_docs_publishing.md` (#453) — introduced the generator; this
+  plan extends its `SPECS` list. No conflict.
+- Per the routing note, **#457** (weighted/query-adaptive hybrid fusion) also
+  touches the benchmark/docs area and may conflict at merge. Mitigation: rebase
+  on `origin/main` immediately before merge and resolve conflicts in
+  `gen_benchmark_pages.py` / `docs/benchmarks.md` cleanly.
+
+**Notes:** No drift. All issue claims hold against current main.
+
+## Prior Art
+
+- **PR #466 — benchmark results docs publishing**: introduced
+  `gen_benchmark_pages.py` with the explicit `SPECS` list and the
+  graceful-degradation skip design. This plan extends it; it does **not** revert
+  the explicit-list decision.
+- **PR #467 (#455) — vector retrieval mode**: produces the `_vector` artifacts.
+  Merged. Its `docs/benchmarks.md` note is the canonical framing source for what
+  vector mode measures ("isolates only the dense arm").
+- No prior attempt to publish vector results exists; this is the first.
+
+## Research
+
+No relevant external findings — the work is entirely internal to the repo's
+`mkdocs-gen-files` generator and the committed artifact layout. `runpy.run_path`
+`__name__` behavior (`"<run_path>"`) was verified empirically rather than from
+docs.
+
+## Data Flow
+
+1. **Artifact commit** — a benchmark run commits
+   `tests/benchmarks/results/external/{dataset}_latest_vector.{json,md}`.
+2. **Build trigger** — `mkdocs build --strict` runs the `gen-files` plugin,
+   which `runpy.run_path`s `gen_benchmark_pages.py`.
+3. **Spec resolution** — `main()` iterates `SPECS`; for each, `_write_page`
+   resolves `RESULTS_ROOT/{stem}.md`. Present → page emitted; missing → skipped
+   with stderr note (graceful degradation, unchanged).
+4. **Orphan scan (new)** — after the spec loop, the generator scans
+   `RESULTS_ROOT/external` for `*_latest*.md` artifacts not referenced by any
+   `Spec.stem`, and emits a **stderr warning** per orphan (never raises).
+5. **Output** — `benchmarks/results/{slug}.md` pages + `index.md` + `SUMMARY.md`
+   under the built site; vector pages appear once their artifacts exist.
+
+## Architectural Impact
+
+- **New dependencies**: none.
+- **Interface changes**: `SPECS` gains two entries; `main()` gains a
+  post-loop orphan-scan call. The module bottom changes from an unconditional
+  `main()` to a `if __name__ in ("__main__", "<run_path>"): main()` guard so the
+  module is importable by a unit test without executing the generator (still runs
+  under mkdocs, which uses `runpy` → `"<run_path>"`).
+- **Coupling**: unchanged — still decoupled from filesystem accidents for
+  *ordering/framing*; the orphan scan only *warns*, it never auto-publishes, so
+  the deterministic-list guarantee holds.
+- **Reversibility**: trivial — revert the two `Spec`s and the orphan-scan helper.
+
+## Appetite
+
+**Size:** Small
+
+**Team:** Solo dev, PM (routing), code reviewer (PR gate)
+
+**Interactions:**
+- PM check-ins: 0-1
+- Review rounds: 1
+
+## Prerequisites
+
+No external prerequisites. Local verification needs Redis on `localhost:6379`
+(pytest plugin isolates on DB 15) and the docs toolchain (`mkdocs build
+--strict` via `scripts/ci-local.sh docs`). Both are already provisioned in this
+environment.
+
+## Solution
+
+### Key Elements
+
+- **Two vector `Spec`s** — `longmemeval_s_vector` (stem
+  `external/longmemeval_s_latest_vector`) and `locomo_vector` (stem
+  `external/locomo_latest_vector`), both `kind="external"`. Placed so page order
+  reads lexical → hybrid → vector per dataset, preserving deterministic ordering.
+- **Doctrine-safe framing notes** — each vector `Spec.note` is a static
+  admonition that (a) states vector = pure cosine over all-MiniLM-L6-v2,
+  isolating **only the dense arm** (echoing PR #467), (b) anchors LoCoMo in the
+  MEMTIER retrieval regime, and (c) contains **no fabricated recall numbers** —
+  numbers come from the artifact body/JSON at build time, so the note stays
+  honest before any artifact lands.
+- **Orphan-artifact scan** — a new helper walks `RESULTS_ROOT/external` for
+  `*_latest*.md` files whose stem is referenced by no `Spec`, printing a loud
+  `[gen_benchmark_pages] WARNING: unmapped artifact ...` to stderr. Never raises
+  → `--strict` stays green; converts the silent gap into a visible one.
+- **Importability guard** — guard the `main()` call so a unit test can import the
+  module and exercise the pure helpers without running the full generator.
+
+### Flow
+
+Benchmark run commits `{dataset}_latest_vector.{json,md}` → next docs deploy runs
+`gen_benchmark_pages.py` → vector `Spec` resolves the now-present artifact → a
+`… — Vector (Dense/Embedding) Retrieval` page appears in the Benchmarks nav with
+its framing note, exactly like lexical/hybrid — with zero code change at that
+point.
+
+### Technical Approach
+
+- Add the two `Spec`s to the `SPECS` tuple in dataset-then-mode order
+  (`longmemeval_s_lexical`, `longmemeval_s_hybrid`, **`longmemeval_s_vector`**,
+  `locomo_lexical`, `locomo_hybrid`, **`locomo_vector`**, `csr`). Slug prefixes
+  keep `_dataset_table("longmemeval_s")` / `_dataset_table("locomo")` grouping
+  correct with no change to the index tables.
+- Framing notes: `!!! note` admonitions. LongMemEval-S vector note frames it as
+  the dense-arm isolation diagnostic (not the headline; hybrid remains headline).
+  LoCoMo vector note carries the MEMTIER retrieval-regime anchor and the
+  "isolates only the dense arm, not the graph/co-occurrence arm" caveat from
+  PR #467. No hardcoded Recall@k values in either note.
+- Add `_iter_spec_stems()` and `_warn_orphan_artifacts(specs)` helpers.
+  `_warn_orphan_artifacts` globs `RESULTS_ROOT/external/*_latest*.md`, derives
+  each artifact's stem relative to `RESULTS_ROOT` (dropping `.md`), and warns for
+  any not present in the set of `Spec.stem` values. Called from `main()` after
+  the spec loop (order irrelevant; it only prints).
+- Change module bottom to `if __name__ in ("__main__", "<run_path>"): main()`.
+  Verified: mkdocs-gen-files execs via `runpy.run_path` → `__name__ ==
+  "<run_path>"`, so the generator still runs at build; a unit `import` (module
+  name `gen_benchmark_pages`) does not trigger `main()`.
+
+## Failure Path Test Strategy
+
+### Exception Handling Coverage
+- The generator's existing skip paths (`_write_page` missing `.md`,
+  `_read_summary` missing/malformed `.json`) already print-and-continue; this
+  plan does not add new `except: pass`. The orphan scan itself performs no
+  risky I/O beyond `Path.glob` (which returns empty on a missing dir) and
+  `print`. A test asserts the orphan scan **warns** (observable stderr), not
+  swallows.
+
+### Empty/Invalid Input Handling
+- Orphan scan on an empty/absent `external/` dir → no warnings, no error (glob
+  yields nothing). Covered by a test using a temp dir with no artifacts.
+- Vector `Spec` with no committed artifact → page skipped (existing graceful
+  path), index/summary omit it. Verified by the `docs` gate staying green on the
+  current repo state (no vector artifacts present).
+
+### Error State Rendering
+- User-visible output is the built docs. The failure path (artifact absent) is
+  the *intended* graceful skip; verified by `mkdocs build --strict` staying
+  green with no vector artifacts present (the current repo state).
+
+## Test Impact
+
+No existing tests are affected — there is currently **no** test module for
+`gen_benchmark_pages.py` (confirmed: `grep -rl gen_benchmark_pages tests/`
+returns nothing). This plan adds a new test module; it modifies no existing
+tests and changes no runtime behavior of the shipped library.
+
+New test module `tests/benchmarks/test_gen_benchmark_pages.py` (import-safe via
+the `main()` guard):
+- `test_vector_specs_present_and_ordered` — both vector specs exist, use the
+  correct `external/{dataset}_latest_vector` stems, `kind="external"`, and sit
+  after their dataset's hybrid spec in `SPECS`.
+- `test_vector_notes_have_no_fabricated_numbers` — the vector `Spec.note`
+  strings contain no `Recall@` / decimal metric literals (doctrine: don't
+  fabricate numbers before artifacts exist).
+- `test_orphan_artifact_scan_warns` — a temp `external/` dir with an unmapped
+  `foo_latest_experimental.md` triggers a warning naming the artifact; a mapped
+  stem does not.
+- `test_orphan_scan_silent_when_all_mapped` — no warnings when every artifact
+  has a spec (and empty dir → no warning, no raise).
+
+## Rabbit Holes
+
+- **Full glob-based auto-discovery (issue direction (b))**: tempting, but it
+  would forfeit the deliberate #466 deterministic-order + per-page-framing
+  design and risk publishing a page with no doctrine-safe framing note. The
+  orphan **warning** captures the safety benefit (no silent drop) without the
+  cost. Out of scope.
+- **Backfilling actual vector artifacts / running the vector benchmark**: this
+  plan wires *publishing*; producing the `_vector` numbers is #455/#457 work and
+  requires the ~90MB MiniLM download and a real run. Do not fabricate artifacts.
+- **Restructuring the index headline tables to add a vector column**: the
+  existing `_external_table` already renders any `kind="external"` row; vector
+  pages will appear as rows automatically once their artifacts exist. No table
+  surgery needed.
+
+## Risks
+
+### Risk 1: Vector framing note drifts from doctrine (cross-compares metric families)
+**Impact:** Publishing a note that tabulates recall beside judge-accuracy, or
+invents recall numbers, would violate benchmark doctrine and mislead readers.
+**Mitigation:** Notes carry no numbers; they only frame *what* vector measures
+(dense arm isolation) and anchor LoCoMo in the MEMTIER regime. A test asserts the
+notes contain no metric literals.
+
+### Risk 2: `main()` guard breaks the mkdocs build
+**Impact:** If the guard predicate is wrong, the generator silently stops running
+at build and *all* benchmark pages vanish.
+**Mitigation:** Guard is `__name__ in ("__main__", "<run_path>")`; `<run_path>`
+is empirically confirmed as the `runpy.run_path` name mkdocs uses. The `docs`
+gate (`mkdocs build --strict`) in `scripts/ci-local.sh` is a hard verification
+that the build still emits the existing pages.
+
+### Risk 3: Merge conflict with #457 in the same files
+**Impact:** #457 touches the benchmark/docs area; a dirty merge could drop a spec
+or corrupt framing.
+**Mitigation:** Rebase on `origin/main` immediately before merge; resolve
+`gen_benchmark_pages.py` conflicts by keeping both sets of specs/logic; re-run
+the `docs` gate post-rebase.
+
+## Race Conditions
+
+No race conditions identified — the generator is a synchronous, single-threaded
+build-time script; the orphan scan is read-only `Path.glob` + `print`.
+
+## No-Gos (Out of Scope)
+
+- [SEPARATE-SLUG #457] Producing/tuning the actual vector-mode benchmark numbers
+  (weighted/query-adaptive fusion, running the MiniLM vector arm) is #457 work,
+  not this publishing wiring.
+- Nothing else deferred — the publishing gap and the silent-drop root cause are
+  both fully addressed in this plan.
+
+## Update System
+
+No update-system changes required — this is a build-time docs generator change
+with no runtime library or deployment surface.
+
+## Agent Integration
+
+No agent integration required — this touches the docs build only; no tool/MCP
+surface or bridge entry point is involved.
+
+## Documentation
+
+### Feature Documentation
+- The generator's module docstring "Output layout" list must add the two vector
+  page paths so the file self-documents what it emits.
+- `docs/benchmarks.md` already documents vector mode (added in PR #467); confirm
+  no additional prose is needed there. Run the `/do-docs` cascade to catch any
+  cross-references (e.g. the Benchmarks overview) that should mention the vector
+  pages.
+
+## Verification
+
+| # | Criterion | Check |
+|---|-----------|-------|
+| 1 | Two vector specs present, correct stems, correct order | `pytest tests/benchmarks/test_gen_benchmark_pages.py::test_vector_specs_present_and_ordered` |
+| 2 | Vector notes contain no fabricated metric numbers | `pytest tests/benchmarks/test_gen_benchmark_pages.py::test_vector_notes_have_no_fabricated_numbers` |
+| 3 | Unmapped artifact triggers a loud stderr warning (silent gap closed) | `pytest tests/benchmarks/test_gen_benchmark_pages.py::test_orphan_artifact_scan_warns` |
+| 4 | Orphan scan silent when all artifacts mapped / dir empty | `pytest tests/benchmarks/test_gen_benchmark_pages.py::test_orphan_scan_silent_when_all_mapped` |
+| 5 | Docs still build clean with no vector artifacts present (graceful) | `scripts/ci-local.sh docs` (`mkdocs build --strict`) |
+| 6 | No fabricated vector artifacts committed | `git status` shows no new files under `tests/benchmarks/results/external/` |

--- a/docs/plans/benchmark_docs_gen_vector_mode.md
+++ b/docs/plans/benchmark_docs_gen_vector_mode.md
@@ -4,6 +4,8 @@ type: feature
 appetite: Small
 owner: valorengels
 created: 2026-07-14
+revision_applied: true
+revision_applied_at: 2026-07-14T06:04:09Z
 tracking: https://github.com/tomcounsell/popoto/issues/469
 last_comment_id: none
 ---
@@ -196,11 +198,17 @@ point.
   LoCoMo vector note carries the MEMTIER retrieval-regime anchor and the
   "isolates only the dense arm, not the graph/co-occurrence arm" caveat from
   PR #467. No hardcoded Recall@k values in either note.
-- Add `_iter_spec_stems()` and `_warn_orphan_artifacts(specs)` helpers.
-  `_warn_orphan_artifacts` globs `RESULTS_ROOT/external/*_latest*.md`, derives
-  each artifact's stem relative to `RESULTS_ROOT` (dropping `.md`), and warns for
-  any not present in the set of `Spec.stem` values. Called from `main()` after
-  the spec loop (order irrelevant; it only prints).
+- Add `_iter_spec_stems()` and `_warn_orphan_artifacts(specs, root=RESULTS_ROOT)`
+  helpers. `_warn_orphan_artifacts` globs `root/"external"/"*_latest*.md"`,
+  derives each artifact's stem relative to `root` (preserving the `external/`
+  prefix, dropping `.md`), and warns for any not present in the set of
+  `Spec.stem` values. Called from `main()` after the spec loop (order
+  irrelevant; it only prints). **The `root` parameter is injectable** (defaults
+  to `RESULTS_ROOT`) so tests pass a `tmp_path` root and never write into or
+  read from the real `tests/benchmarks/results/external/` — this keeps
+  Verification criterion 6 (no new files under `results/external/`) safe and the
+  tests hermetic. Stem derivation stays relative to `root` so a mapped
+  `Spec.stem` like `external/longmemeval_s_latest_vector` compares equal.
 - Change module bottom to `if __name__ in ("__main__", "<run_path>"): main()`.
   Verified: mkdocs-gen-files execs via `runpy.run_path` → `__name__ ==
   "<run_path>"`, so the generator still runs at build; a unit `import` (module
@@ -243,11 +251,16 @@ the `main()` guard):
 - `test_vector_notes_have_no_fabricated_numbers` — the vector `Spec.note`
   strings contain no `Recall@` / decimal metric literals (doctrine: don't
   fabricate numbers before artifacts exist).
-- `test_orphan_artifact_scan_warns` — a temp `external/` dir with an unmapped
-  `foo_latest_experimental.md` triggers a warning naming the artifact; a mapped
-  stem does not.
-- `test_orphan_scan_silent_when_all_mapped` — no warnings when every artifact
-  has a spec (and empty dir → no warning, no raise).
+- `test_orphan_artifact_scan_warns` — pass a `tmp_path` root containing an
+  `external/foo_latest_experimental.md` (unmapped) via
+  `_warn_orphan_artifacts(SPECS, root=tmp_path)`; assert a warning names the
+  artifact.
+- `test_orphan_scan_silent_when_all_mapped` — a `tmp_path` root whose only
+  `external/*_latest*.md` files correspond to existing `Spec.stem`s emits no
+  warning; an empty root emits no warning and does not raise.
+
+All orphan-scan tests pass an injected `tmp_path` root — they never write into
+or monkeypatch the real `RESULTS_ROOT`.
 
 ## Rabbit Holes
 

--- a/docs/scripts/gen_benchmark_pages.py
+++ b/docs/scripts/gen_benchmark_pages.py
@@ -49,9 +49,20 @@ Output layout (virtual files under ``benchmarks/results/``):
     benchmarks/results/index.md                    -- Overview + framing + headline table
     benchmarks/results/longmemeval_s_lexical.md
     benchmarks/results/longmemeval_s_hybrid.md
+    benchmarks/results/longmemeval_s_vector.md
     benchmarks/results/locomo_lexical.md
     benchmarks/results/locomo_hybrid.md
+    benchmarks/results/locomo_vector.md
     benchmarks/results/csr.md
+
+A page is emitted only when its artifact is committed. The ``_vector`` pages
+(dense/embedding retrieval, produced by the ``--retrieval-mode vector`` harness
+in #455/PR #467) therefore appear on the docs site the moment a
+``{dataset}_latest_vector.{json,md}`` artifact lands under
+``tests/benchmarks/results/external/`` — no code edit required at that point.
+Any ``*_latest*`` artifact not covered by a ``Spec`` is reported as a loud
+build-time warning by ``_warn_orphan_artifacts`` (never raised), so a new
+retrieval mode can never be silently dropped from the site.
 
 Valkey-safety: this generator writes only framing prose plus the embedded
 harness markdown. It introduces no Redis-module command strings (the search,
@@ -108,7 +119,7 @@ SPECS: tuple[Spec, ...] = (
         stem="external/longmemeval_s_latest",
         kind="external",
         note=(
-            "!!! note \"Lexical (BM25-only) baseline\"\n"
+            '!!! note "Lexical (BM25-only) baseline"\n'
             "    Query-sensitive BM25 with no vector signal fused in. This is the\n"
             "    score-only baseline; the LongMemEval-S hybrid variant adds the\n"
             "    vector arm and is the headline result (see the\n"
@@ -122,7 +133,7 @@ SPECS: tuple[Spec, ...] = (
         stem="external/longmemeval_s_latest_hybrid",
         kind="external",
         note=(
-            "!!! success \"Headline result — like-for-like win over the reference\"\n"
+            '!!! success "Headline result — like-for-like win over the reference"\n'
             "    Hybrid retrieval (BM25 + all-MiniLM-L6-v2 vector fused via Reciprocal\n"
             "    Rank Fusion, k=60) reaches **Recall@1 0.894 / Recall@5 0.986 /\n"
             "    Recall@10 0.992 / MRR 0.932**, beating the agentmemory BM25+Vector\n"
@@ -132,13 +143,30 @@ SPECS: tuple[Spec, ...] = (
         ),
     ),
     Spec(
+        slug="longmemeval_s_vector",
+        title="LongMemEval-S — Vector (Dense/Embedding) Retrieval",
+        nav_title="LongMemEval-S (vector)",
+        stem="external/longmemeval_s_latest_vector",
+        kind="external",
+        note=(
+            '!!! note "Dense-arm diagnostic — not the headline"\n'
+            "    Vector retrieval ranks by **pure cosine** over the\n"
+            "    all-MiniLM-L6-v2 embedding (no BM25, no Reciprocal Rank Fusion).\n"
+            "    It isolates the **dense arm only** — a diagnostic baseline for the\n"
+            "    hybrid-vs-lexical investigation, not a headline result. The\n"
+            "    LongMemEval-S headline remains the hybrid variant (see the\n"
+            "    [Overview](index.md)). Same retrieval-recall metric family as the\n"
+            "    lexical and hybrid pages, so the three are directly comparable.\n"
+        ),
+    ),
+    Spec(
         slug="locomo_lexical",
         title="LoCoMo — Lexical (BM25) Retrieval",
         nav_title="LoCoMo (lexical)",
         stem="external/locomo_latest",
         kind="external",
         note=(
-            "!!! note \"Retrieval regime — read the [Overview](index.md) first\"\n"
+            '!!! note "Retrieval regime — read the [Overview](index.md) first"\n'
             "    Measured as *retrieval recall*, published LoCoMo Recall@1 sits in the\n"
             "    0.10–0.30 band (MEMTIER, arXiv:2605.03675). Popoto lexical Recall@1\n"
             "    **0.2986** is competitive-to-strong in this regime. This variant is\n"
@@ -153,7 +181,7 @@ SPECS: tuple[Spec, ...] = (
         stem="external/locomo_latest_hybrid",
         kind="external",
         note=(
-            "!!! warning \"Hybrid underperforms lexical here — reported factually, untuned\"\n"
+            '!!! warning "Hybrid underperforms lexical here — reported factually, untuned"\n'
             "    On this LoCoMo variant, hybrid (**Recall@1 0.1667 / MRR 0.2835**)\n"
             "    measurably underperforms the lexical path (**Recall@1 0.2986 /\n"
             "    MRR 0.4124**). No retrieval tuning has been attempted; an unweighted\n"
@@ -164,18 +192,37 @@ SPECS: tuple[Spec, ...] = (
         ),
     ),
     Spec(
+        slug="locomo_vector",
+        title="LoCoMo — Vector (Dense/Embedding) Retrieval",
+        nav_title="LoCoMo (vector)",
+        stem="external/locomo_latest_vector",
+        kind="external",
+        note=(
+            '!!! note "Dense-arm diagnostic — read in the retrieval regime"\n'
+            "    Vector retrieval ranks by **pure cosine** over the\n"
+            "    all-MiniLM-L6-v2 embedding (no BM25, no Reciprocal Rank Fusion). It\n"
+            "    isolates the **dense arm only** — *not* the graph/co-occurrence arm\n"
+            "    that also lives inside hybrid — so a weak number here does not by\n"
+            "    itself explain the hybrid-vs-lexical gap. Read it in the MEMTIER\n"
+            "    retrieval regime (published LoCoMo Recall@1 sits in the 0.10–0.30\n"
+            "    band, arXiv:2605.03675), and against the same 10-dialogue /\n"
+            "    5-category / 1986-QA-pair LoCoMo variant used by the lexical and\n"
+            "    hybrid pages — same retrieval-recall metric family throughout.\n"
+        ),
+    ),
+    Spec(
         slug="csr",
         title="Deterministic CSR Regression Gate",
         nav_title="CSR Regression Gate",
         stem="csr/csr_latest",
         kind="csr",
         note=(
-            "!!! info \"Report-only CI gate — not a leaderboard metric\"\n"
+            '!!! info "Report-only CI gate — not a leaderboard metric"\n'
             "    The Constraint Satisfaction Rate (CSR) harness is a deterministic,\n"
             "    per-PR regression gate (bit-identical every run — no LLM judge, no\n"
             "    embeddings, no Redis module; identical on Redis and Valkey). Its RSR\n"
             "    (standard/adversarial) and Adversarial Gap numbers are report-only\n"
-            "    signals for catching regressions, **not** a \"higher is better\"\n"
+            '    signals for catching regressions, **not** a "higher is better"\n'
             "    leaderboard score.\n"
         ),
     ),
@@ -413,6 +460,52 @@ def _write_summary(rows: list[dict]) -> None:
             fd.write(f"* [{spec.nav_title}]({spec.slug}.md)\n")
 
 
+def _warn_orphan_artifacts(
+    specs: tuple[Spec, ...], root: Path = RESULTS_ROOT
+) -> list[str]:
+    """Warn (never raise) about ``external/`` artifacts no ``Spec`` publishes.
+
+    The published set is an *explicit* ``SPECS`` list (not a directory glob), by
+    design, so page order and per-dataset framing stay deterministic. The cost
+    of that design is a **silent** gap: an ``external/*_latest*`` artifact that
+    no ``Spec`` references is skipped without a trace, so a new retrieval mode's
+    results can land in the repo yet never appear on the docs site.
+
+    This scan converts that silent gap into a **loud** one. It globs
+    ``root/external/*_latest*.md`` (the artifact whose presence would drive a
+    page), and for every artifact whose ``RESULTS_ROOT``-relative stem is not the
+    ``stem`` of some ``Spec``, prints a build-time WARNING to stderr. It never
+    raises — ``mkdocs build --strict`` stays green — and it never publishes; a
+    human still authors the ``Spec`` (with deterministic order and framing). The
+    warning simply makes the omission visible in the deploy log.
+
+    ``root`` is injectable (defaults to ``RESULTS_ROOT``) so tests can point it
+    at a ``tmp_path`` and never touch the committed ``results/external/`` tree.
+    Returns the list of orphan stems it warned about (for testability).
+
+    Only the ``.md`` artifact is scanned: the ``.md`` is what drives a page body,
+    so a lone ``.json`` without an ``.md`` would be skipped by ``_write_page``
+    anyway and is not an "unpublished results page" in the sense this guards.
+    """
+    mapped = {spec.stem for spec in specs}
+    external_dir = root / "external"
+    orphans: list[str] = []
+    for md_path in sorted(external_dir.glob("*_latest*.md")):
+        # Stem relative to RESULTS_ROOT, preserving the ``external/`` prefix and
+        # dropping the ``.md`` suffix, so it compares equal to a ``Spec.stem``
+        # such as ``external/longmemeval_s_latest_vector``.
+        stem = md_path.relative_to(root).with_suffix("").as_posix()
+        if stem not in mapped:
+            orphans.append(stem)
+            print(
+                f"[gen_benchmark_pages] WARNING: unmapped artifact {stem!r} "
+                f"({md_path}) — no Spec publishes it, so it is absent from the "
+                "docs site. Add a Spec to SPECS to publish it.",
+                file=sys.stderr,
+            )
+    return orphans
+
+
 def main() -> None:
     rows: list[dict] = []
     for spec in SPECS:
@@ -421,6 +514,13 @@ def main() -> None:
             rows.append(result)
     _write_index(rows)
     _write_summary(rows)
+    _warn_orphan_artifacts(SPECS)
 
 
-main()
+if __name__ in ("__main__", "<run_path>"):
+    # mkdocs-gen-files execs this file via ``runpy.run_path``, which sets
+    # ``__name__`` to ``"<run_path>"``; running it directly sets ``"__main__"``.
+    # Guarding on both keeps the generator running at build time while letting a
+    # unit test ``import`` the module (to exercise SPECS / _warn_orphan_artifacts)
+    # without triggering the full build-time generation.
+    main()

--- a/tests/benchmarks/test_gen_benchmark_pages.py
+++ b/tests/benchmarks/test_gen_benchmark_pages.py
@@ -1,0 +1,193 @@
+"""Tests for the benchmark docs generator ``docs/scripts/gen_benchmark_pages.py``.
+
+The generator publishes committed ``*_latest*.{json,md}`` benchmark artifacts to
+the docs site from an *explicit* ``SPECS`` list. These tests cover the #469
+additions:
+
+* vector-mode ``Spec``s exist, target the correct ``_vector`` artifact stems,
+  and sit in deterministic dataset-then-mode order;
+* the vector framing notes fabricate no metric numbers (benchmark doctrine:
+  never publish results that do not exist as committed artifacts);
+* ``_warn_orphan_artifacts`` turns the previously-silent "unmapped artifact"
+  gap into a loud stderr warning, without raising and without touching the real
+  ``results/external/`` tree (the scan root is injectable).
+
+The generator lives under ``docs/scripts/`` (not an importable package) and its
+``main()`` is guarded so ``import`` does not trigger the full build-time run.
+We therefore load it by file path via ``importlib``.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GEN_PATH = _REPO_ROOT / "docs" / "scripts" / "gen_benchmark_pages.py"
+
+pytest.importorskip(
+    "mkdocs_gen_files",
+    reason="gen_benchmark_pages imports mkdocs_gen_files (docs extra)",
+)
+
+
+def _load_generator():
+    """Import the generator module by file path without running ``main()``."""
+    spec = importlib.util.spec_from_file_location("gen_benchmark_pages", _GEN_PATH)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclasses/refs resolve against a real module.
+    sys.modules["gen_benchmark_pages"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gen():
+    return _load_generator()
+
+
+def test_import_does_not_run_main(gen):
+    """The ``main()`` guard must keep plain import side-effect-free.
+
+    If import triggered ``main()`` it would call ``mkdocs_gen_files.open`` outside
+    a build and blow up; reaching this assertion at all proves the guard holds.
+    """
+    assert callable(gen.main)
+    assert callable(gen._warn_orphan_artifacts)
+
+
+def _specs_by_slug(gen):
+    return {spec.slug: spec for spec in gen.SPECS}
+
+
+def test_vector_specs_present_and_ordered(gen):
+    by_slug = _specs_by_slug(gen)
+
+    # Both vector specs exist with the correct artifact stems and kind.
+    assert "longmemeval_s_vector" in by_slug
+    assert "locomo_vector" in by_slug
+
+    lme = by_slug["longmemeval_s_vector"]
+    loc = by_slug["locomo_vector"]
+    assert lme.stem == "external/longmemeval_s_latest_vector"
+    assert loc.stem == "external/locomo_latest_vector"
+    assert lme.kind == "external"
+    assert loc.kind == "external"
+
+    # Deterministic order: each vector spec follows its dataset's hybrid spec.
+    slugs = [spec.slug for spec in gen.SPECS]
+    assert slugs.index("longmemeval_s_vector") > slugs.index("longmemeval_s_hybrid")
+    assert slugs.index("locomo_vector") > slugs.index("locomo_hybrid")
+    # CSR stays last.
+    assert slugs.index("csr") == len(slugs) - 1
+
+
+def test_vector_specs_group_with_their_dataset_tables(gen):
+    """Slug prefixes must keep the index headline tables grouping correctly.
+
+    ``_dataset_table`` filters by ``slug.startswith(prefix)``; the vector slugs
+    must share the dataset prefix so they land in the right table.
+    """
+    assert "longmemeval_s_vector".startswith("longmemeval_s")
+    assert "locomo_vector".startswith("locomo")
+    # Guard against the LoCoMo prefix accidentally swallowing longmemeval rows.
+    assert not "longmemeval_s_vector".startswith("locomo")
+
+
+def test_vector_notes_have_no_fabricated_numbers(gen):
+    """Doctrine: publish only results that exist as committed artifacts.
+
+    No vector artifact is committed yet, so the framing notes must not assert any
+    concrete **Popoto** recall/MRR figures — those come from the committed
+    artifact at build time. Citing an external published anchor (the MEMTIER
+    LoCoMo retrieval-regime band) is explicitly allowed and mirrors the existing
+    lexical/hybrid notes, so we forbid attributed ``Recall@``/``MRR`` metric
+    literals but permit a bare decimal only when the note cites MEMTIER.
+    """
+    import re
+
+    # Fabricated Popoto results are written as attributed metric literals.
+    attributed_metric = [
+        re.compile(r"Recall@\d+\s*[:=]?\s*0?\.\d"),  # "Recall@1 0.89"
+        re.compile(r"\bMRR\b\s*[:=]?\s*0?\.\d"),  # "MRR 0.93"
+    ]
+    bare_decimal = re.compile(r"\b0\.\d{2,}\b")
+
+    for slug in ("longmemeval_s_vector", "locomo_vector"):
+        note = _specs_by_slug(gen)[slug].note
+        for pat in attributed_metric:
+            match = pat.search(note)
+            assert match is None, (
+                f"{slug} note contains a fabricated metric literal "
+                f"{match.group(0)!r}; vector numbers must come from the "
+                f"committed artifact, not the framing note"
+            )
+        # Any bare decimal is permitted ONLY as the cited MEMTIER anchor band.
+        if bare_decimal.search(note):
+            assert "MEMTIER" in note, (
+                f"{slug} note has a bare decimal that is not the cited MEMTIER "
+                f"retrieval-regime anchor — that reads as a fabricated result"
+            )
+
+
+def test_metric_family_not_cross_compared_in_vector_notes(gen):
+    """Vector notes must not tabulate recall beside LLM-judge accuracy."""
+    for slug in ("longmemeval_s_vector", "locomo_vector"):
+        note = _specs_by_slug(gen)[slug].note.lower()
+        assert "judge" not in note
+        assert "answer accuracy" not in note
+
+
+def _write_artifact(root: Path, name: str) -> None:
+    external = root / "external"
+    external.mkdir(parents=True, exist_ok=True)
+    (external / name).write_text("# placeholder\n")
+
+
+def test_orphan_artifact_scan_warns(gen, tmp_path, capsys):
+    """An unmapped ``external/*_latest*.md`` triggers a loud stderr warning."""
+    _write_artifact(tmp_path, "foo_latest_experimental.md")
+
+    orphans = gen._warn_orphan_artifacts(gen.SPECS, root=tmp_path)
+
+    assert "external/foo_latest_experimental" in orphans
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "foo_latest_experimental" in err
+
+
+def test_orphan_scan_silent_when_all_mapped(gen, tmp_path, capsys):
+    """No warning when every artifact corresponds to a Spec stem."""
+    # Materialize the .md file for an existing external Spec stem.
+    stem = "external/longmemeval_s_latest_vector"
+    assert any(s.stem == stem for s in gen.SPECS)
+    _write_artifact(tmp_path, "longmemeval_s_latest_vector.md")
+
+    orphans = gen._warn_orphan_artifacts(gen.SPECS, root=tmp_path)
+
+    assert orphans == []
+    assert "WARNING" not in capsys.readouterr().err
+
+
+def test_orphan_scan_silent_on_empty_root(gen, tmp_path, capsys):
+    """An absent/empty ``external/`` dir yields no warning and does not raise."""
+    orphans = gen._warn_orphan_artifacts(gen.SPECS, root=tmp_path)
+    assert orphans == []
+    assert "WARNING" not in capsys.readouterr().err
+
+
+def test_orphan_scan_ignores_lone_json(gen, tmp_path, capsys):
+    """A ``.json`` with no ``.md`` is not an unpublished page — no warning.
+
+    ``_write_page`` drives the page off the ``.md`` body, so a lone ``.json``
+    could never produce a page and must not be flagged as an orphan.
+    """
+    external = tmp_path / "external"
+    external.mkdir(parents=True)
+    (external / "bar_latest_experimental.json").write_text("{}")
+
+    orphans = gen._warn_orphan_artifacts(gen.SPECS, root=tmp_path)
+
+    assert orphans == []
+    assert "WARNING" not in capsys.readouterr().err


### PR DESCRIPTION
Closes #469.

## Problem

The benchmark docs generator `docs/scripts/gen_benchmark_pages.py` publishes result artifacts from an **explicit hardcoded `SPECS` tuple**, not directory auto-discovery. It covered lexical + hybrid (LongMemEval-S, LoCoMo) + CSR only — **no vector-mode `Spec`**. The vector retrieval mode (#455 / PR #467) produces `external/{dataset}_latest_vector.{json,md}` artifacts, so the moment such an artifact is committed it would **silently** fail to publish (the generator skips missing/unmapped artifacts without erroring, by design, to keep `mkdocs build --strict` green). Latent gap: nothing is dropped today (no `_vector` artifact committed yet), but it trips the moment vector artifacts land.

## What this does

- **Two vector `Spec`s** — `longmemeval_s_vector` (`external/longmemeval_s_latest_vector`) and `locomo_vector` (`external/locomo_latest_vector`), both `kind="external"`, placed in deterministic dataset-then-mode order (lexical → hybrid → vector; CSR stays last). Vector pages now publish automatically the moment their artifact is committed — same zero-hand-edit path as lexical/hybrid.
- **`_warn_orphan_artifacts()`** — scans `external/*_latest*.md` for artifacts no `Spec` publishes and prints a loud build-time stderr `WARNING` (never raises → `--strict` stays green). Converts the previously-**silent** publishing gap into a **visible** one for any future retrieval mode. Scan root is injectable so tests never touch the real `results/external/` tree.
- **`main()` guard** — `if __name__ in ("__main__", "<run_path>"): main()`. mkdocs-gen-files execs the script via `runpy.run_path` (`__name__ == "<run_path>"`, verified empirically), so the build is unaffected; a unit test can now `import` the module without triggering build-time generation.

## Design decision: explicit Specs + orphan warning (issue direction (a) hardened), not glob auto-discovery (b)

The explicit list is a deliberate #466 choice: deterministic page order, per-page titles, and doctrine-safe per-dataset framing prose. Glob auto-discovery would forfeit that and risk publishing a page with no framing note. The orphan **warning** captures the safety benefit of (b) — no silent drop — without abandoning (a)'s determinism.

## Doctrine

- Vector framing notes carry **no fabricated Popoto numbers** — real numbers come from the committed artifact at build time. The only decimals are the cited **MEMTIER** LoCoMo retrieval-regime anchor (0.10–0.30 band), consistent with the existing lexical/hybrid notes.
- Notes echo PR #467: vector isolates the **dense arm only**, not the graph/co-occurrence arm inside hybrid.
- No metric-family cross-comparison (recall vs judge-accuracy); a test asserts this.

## Tests & verification

- New `tests/benchmarks/test_gen_benchmark_pages.py` — **9 tests, all pass**: spec presence/ordering, dataset-table grouping, no-fabricated-numbers, no metric-family cross-comparison, orphan-scan warns / silent-when-mapped / silent-on-empty / ignores-lone-json, import-does-not-run-main.
- `mkdocs build --strict` — **exit 0**. Generator runs, gracefully skips the two vector specs (no artifact committed yet), emits no orphan warning (all artifacts now mapped).
- No new files under `tests/benchmarks/results/external/` — no artifacts fabricated.

Plan: `docs/plans/benchmark_docs_gen_vector_mode.md` (shipped in this PR; touches generator code so treated as code → PR per CLAUDE.md).