### PR TITLE
feat(#464): live-agent memory telemetry (ContextAssembler + outcome loop)

### DIFF
--- a/docs/features/context-assembler.md
+++ b/docs/features/context-assembler.md
@@ -130,6 +130,16 @@ The `assemble()` call returns an `AssemblyResult` dataclass:
 | `formatted` | `str` | LLM-ready formatted string |
 | `metadata` | `dict` | Scores, timing, token counts |
 
+### Telemetry hook: `emit_trace`
+
+`assemble(..., emit_trace=True)` attaches `metadata["trace"]` — a list of
+`{"key", "rank", "score", "source"}` dicts describing the injected records in
+final rank order (`score` is the injection-time composite score captured before
+post-effects; `source` is `"pull"` or `"push"`). It is **off by default**; when
+`False` the result is bit-for-bit identical to the pre-telemetry behavior. This
+is the instrumentation point consumed by the [Memory Telemetry](memory-telemetry.md)
+recipe to turn live `assemble()` calls into a real-workload benchmark.
+
 ## Tuning Constants
 
 ```python

--- a/docs/features/memory-telemetry.md
+++ b/docs/features/memory-telemetry.md
@@ -1,0 +1,165 @@
+# Memory Telemetry
+
+`popoto.recipes.memory_telemetry` turns every live
+[`ContextAssembler.assemble()`](context-assembler.md) call into a durable,
+TTL-bounded, Valkey-safe event record — the injected memory set (ids, ranks,
+scores), retrieval mode, budget consumed, and latency — joinable to the later
+outcome reported through the [ObservationProtocol](observation-protocol.md)
+(`acted` / `used` / `dismissed` / `deferred` / `contradicted`). An offline
+analyzer reads those records into injection-precision, confidence-calibration,
+and decay-regret reports.
+
+Live agents give what offline benchmarks cannot: the real query/turn
+distribution and real outcome labels. The outcome signal already exists — it is
+used to nudge `ConfidenceField` / `CyclicDecayField` and then evaporates. This
+recipe records it so every live agent becomes a continuous, real-workload
+benchmark.
+
+!!! warning "Privacy default is ids-only"
+    Content capture is **opt-in**. The default `capture="ids"` records memory
+    ids, ranks, scores, and metadata only — never memory content or query text.
+    Enabling `capture="content"` is a per-store decision made explicitly in
+    code (never a global env var or runtime toggle) for fully-open deployments
+    whose operator asserts the store is publishable. Even in all-open
+    deployments, humans talking to an agent can volunteer personal details;
+    enabling `content` means the operator takes responsibility for that store
+    being public-safe.
+
+## Components
+
+| Component | Role |
+|-----------|------|
+| `AssemblyEvent` | Popoto `Model` (msgpack, `Meta.ttl`) — one record per `assemble()` call |
+| `TelemetryRecorder` | Wraps a `ContextAssembler`; writes one event per call; fail-open, sampled |
+| `report_outcomes()` | Joins later outcomes onto the matching event record |
+| `TelemetryAnalyzer` | Offline, read-only report generator |
+
+## Quick start
+
+```python
+from popoto.recipes.context_assembler import ContextAssembler
+from popoto.recipes.memory_telemetry import (
+    TelemetryRecorder, TelemetryAnalyzer, report_outcomes,
+)
+
+assembler = ContextAssembler(Memory, score_weights={"relevance": 1.0})
+recorder = TelemetryRecorder(assembler)            # capture="ids" (private)
+
+result = recorder.assemble({"topic": "deploy"}, agent_id="agent-1")
+event_id = result.metadata["telemetry_event_id"]
+
+# ... later, when the agent's response is observed ...
+report_outcomes(event_id, {mem.db_key.redis_key: "acted"})
+
+# ... offline ...
+print(TelemetryAnalyzer(agent_id="agent-1").report())
+```
+
+`TelemetryRecorder.assemble()` delegates to the wrapped assembler unchanged and
+returns the real `AssemblyResult`, adding `metadata["telemetry_event_id"]` when
+an event was written. It forces the assembler's off-by-default
+[`emit_trace`](context-assembler.md#telemetry-hook-emit_trace) hook on so the
+injection trace is available.
+
+## `AssemblyEvent`
+
+One record per call. Queryable by `agent_id` (partition), TTL-bounded so
+telemetry can never grow a store past the scale posture.
+
+| Field | Notes |
+|-------|-------|
+| `event_id` | Auto key |
+| `agent_id` | Partition — matches `assemble(agent_id=...)` |
+| `model_name` | Class the assembler queried |
+| `ts` | Unix timestamp (float) |
+| `retrieval_mode` | `"hybrid"` \| `"lexical"` \| `"composite"` |
+| `capture` | `"ids"` (default) \| `"content"` (opt-in) |
+| `injected` | `[{key, rank, score, source[, content]}]`, rank order |
+| `budget_tokens` / `budget_items` | Budget consumed |
+| `latency_ms` | `assemble()` wall time |
+| `overhead_ms` | Telemetry preparation cost |
+| `query_text` | Populated **only** under `capture="content"` |
+| `outcomes` | Joined by `report_outcomes()`: `[{key, outcome, at}]` |
+
+## `TelemetryRecorder`
+
+```python
+TelemetryRecorder(
+    inner,                 # a ContextAssembler
+    *,
+    capture="ids",         # "ids" (private) | "content" (opt-in). Invalid -> ValueError
+    sample_rate=1.0,       # fraction of calls recorded, [0.0, 1.0]
+    ttl=DEFAULT_EVENT_TTL,  # per-instance TTL (seconds)
+    rng=None,              # random.Random for deterministic sampling in tests
+)
+```
+
+- **Fail-open.** Any error in the telemetry path is caught and logged — it
+  never propagates into `assemble()` and never blocks a live agent. (Popoto has
+  no Sentry dependency; a deployment routes these warnings to its own reporter.)
+- **Sampling.** Lower `sample_rate` on hot paths where write volume would
+  distort latency benchmarks.
+- **Overhead reported.** `recorder.overhead_stats` returns
+  `{count, mean_ms, p95_ms, max_ms}` over the measured per-call telemetry cost
+  — so telemetry can be shown *not* to distort latency numbers.
+
+## `report_outcomes()`
+
+```python
+report_outcomes(event_id, outcome_map, *, apply_effects=False, instances=None)
+```
+
+For each `memory_key -> outcome` in `outcome_map` whose key was injected in this
+event, appends `{key, outcome, at}` to the event's `outcomes`. Keys are the same
+redis keys stored in `injected` (i.e. `instance.db_key.redis_key`); outcomes are
+validated against `ObservationProtocol.VALID_OUTCOMES`.
+
+Record-only by default — telemetry is pure observation and does not double-apply
+confidence/decay effects. Pass `apply_effects=True` (with `instances=`) to also
+forward to `ObservationProtocol.on_context_used()` so one call owns both sides.
+A missing event (e.g. TTL-expired) is a logged no-op returning `None`, not an
+error. Re-saving refreshes the event's TTL to the model default.
+
+## `TelemetryAnalyzer`
+
+Offline, read-only. All metrics are computed over injected memories that carry a
+joined outcome; injections without one are counted as `pending`.
+
+| Method | Signal |
+|--------|--------|
+| `injection_precision()` | Fraction of injected-and-labeled memories acted on, overall and by rank |
+| `confidence_calibration()` | Acted-rate bucketed by injection-time score |
+| `decay_regret()` | Injected-then-`dismissed`/`contradicted` vs injected-then-`acted`, by score bucket |
+| `report()` | Markdown summary of all three |
+
+```python
+an = TelemetryAnalyzer(agent_id="agent-1")
+an.injection_precision()      # {'injected', 'labeled', 'pending', 'acted_rate', 'by_rank', ...}
+an.confidence_calibration()   # {'buckets': [{'label', 'labeled', 'acted', 'acted_rate'}, ...]}
+an.decay_regret()             # {'regret', 'acted', 'regret_rate', 'by_bucket': [...]}
+print(an.report())            # markdown
+```
+
+Fusion-disagreement and refusal-threshold analyses are fast-follows (the trace
+already stores the fused score, so they need no schema change).
+
+## Scope and constraints
+
+- **Valkey-safe:** only core commands. The injection trace uses read-only
+  pipelined `ZSCORE`; the event write is an ordinary model `save()`. No modules,
+  no Lua.
+- **TTL mandatory:** `AssemblyEvent.Meta.ttl` bounds the store; the recorder can
+  shorten but the record always expires.
+- **Not self-benchmarking:** no before/after gates and no automated tuning. This
+  produces *evidence* for the maintainer-reserved policy-default conversations
+  (refusal threshold, decay rates, outcome semantics) — it never changes a
+  default on its own.
+- **Namespace:** popoto owns model-keyed, queryable, TTL'd records
+  (`AssemblyEvent:*`); a deployment's own counter namespace (e.g. `analytics:*`)
+  is separate by design.
+
+## See Also
+
+- [ContextAssembler](context-assembler.md) — the retrieval-to-injection bridge and the `emit_trace` hook
+- [ObservationProtocol](observation-protocol.md) — the outcome vocabulary the join records
+- [Agent Memory](agent-memory.md) — the primitives overview

--- a/docs/plans/live_agent_memory_telemetry.md
+++ b/docs/plans/live_agent_memory_telemetry.md
@@ -1,0 +1,260 @@
+---
+status: planned
+type: feature
+appetite: Large
+owner: valorengels
+created: 2026-07-14
+tracking: https://github.com/tomcounsell/popoto/issues/464
+last_comment_id:
+revision_applied: false
+---
+
+# Live-agent memory telemetry: instrument ContextAssembler + outcome loop
+
+## Problem
+
+Every offline benchmark the project runs (SIQ #459, RLT #460, hybrid sweeps) is a
+*proxy* for the one thing they cannot synthesize: the real query/turn distribution a
+live agent sees, and real outcome labels for the memories it injects. That signal
+already exists in the running system — `ContextAssembler.assemble()` picks a set of
+memories on every turn, and `ObservationProtocol.on_context_used()` already knows
+whether each one was **acted / used / dismissed / deferred / contradicted**. But the
+outcome signal is consumed to nudge `ConfidenceField` / `CyclicDecayField` and then
+**evaporates**: no record of *which memories were injected, at what rank, with what
+score, and what happened to them* survives the call.
+
+The 2026-07-10 dogfood audit (issue #464 comment) confirmed the gap on this machine's
+live db0: the memory system runs live (≈2k `Memory` records, ≈47k `ReflectionRun`),
+but **zero outcome records exist** — the outcome loop is not wired end-to-end, so
+telemetry ships blind until the join is captured. It also found an existing
+`analytics:*` counter namespace in the *agent stack* (not popoto), and Sentry for
+error reporting in the agent stack.
+
+**Desired outcome.** A thin, opt-in telemetry layer in popoto that turns every live
+`assemble()` call into a durable, TTL-bounded, Valkey-safe event record: the injected
+set (ids, ranks, scores), retrieval mode, budget consumed, and latency — joinable to
+the later outcome. Plus an offline analyzer that reads those records into
+decay-regret and confidence-calibration reports. Privacy default: **ids only**; memory
+content/query text captured **only** on explicit per-store opt-in.
+
+## Scope boundary (what this issue is and is NOT)
+
+- **IN (this repo, popoto):** the event-record model, the recorder that instruments
+  `ContextAssembler`, the `report_outcomes()` join, the offline analyzer, the
+  `telemetry_capture` opt-in flag, and docs.
+- **OUT (separate repo, the AI agent stack):** the "agent-side wiring audit" —
+  actually calling `report_outcomes()` / `on_context_used()` in the live deployments,
+  routing telemetry-path errors to Sentry, and the `analytics:*` counter convention.
+  popoto ships the *mechanism*; the deployment wires it. This plan produces a handoff
+  note for that work, but writes no agent-stack code.
+- **OUT (v1):** export/publication tooling for content-bearing traces (that becomes
+  part of #459 fixture curation); fusion-disagreement and refusal-threshold analyses
+  (fast-follows per the issue); per-signal (BM25 vs vector vs graph) score
+  decomposition (the v1 trace captures the final fused/composite score per record).
+- **Not self-benchmarking** in the 2026-06-11 sense: no before/after gates, no
+  automated tuning. This produces *evidence* for the maintainer-reserved
+  policy-default conversations (refusal threshold, decay rates, outcome semantics).
+
+## Design
+
+New recipe module: `src/popoto/recipes/memory_telemetry.py`. Recipes are the right
+layer — this composes existing primitives (a `Model` with TTL, `ContextAssembler`,
+`ObservationProtocol`) and is substrate/beta, so breaking changes here are acceptable
+while the ORM core stays untouched. One small, additive, off-by-default hook is added
+to `ContextAssembler.assemble()` (see §4).
+
+### 1. Event-record model: `AssemblyEvent`
+
+A concrete Popoto `Model` shipped by popoto (dogfooding — telemetry lands in the same
+Redis/Valkey), with a mandatory default TTL so telemetry can never grow a store past
+the 20k-scale posture.
+
+```python
+class AssemblyEvent(Model):
+    event_id       = AutoKeyField()
+    agent_id       = KeyField(null=True)     # partition; matches assemble(agent_id=)
+    model_name     = KeyField(null=True)     # class the assembler queried
+    ts             = SortedField(type=float) # unix ts; range queries for the analyzer
+    retrieval_mode = KeyField(null=True)     # "hybrid"|"lexical"|"composite"
+    capture        = KeyField(null=True)     # "ids" | "content"
+    injected       = ListField(default=[])   # [{key, rank, score, source}]
+    budget_tokens  = IntField(null=True)     # metadata["token_count"]
+    budget_items   = IntField(null=True)     # len(records)
+    corpus_size    = IntField(null=True)     # count of candidate store (best-effort)
+    latency_ms     = FloatField(null=True)   # metadata["timing_ms"]
+    overhead_ms    = FloatField(null=True)   # cost of the telemetry write itself
+    query_text     = StringField(null=True)  # ONLY when capture == "content"
+    outcomes       = ListField(default=[])   # joined later: [{key, outcome, at}]
+
+    class Meta:
+        ttl = DEFAULT_EVENT_TTL  # seconds; magic-number constant, not user config
+```
+
+- `injected` entries are `{"key", "rank", "score", "source"}` where `source` is
+  `"pull"` or `"push"`. Under `capture="ids"` (default) there is **no content** —
+  ids/ranks/scores/metadata only. Under `capture="content"`, entries additionally
+  carry `"content"` (the record dict) and the event carries `query_text`.
+- msgpack-serialized `ListField` holds the list-of-dicts natively (existing behavior).
+- **Namespace decision (audit comment #2):** popoto owns *model-keyed, queryable,
+  TTL'd records* (`AssemblyEvent:*`); the agent stack owns the `analytics:*` counters.
+  Deliberate divergence, not a third convention — documented in the feature doc.
+
+### 2. `TelemetryRecorder` — instrument `assemble()`
+
+Wraps a `ContextAssembler` (same pattern as `AdaptiveAssembler`), delegates
+`assemble()`, and writes one `AssemblyEvent` per call. **Fail-open**: any error in the
+telemetry path is caught and logged (popoto has no Sentry dep; the agent stack routes
+these to Sentry). Telemetry must never break or measurably slow `assemble()`.
+
+```python
+class TelemetryRecorder:
+    def __init__(self, inner, *, event_model=AssemblyEvent, capture="ids",
+                 sample_rate=1.0, ttl=DEFAULT_EVENT_TTL, rng=None): ...
+    def assemble(self, query_cues=None, agent_id=None, **kwargs) -> AssemblyResult:
+        kwargs["emit_trace"] = True                 # force the trace hook on
+        result = self.inner.assemble(query_cues, agent_id=agent_id, **kwargs)
+        if self._should_sample():
+            self._record(result, query_cues, agent_id)  # try/except, timed
+        return result
+```
+
+- `sample_rate` (0.0–1.0, deterministic via injected `rng`) caps volume on hot paths.
+- `_record` reads `result.metadata["trace"]` (ids/rank/score/source), `token_count`,
+  `timing_ms`, and `inner._effective_mode`; times its own write into `overhead_ms`;
+  writes the event with `_ttl = self.ttl`; stashes `result.metadata["telemetry_event_id"]`
+  so the caller can join outcomes later.
+- Cumulative overhead is exposed via `recorder.overhead_stats` (count, mean, p95) so
+  the cost is *reported*, satisfying the issue's "record the cost" constraint and
+  protecting #460's latency numbers.
+- `capture="content"` is set explicitly in code at construction — **never** a global
+  env var or runtime toggle. Passing an unknown value raises at construction.
+
+### 3. Outcome join: `report_outcomes()`
+
+```python
+def report_outcomes(event_id, outcome_map, *, event_model=AssemblyEvent,
+                    apply_effects=False, instances=None): ...
+```
+
+Loads the `AssemblyEvent`, and for each injected key present in `outcome_map` appends
+`{"key", "outcome", "at"}` to `event.outcomes`, then saves (TTL preserved). Validates
+outcomes against `ObservationProtocol.VALID_OUTCOMES`. Record-only by default:
+telemetry is pure observation and does not double-apply confidence/decay effects.
+`apply_effects=True` (with `instances=`) forwards to
+`ObservationProtocol.on_context_used()` for callers that want the recorder to own both
+sides. Missing event (TTL-expired) is a logged no-op, not an error.
+
+### 4. `ContextAssembler` instrumentation hook (additive, off-by-default)
+
+Add `emit_trace: bool = False` to `assemble()`, mirroring the existing
+`assess_quality` opt-in exactly. When `True`, attach:
+
+```python
+metadata["trace"] = [
+    {"key": _get_key(r), "rank": i, "score": score, "source": "pull"|"push"}
+    for i, r in enumerate(selected)
+]
+```
+
+Scores come from the existing read-only, pipelined `_score_proxy_for_records(selected)`
+(ZSCORE-only, Valkey-safe) — no new query machinery. `source` is derived from the
+already-computed `pull_keys`/`push_keys`. When `emit_trace=False` (every existing
+caller) the result is **bit-for-bit identical** to today. This is the only change to a
+shipped file; it is additive and within the beta recipe layer.
+
+### 5. Offline analyzer: `TelemetryAnalyzer`
+
+Report generator in the style of the sweep reports (returns a dict + a markdown
+string; no side effects, read-only over `AssemblyEvent`).
+
+```python
+class TelemetryAnalyzer:
+    def __init__(self, event_model=AssemblyEvent, agent_id=None): ...
+    def load_events(self, since=None, limit=None) -> list[AssemblyEvent]
+    def injection_precision(self) -> dict     # injected → acted fraction, overall + @rank
+    def confidence_calibration(self) -> dict  # score-at-injection buckets → acted rate
+    def decay_regret(self) -> dict            # injected-then-dismissed vs -then-acted
+    def report(self) -> str                   # markdown summary
+```
+
+- **injection_precision**: over events with joined outcomes, fraction of injected
+  memories whose outcome is `acted` (and `acted|used`), sliced by rank — the live
+  injection-precision-@-budget signal (SIQ #459 in production).
+- **confidence_calibration**: bucket injected memories by their injection-time `score`,
+  report acted-rate per bucket → the calibration curve that informs ConfidenceField
+  cap/initial constants.
+- **decay_regret**: counts of injected-then-`dismissed`/`contradicted` (surfaced but
+  wrong) vs injected-then-`acted` per score bucket — first empirical feedback for the
+  decay magic numbers.
+- Fusion-disagreement and refusal-threshold analyses are explicitly deferred
+  (fast-follow, per the issue) — the per-record trace already stores the fused score,
+  so adding them later needs no schema change.
+
+### 6. Exports
+
+Add `TelemetryRecorder`, `TelemetryAnalyzer`, `AssemblyEvent`, `report_outcomes` to
+`recipes/__init__.py` and the top-level `popoto/__init__.py` (`__all__`), matching how
+`AdaptiveAssembler` / `ContextAssembler` are exported.
+
+## Constraints (from the issue, enforced here)
+
+- **Valkey-safe:** only core commands. The trace uses ZSCORE (read-only pipeline); the
+  event write is an ordinary model `save()`. No modules, no Lua added.
+- **Overhead measured and reported:** `overhead_ms` per event + `overhead_stats`
+  aggregate on the recorder.
+- **TTL mandatory:** `Meta.ttl = DEFAULT_EVENT_TTL`; recorder can shorten but the model
+  always expires. Telemetry cannot grow a store unboundedly.
+- **Privacy default off:** `capture="ids"`; `content` is per-store, code-set, explicit.
+- **Magic numbers, not config:** `DEFAULT_EVENT_TTL`, calibration bucket edges, and the
+  sample-rate default are experimental constants with sourced docstrings, not user
+  knobs (feedback_magic_numbers).
+- **ORM stays stable:** the only shipped-file change is the additive, off-by-default
+  `emit_trace` kwarg on the (beta, recipe-layer) `ContextAssembler`.
+
+## Testing
+
+New `tests/test_memory_telemetry.py` (uses the pytest plugin's DB-15 isolation; no
+manual flush needed):
+
+1. **Event write, ids-only:** `assemble()` via recorder writes one `AssemblyEvent` with
+   injected ids/ranks/scores, correct mode/budget/latency, TTL set, and **no**
+   `query_text`/`content`.
+2. **Content capture opt-in:** `capture="content"` includes `query_text` and per-record
+   `content`; `capture="ids"` (default) never does. Unknown `capture` raises.
+3. **emit_trace parity:** `assemble(emit_trace=False)` metadata is byte-identical to a
+   run without the kwarg; `emit_trace=True` adds a well-formed `trace`.
+4. **Fail-open:** a recorder whose event model save raises (monkeypatched) still returns
+   the real `AssemblyResult` and logs; `assemble()` never propagates the error.
+5. **Sampling:** `sample_rate=0.0` writes nothing; `1.0` writes every call; a seeded rng
+   at `0.5` writes the expected subset.
+6. **Outcome join:** `report_outcomes(event_id, {...})` appends outcomes to the matching
+   event; invalid outcome raises; expired/missing event is a logged no-op.
+7. **Analyzer:** seed a handful of events + outcomes, assert `injection_precision`,
+   `confidence_calibration`, and `decay_regret` compute the expected numbers, and
+   `report()` returns non-empty markdown.
+8. **Overhead reported:** `overhead_stats` is populated after N calls.
+
+Run narrow: `PYTHONPATH=src pytest tests/test_memory_telemetry.py` plus the existing
+`tests/test_context_assembler*.py` to prove the `emit_trace` addition is inert.
+Then `scripts/ci-local.sh` for the gates.
+
+## Rabbit holes (out of scope — do not chase)
+
+- **Per-signal score decomposition** (BM25 vs vector vs graph per record): v1 stores the
+  fused/composite score only. The fuse path would need to thread per-arm scores through
+  `QueryBuilder.fuse()` — a separate change.
+- **Streaming/async event writes, batching queues, background flushers:** v1 writes
+  synchronously inside the sampled call (fail-open, timed). If overhead proves material
+  at scale, a batched writer is a follow-up, informed by the reported `overhead_stats`.
+- **Tuning any constant from the collected data:** explicitly maintainer-reserved.
+- **Export/publication of content traces:** #459 fixture curation owns it.
+
+## Handoff (agent-stack, separate repo — not built here)
+
+1. Call `report_outcomes()` (or `TelemetryRecorder` + `on_context_used`) where the live
+   agents resolve memory outcomes — the audit found this is not wired today.
+2. Decide `capture` per store: only stores the operator asserts are public-safe get
+   `content`. Document that humans can volunteer personal details even to all-open
+   agents — enabling `content` means the operator takes responsibility for that store
+   being publishable.
+3. Route telemetry-path warnings to Sentry (popoto only logs).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
                 - SubconsciousMemory: 'guides/subconscious-memory-recipe.md'
                 - TrajectoryMemory: 'guides/trajectory-memory-recipe.md'
                 - RAG Chatbot: 'guides/rag-chatbot-recipe.md'
+                - Memory Telemetry: 'features/memory-telemetry.md'
           - Tuning:
                 - Magic Numbers: 'guides/tuning-magic-numbers.md'
                 - Parametric Sweep: 'features/parametric-sweep.md'

--- a/src/popoto/__init__.py
+++ b/src/popoto/__init__.py
@@ -74,6 +74,12 @@ from .recipes.context_assembler import (
     ContextAssembler,
     RetrievalQuality,
 )
+from .recipes.memory_telemetry import (
+    AssemblyEvent,
+    TelemetryAnalyzer,
+    TelemetryRecorder,
+    report_outcomes,
+)
 from .streams import StreamConsumer
 from .redis_db import POPOTO_REDIS_DB, get_async_redis_db
 from ._error_reporting import enable_error_reporting
@@ -206,6 +212,10 @@ __all__ = [
     "AssemblyResult",
     "RetrievalQuality",
     "AdaptiveAssembler",
+    "AssemblyEvent",
+    "TelemetryRecorder",
+    "TelemetryAnalyzer",
+    "report_outcomes",
     "ContentField",
     "EmbeddingField",
     "BM25Field",

--- a/src/popoto/recipes/__init__.py
+++ b/src/popoto/recipes/__init__.py
@@ -8,12 +8,19 @@ are importable and usable, but designed primarily as reference implementations.
 from .adaptive_assembler import AdaptiveAssembler
 from .context_assembler import AssemblyResult, ContextAssembler, RetrievalQuality
 from .memory_lifecycle import LifecycleState, MemoryLifecycle
+from .memory_telemetry import (
+    AssemblyEvent,
+    TelemetryAnalyzer,
+    TelemetryRecorder,
+    report_outcomes,
+)
 from .policy_cache import PolicyEntry, compute_fingerprint, update_q_value
 from .subconscious_memory import SubconsciousMemory
 from .trajectory_memory import TrajectoryMemory
 
 __all__ = [
     "AdaptiveAssembler",
+    "AssemblyEvent",
     "AssemblyResult",
     "ContextAssembler",
     "LifecycleState",
@@ -21,7 +28,10 @@ __all__ = [
     "PolicyEntry",
     "RetrievalQuality",
     "SubconsciousMemory",
+    "TelemetryAnalyzer",
+    "TelemetryRecorder",
     "TrajectoryMemory",
     "compute_fingerprint",
+    "report_outcomes",
     "update_q_value",
 ]

--- a/src/popoto/recipes/context_assembler.py
+++ b/src/popoto/recipes/context_assembler.py
@@ -990,6 +990,7 @@ class ContextAssembler:
         agent_id=None,
         partition_filters=None,
         assess_quality=False,
+        emit_trace=False,
     ):
         """Execute the full retrieval pipeline.
 
@@ -1007,6 +1008,17 @@ class ContextAssembler:
                 the pre-metacognitive-layer behavior. Turning this on adds
                 bounded overhead (one ``might_exist`` per cue plus one
                 ``get_confidence`` per selected record).
+            emit_trace: When True, attach ``metadata["trace"]`` — a list of
+                ``{"key", "rank", "score", "source"}`` dicts describing the
+                selected (injected) records in final rank order. ``score``
+                is the injection-time composite/fused score proxy, captured
+                *before* post-retrieval effects mutate decay clocks;
+                ``source`` is ``"pull"`` or ``"push"``. Default False; when
+                False the result is bit-for-bit identical to the
+                pre-telemetry behavior. This is the instrumentation hook the
+                telemetry recipe (issue #464) consumes — it uses only the
+                read-only, pipelined score proxy (ZSCORE), so it is
+                Valkey-safe and adds bounded overhead.
 
         Returns:
             AssemblyResult with records, proactive, formatted, and metadata.
@@ -1083,6 +1095,30 @@ class ContextAssembler:
         # Identify proactive records in final selection
         proactive = [r for r in selected if _get_key(r) in push_keys]
 
+        # [TELEMETRY] Capture the injection trace BEFORE post-effects mutate
+        # decay clocks, so the recorded score reflects the score the record
+        # was actually ranked/injected on. Off-by-default (issue #464): when
+        # emit_trace is False this block does no Redis work and the result is
+        # bit-for-bit identical to the pre-telemetry behavior.
+        trace = None
+        if emit_trace:
+            try:
+                proxy = self._injection_scores(selected)
+            except Exception as e:
+                logger.warning("emit_trace score proxy failed: %s", e)
+                proxy = {}
+            trace = []
+            for rank, record in enumerate(selected):
+                rk = _get_key(record)
+                trace.append(
+                    {
+                        "key": rk,
+                        "rank": rank,
+                        "score": proxy.get(rk, 0.0),
+                        "source": "pull" if rk in pull_keys else "push",
+                    }
+                )
+
         # --- Post-retrieval effects ---
         self._post_effects(
             selected, pull_keys, push_keys, all_pull_candidates, agent_id
@@ -1110,6 +1146,11 @@ class ContextAssembler:
             "total_candidates": len(merged),
         }
 
+        # [TELEMETRY] Attach the injection trace captured pre-post-effects.
+        # Off-by-default so existing callers see identical metadata.
+        if trace is not None:
+            metadata["trace"] = trace
+
         # [METACOGNITIVE] Quality assessment — opt-in, off-by-default so existing
         # callers see bit-for-bit identical metadata.
         if assess_quality:
@@ -1129,6 +1170,66 @@ class ContextAssembler:
             formatted=formatted,
             metadata=metadata,
         )
+
+    def _injection_scores(self, records):
+        """Partition-aware composite-score proxy for the telemetry trace (#464).
+
+        Unlike the metacognitive :func:`_score_proxy_for_records` helper (which
+        keys the non-partitioned sorted-set index), this reads each record's
+        score from the *partition-specific* sorted set via
+        ``get_partitioned_sortedset_db_key`` — so scores are correct for models
+        whose sorted fields declare ``partition_by`` (the common agent-memory
+        case, where the metacognitive proxy would return 0.0). Read-only,
+        pipelined ZSCORE only — Valkey-safe, no temp keys.
+
+        Only sorted-field-backed entries in ``score_weights`` contribute
+        (ConfidenceField / WriteFilter scores are not persisted in a ZSET). In
+        hybrid/lexical retrieval the fused RRF score is not persisted either, so
+        the trace score reflects only ``score_weights`` sorted fields (0.0 when
+        none) — per-arm score decomposition is the documented fast-follow.
+
+        Returns:
+            ``{record_key: weighted_score}`` for every record in ``records``.
+        """
+        if not records or not self.score_weights:
+            return {_get_key(r): 0.0 for r in records}
+
+        sorted_field_names = []
+        for field_name in self.score_weights:
+            try:
+                f = self.model_class._meta.fields.get(field_name)
+            except Exception:
+                f = None
+            if f is not None and isinstance(f, SortedFieldMixin):
+                sorted_field_names.append(field_name)
+
+        if not sorted_field_names:
+            return {_get_key(r): 0.0 for r in records}
+
+        pipe = POPOTO_REDIS_DB.pipeline()
+        plan = []  # parallel list of (record_key, weight) per queued ZSCORE
+        for field_name in sorted_field_names:
+            f = self.model_class._meta.fields[field_name]
+            weight = float(self.score_weights.get(field_name, 0.0))
+            for record in records:
+                try:
+                    zkey = f.get_partitioned_sortedset_db_key(
+                        record, field_name
+                    ).redis_key
+                    pipe.zscore(zkey, _get_key(record))
+                except Exception:
+                    pipe.zscore("", "")  # placeholder to keep plan aligned
+                plan.append((_get_key(record), weight))
+        raw = pipe.execute()
+
+        scores = {_get_key(r): 0.0 for r in records}
+        for (r_key, weight), val in zip(plan, raw):
+            if val is not None:
+                try:
+                    scores[r_key] += weight * float(val)
+                except (TypeError, ValueError):
+                    pass
+        return scores
 
     def _count_record_tokens(self, record):
         """Serialize ``record`` for the active output format and count tokens.
@@ -1319,9 +1420,11 @@ class ContextAssembler:
                 "reindex caveat). Falling back to composite (query-blind).",
                 self._effective_mode,
                 self.model_class.__name__,
-                " and the vector search returned none"
-                if self._embedding_field is not None
-                else "",
+                (
+                    " and the vector search returned none"
+                    if self._embedding_field is not None
+                    else ""
+                ),
             )
             return self._pull_path_composite(query_cues, filters)
 

--- a/src/popoto/recipes/memory_telemetry.py
+++ b/src/popoto/recipes/memory_telemetry.py
@@ -1,0 +1,667 @@
+"""MemoryTelemetry — turn live ``assemble()`` calls into a real-workload benchmark.
+
+Issue #464 (part of #456, Track A). Live agents give us the two things every
+offline benchmark lacks: the real query/turn distribution and real outcome
+labels. ``ContextAssembler.assemble()`` already picks a memory set on every
+turn, and ``ObservationProtocol.on_context_used()`` already knows whether each
+memory was acted / used / dismissed / deferred / contradicted — but that signal
+is consumed to nudge confidence/decay and then evaporates. This recipe records
+it durably (TTL-bounded, Valkey-safe) so every live agent becomes a continuous,
+real-workload benchmark.
+
+Three pieces:
+
+* :class:`AssemblyEvent` — one msgpack-backed Popoto model instance per
+  ``assemble()`` call, with a mandatory default TTL so telemetry can never grow
+  a store past the 20k-scale posture. Dogfoods the same Redis/Valkey.
+* :class:`TelemetryRecorder` — wraps a ``ContextAssembler`` (same pattern as
+  ``AdaptiveAssembler``), delegates ``assemble()``, and writes one event per
+  call. Fail-open: a telemetry error never breaks or measurably slows
+  ``assemble()``. Overhead is measured and reported.
+* :func:`report_outcomes` — joins the later outcome onto the matching event.
+* :class:`TelemetryAnalyzer` — offline, read-only report generator producing
+  injection-precision, confidence-calibration, and decay-regret reports.
+
+Privacy: content capture is **opt-in**. The default ``capture="ids"`` records
+memory ids, ranks, scores, and metadata only — never memory content or query
+text. ``capture="content"`` (set explicitly in code, per store — never a global
+env var or runtime toggle) additionally records content and query text, for
+fully-open deployments whose operator asserts the store is publishable.
+
+Namespace note: popoto owns *model-keyed, queryable, TTL'd* records
+(``AssemblyEvent:*``); the agent stack owns its ``analytics:*`` counters. This
+is a deliberate divergence, not a third convention.
+
+Example:
+    from popoto.recipes.context_assembler import ContextAssembler
+    from popoto.recipes.memory_telemetry import (
+        TelemetryRecorder, TelemetryAnalyzer, report_outcomes,
+    )
+
+    assembler = ContextAssembler(Memory, score_weights={"relevance": 1.0})
+    recorder = TelemetryRecorder(assembler)          # capture="ids" (private)
+    result = recorder.assemble({"topic": "deploy"}, agent_id="agent-1")
+    event_id = result.metadata["telemetry_event_id"]
+    # ... later, when the agent's response is observed ...
+    report_outcomes(event_id, {mem.db_key.redis_key: "acted"})
+    # ... offline ...
+    print(TelemetryAnalyzer(agent_id="agent-1").report())
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+
+from ..fields.observation import VALID_OUTCOMES
+from ..fields.shortcuts import (
+    AutoKeyField,
+    FloatField,
+    IntField,
+    KeyField,
+    ListField,
+    StringField,
+)
+from ..models.base import Model
+from .context_assembler import _get_key, _record_to_dict
+
+logger = logging.getLogger("POPOTO.MemoryTelemetry")
+
+
+# ---------------------------------------------------------------------------
+# Tuning constants — experimental magic numbers (feedback_magic_numbers), NOT
+# user config. Sourced docstrings per project convention.
+# ---------------------------------------------------------------------------
+
+DEFAULT_EVENT_TTL = 7 * 24 * 3600
+"""Default lifetime (seconds) of an AssemblyEvent record: 7 days. Bounds the
+telemetry store so it can never grow past the 20k-scale posture regardless of
+call volume. Long enough to join same-week outcomes and run a weekly analyzer
+pass; short enough that residue self-clears. Recorder may shorten per store."""
+
+DEFAULT_SAMPLE_RATE = 1.0
+"""Fraction of ``assemble()`` calls recorded. 1.0 = every call. Lower it on hot
+paths where the write volume would distort #460's latency numbers; the recorder
+reports measured overhead so the operator can pick a rate from evidence."""
+
+CALIBRATION_BUCKET_EDGES = (0.2, 0.4, 0.6, 0.8)
+"""Interior edges partitioning injection-time score into 5 calibration buckets
+([-inf,0.2), [0.2,0.4), [0.4,0.6), [0.6,0.8), [0.8,inf)). Used only by the
+offline analyzer to bin the confidence-calibration and decay-regret curves."""
+
+_ACTED_OUTCOMES = frozenset({"acted"})
+_POSITIVE_OUTCOMES = frozenset({"acted", "used"})
+_REGRET_OUTCOMES = frozenset({"dismissed", "contradicted"})
+
+
+# ---------------------------------------------------------------------------
+# AssemblyEvent — the durable event record
+# ---------------------------------------------------------------------------
+
+
+class AssemblyEvent(Model):
+    """One telemetry record per ``ContextAssembler.assemble()`` call.
+
+    ids-only by default; content/query_text populated only under
+    ``capture="content"``. TTL-bounded via ``Meta.ttl`` (overridable per
+    instance by the recorder). Queryable by ``agent_id`` (partition KeyField).
+
+    Fields:
+        event_id: Auto key.
+        agent_id: Partition — matches ``assemble(agent_id=...)``. May be None.
+        model_name: Name of the model class the assembler queried.
+        ts: Unix timestamp (float) of the call. Plain field (not a sorted
+            index) to keep the hot-path write to a single key — the offline
+            analyzer filters by time in Python over the TTL-bounded corpus.
+        retrieval_mode: ``"hybrid"`` | ``"lexical"`` | ``"composite"``.
+        capture: ``"ids"`` (default, private) | ``"content"`` (opt-in).
+        injected: List of ``{key, rank, score, source[, content]}`` — one per
+            injected memory, in final rank order. ``content`` present only
+            under ``capture="content"``.
+        budget_tokens / budget_items: Budget consumed by the injection.
+        corpus_size: Best-effort candidate-store size (may be None).
+        latency_ms: ``assemble()`` wall time.
+        overhead_ms: Telemetry preparation cost (see TelemetryRecorder).
+        query_text: The query cue text — populated only under
+            ``capture="content"``.
+        outcomes: Joined later by :func:`report_outcomes`; list of
+            ``{key, outcome, at}``.
+    """
+
+    event_id = AutoKeyField()
+    agent_id = KeyField(null=True)
+    model_name = KeyField(null=True)
+    ts = FloatField(null=True)
+    retrieval_mode = KeyField(null=True)
+    capture = KeyField(null=True)
+    injected = ListField(default=[])
+    budget_tokens = IntField(null=True)
+    budget_items = IntField(null=True)
+    corpus_size = IntField(null=True)
+    latency_ms = FloatField(null=True)
+    overhead_ms = FloatField(null=True)
+    query_text = StringField(null=True)
+    outcomes = ListField(default=[])
+
+    class Meta:
+        ttl = DEFAULT_EVENT_TTL
+
+
+_VALID_CAPTURE = frozenset({"ids", "content"})
+
+
+# ---------------------------------------------------------------------------
+# TelemetryRecorder — instrument assemble()
+# ---------------------------------------------------------------------------
+
+
+class TelemetryRecorder:
+    """Wrap a ``ContextAssembler`` and record one ``AssemblyEvent`` per call.
+
+    Delegates ``assemble()`` unchanged and returns the real
+    ``AssemblyResult`` (with ``metadata["telemetry_event_id"]`` added when an
+    event was written). The telemetry path is **fail-open**: any error is
+    caught and logged — it never propagates into ``assemble()``.
+
+    Args:
+        inner: A ``ContextAssembler`` (or any object with a compatible
+            ``assemble(...)`` returning an ``AssemblyResult`` and exposing
+            ``model_class`` / ``_effective_mode``).
+        event_model: The event Model class. Default :class:`AssemblyEvent`.
+        capture: ``"ids"`` (default, private — ids/ranks/scores/metadata only)
+            or ``"content"`` (opt-in — additionally records memory content and
+            query text). Set explicitly in code, per store. Any other value
+            raises ``ValueError`` at construction.
+        sample_rate: Fraction of calls to record in ``[0.0, 1.0]``. Default
+            :data:`DEFAULT_SAMPLE_RATE` (1.0). ``0.0`` records nothing.
+        ttl: Per-instance TTL (seconds) applied to each event. Default
+            :data:`DEFAULT_EVENT_TTL`.
+        rng: Optional ``random.Random`` for deterministic sampling in tests.
+    """
+
+    def __init__(
+        self,
+        inner,
+        *,
+        event_model=AssemblyEvent,
+        capture: str = "ids",
+        sample_rate: float = DEFAULT_SAMPLE_RATE,
+        ttl: int = DEFAULT_EVENT_TTL,
+        rng: random.Random | None = None,
+    ):
+        if capture not in _VALID_CAPTURE:
+            raise ValueError(
+                f"capture={capture!r} is not valid. Allowed: {sorted(_VALID_CAPTURE)}. "
+                "'content' is opt-in and must be set explicitly per store."
+            )
+        if not 0.0 <= float(sample_rate) <= 1.0:
+            raise ValueError(f"sample_rate must be in [0.0, 1.0], got {sample_rate!r}")
+        self.inner = inner
+        self.event_model = event_model
+        self.capture = capture
+        self.sample_rate = float(sample_rate)
+        self.ttl = int(ttl)
+        self._rng = rng if rng is not None else random.Random()
+        self._overhead_samples: list[float] = []
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def assemble(self, query_cues=None, agent_id=None, **kwargs):
+        """Delegate to the wrapped assembler, recording one event per call.
+
+        Forces ``emit_trace=True`` on the inner call (overriding any caller
+        value) so the injection trace is available. Returns the inner
+        ``AssemblyResult`` unchanged apart from an added
+        ``metadata["telemetry_event_id"]`` when an event was written.
+        """
+        kwargs["emit_trace"] = True
+        result = self.inner.assemble(query_cues=query_cues, agent_id=agent_id, **kwargs)
+        if self._should_sample():
+            self._record(result, query_cues, agent_id)
+        return result
+
+    @property
+    def overhead_stats(self) -> dict:
+        """Measured telemetry overhead across recorded calls.
+
+        Returns a dict ``{count, mean_ms, p95_ms, max_ms}`` over the full
+        per-call ``_record`` wall time (preparation + Redis write). Empty
+        history yields zeros. This is the "record the cost" report the issue
+        requires — so telemetry can be shown not to distort #460's latency.
+        """
+        samples = self._overhead_samples
+        if not samples:
+            return {"count": 0, "mean_ms": 0.0, "p95_ms": 0.0, "max_ms": 0.0}
+        ordered = sorted(samples)
+        n = len(ordered)
+        # Nearest-rank p95 (no interpolation) — stable for small n.
+        p95_idx = min(n - 1, max(0, int(round(0.95 * (n - 1)))))
+        return {
+            "count": n,
+            "mean_ms": round(sum(ordered) / n, 4),
+            "p95_ms": round(ordered[p95_idx], 4),
+            "max_ms": round(ordered[-1], 4),
+        }
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _should_sample(self) -> bool:
+        if self.sample_rate >= 1.0:
+            return True
+        if self.sample_rate <= 0.0:
+            return False
+        return self._rng.random() < self.sample_rate
+
+    @staticmethod
+    def _query_text(query_cues) -> str | None:
+        if not query_cues:
+            return None
+        return " ".join(str(v) for v in query_cues.values())
+
+    def _record(self, result, query_cues, agent_id):
+        """Write one AssemblyEvent. Fail-open: log and swallow any error."""
+        wall_t0 = time.perf_counter()
+        try:
+            trace = result.metadata.get("trace") or []
+            content_map = {}
+            if self.capture == "content":
+                for r in result.records:
+                    try:
+                        content_map[_get_key(r)] = _record_to_dict(r)
+                    except Exception:  # pragma: no cover - defensive
+                        pass
+
+            injected = []
+            for entry in trace:
+                item = {
+                    "key": entry["key"],
+                    "rank": entry["rank"],
+                    "score": entry["score"],
+                    "source": entry["source"],
+                }
+                if self.capture == "content":
+                    content = content_map.get(entry["key"])
+                    if content is not None:
+                        item["content"] = content
+                injected.append(item)
+
+            prep_ms = round((time.perf_counter() - wall_t0) * 1000.0, 4)
+
+            model_name = getattr(
+                getattr(self.inner, "model_class", None), "__name__", None
+            )
+            event = self.event_model(
+                agent_id=agent_id,
+                model_name=model_name,
+                ts=time.time(),
+                retrieval_mode=getattr(self.inner, "_effective_mode", None),
+                capture=self.capture,
+                injected=injected,
+                budget_tokens=int(result.metadata.get("token_count", 0) or 0),
+                budget_items=len(result.records),
+                latency_ms=float(result.metadata.get("timing_ms", 0.0) or 0.0),
+                overhead_ms=prep_ms,
+                query_text=(
+                    self._query_text(query_cues) if self.capture == "content" else None
+                ),
+            )
+            event._ttl = self.ttl
+            event.save()
+            result.metadata["telemetry_event_id"] = event.event_id
+        except Exception as e:  # fail-open
+            logger.warning("telemetry record failed (fail-open): %s", e)
+        finally:
+            self._overhead_samples.append((time.perf_counter() - wall_t0) * 1000.0)
+
+
+# ---------------------------------------------------------------------------
+# Outcome join
+# ---------------------------------------------------------------------------
+
+
+def report_outcomes(
+    event_id,
+    outcome_map,
+    *,
+    event_model=AssemblyEvent,
+    apply_effects: bool = False,
+    instances=None,
+):
+    """Join later outcomes onto the matching AssemblyEvent.
+
+    For each ``(memory_key -> outcome)`` in ``outcome_map`` whose key was
+    injected in this event, appends ``{key, outcome, at}`` to the event's
+    ``outcomes`` list and saves. Record-only by default: telemetry is pure
+    observation and does not double-apply confidence/decay effects (the agent
+    stack applies those via ``ObservationProtocol.on_context_used`` separately).
+
+    Args:
+        event_id: The ``event_id`` returned in
+            ``result.metadata["telemetry_event_id"]``.
+        outcome_map: Dict mapping memory redis keys (the same keys stored in
+            ``injected``, i.e. ``instance.db_key.redis_key``) to outcome
+            strings. Validated against ``ObservationProtocol.VALID_OUTCOMES``.
+        event_model: The event Model class. Default :class:`AssemblyEvent`.
+        apply_effects: When True (and ``instances`` provided), also forward to
+            ``ObservationProtocol.on_context_used(instances, outcome_map)`` so
+            one call owns both the telemetry join and the ORM effects. Default
+            False.
+        instances: Optional list of the memory instances, required only when
+            ``apply_effects=True``.
+
+    Returns:
+        The updated ``AssemblyEvent``, or ``None`` if the event was not found
+        (e.g. its TTL expired) — a missing event is a logged no-op, not an
+        error.
+
+    Raises:
+        ValueError: If any outcome string is not a valid outcome.
+
+    Note:
+        Re-saving refreshes the event's TTL to the model default. A same-week
+        outcome join therefore keeps the event alive another full TTL — fine,
+        the event is still the freshest evidence for that injection.
+    """
+    for key, outcome in outcome_map.items():
+        if outcome not in VALID_OUTCOMES:
+            raise ValueError(
+                f"Invalid outcome '{outcome}' for key '{key}'. "
+                f"Valid outcomes: {sorted(VALID_OUTCOMES)}"
+            )
+
+    event = None
+    try:
+        event = event_model.query.get(event_id=event_id)
+    except Exception as e:
+        logger.warning("report_outcomes: lookup of event %s failed: %s", event_id, e)
+
+    if event is None:
+        logger.warning(
+            "report_outcomes: event %s not found (expired?); no join written",
+            event_id,
+        )
+        if apply_effects and instances:
+            _apply_observation_effects(instances, outcome_map)
+        return None
+
+    now = time.time()
+    injected_keys = {i.get("key") for i in (event.injected or [])}
+    joined = list(event.outcomes or [])
+    for key, outcome in outcome_map.items():
+        if key in injected_keys:
+            joined.append({"key": key, "outcome": outcome, "at": now})
+    event.outcomes = joined
+    event.save()
+
+    if apply_effects and instances:
+        _apply_observation_effects(instances, outcome_map)
+
+    return event
+
+
+def _apply_observation_effects(instances, outcome_map):
+    from ..fields.observation import ObservationProtocol
+
+    try:
+        ObservationProtocol.on_context_used(instances, outcome_map)
+    except Exception as e:  # fail-open: telemetry must not break the caller
+        logger.warning("report_outcomes apply_effects failed (fail-open): %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Offline analyzer
+# ---------------------------------------------------------------------------
+
+
+def _bucket_index(score: float) -> int:
+    """Return the calibration bucket index for a score."""
+    for i, edge in enumerate(CALIBRATION_BUCKET_EDGES):
+        if score < edge:
+            return i
+    return len(CALIBRATION_BUCKET_EDGES)
+
+
+def _bucket_label(i: int) -> str:
+    edges = CALIBRATION_BUCKET_EDGES
+    lo = "-inf" if i == 0 else f"{edges[i - 1]:.1f}"
+    hi = "inf" if i == len(edges) else f"{edges[i]:.1f}"
+    return f"[{lo}, {hi})"
+
+
+class TelemetryAnalyzer:
+    """Offline, read-only report generator over :class:`AssemblyEvent` records.
+
+    Produces the v1 report family: injection precision (@budget and @rank),
+    confidence calibration (acted-rate by injection-time score), and decay
+    regret (injected-then-dismissed vs -then-acted by score bucket). All
+    metrics are computed only over injected memories that carry a joined
+    outcome; injections without an outcome are counted separately as
+    ``pending``. Fusion-disagreement and refusal-threshold analyses are
+    explicit fast-follows (the trace already stores the fused score, so they
+    need no schema change).
+
+    Args:
+        event_model: The event Model class. Default :class:`AssemblyEvent`.
+        agent_id: Optional partition to restrict analysis to one agent.
+    """
+
+    def __init__(self, event_model=AssemblyEvent, agent_id=None):
+        self.event_model = event_model
+        self.agent_id = agent_id
+
+    def load_events(self, since=None, limit=None):
+        """Load events, optionally filtered by ``agent_id`` and ``ts >= since``.
+
+        Read-only. ``since`` is a unix timestamp (float); filtering is done in
+        Python over the TTL-bounded corpus. ``limit`` caps the most-recent N by
+        timestamp.
+        """
+        if self.agent_id is not None:
+            events = list(self.event_model.query.filter(agent_id=self.agent_id))
+        else:
+            events = list(self.event_model.query.all())
+        if since is not None:
+            events = [e for e in events if (e.ts or 0.0) >= since]
+        events.sort(key=lambda e: (e.ts or 0.0), reverse=True)
+        if limit is not None:
+            events = events[:limit]
+        return events
+
+    def _joined_injections(self, events):
+        """Flatten events into per-injection rows joined with their outcome.
+
+        Returns a list of dicts: ``{key, rank, score, source, outcome}`` where
+        ``outcome`` is the last reported outcome for that key in that event, or
+        ``None`` if none was joined.
+        """
+        rows = []
+        for event in events:
+            # key -> last outcome joined for this event
+            outcome_by_key = {}
+            for o in event.outcomes or []:
+                outcome_by_key[o.get("key")] = o.get("outcome")
+            for inj in event.injected or []:
+                rows.append(
+                    {
+                        "key": inj.get("key"),
+                        "rank": inj.get("rank"),
+                        "score": float(inj.get("score", 0.0) or 0.0),
+                        "source": inj.get("source"),
+                        "outcome": outcome_by_key.get(inj.get("key")),
+                    }
+                )
+        return rows
+
+    def injection_precision(self, since=None, limit=None) -> dict:
+        """Fraction of injected-and-labeled memories that were acted on.
+
+        Returns ``{injected, labeled, pending, acted, acted_rate,
+        acted_or_used_rate, by_rank}`` where ``by_rank`` maps rank -> that
+        rank's acted_rate over labeled injections.
+        """
+        rows = self._joined_injections(self.load_events(since=since, limit=limit))
+        labeled = [r for r in rows if r["outcome"] is not None]
+        acted = sum(1 for r in labeled if r["outcome"] in _ACTED_OUTCOMES)
+        positive = sum(1 for r in labeled if r["outcome"] in _POSITIVE_OUTCOMES)
+        n = len(labeled)
+
+        by_rank: dict = {}
+        rank_groups: dict = {}
+        for r in labeled:
+            rank_groups.setdefault(r["rank"], []).append(r)
+        for rank, group in sorted(
+            rank_groups.items(), key=lambda kv: (kv[0] is None, kv[0])
+        ):
+            acted_g = sum(1 for r in group if r["outcome"] in _ACTED_OUTCOMES)
+            by_rank[rank] = {
+                "labeled": len(group),
+                "acted_rate": round(acted_g / len(group), 4) if group else 0.0,
+            }
+
+        return {
+            "injected": len(rows),
+            "labeled": n,
+            "pending": len(rows) - n,
+            "acted": acted,
+            "acted_rate": round(acted / n, 4) if n else 0.0,
+            "acted_or_used_rate": round(positive / n, 4) if n else 0.0,
+            "by_rank": by_rank,
+        }
+
+    def confidence_calibration(self, since=None, limit=None) -> dict:
+        """Acted-rate bucketed by injection-time score.
+
+        Returns ``{buckets: [{label, labeled, acted, acted_rate}, ...]}`` over
+        the 5 :data:`CALIBRATION_BUCKET_EDGES` buckets. A well-calibrated
+        scorer shows acted_rate rising monotonically across buckets.
+        """
+        rows = self._joined_injections(self.load_events(since=since, limit=limit))
+        labeled = [r for r in rows if r["outcome"] is not None]
+        n_buckets = len(CALIBRATION_BUCKET_EDGES) + 1
+        buckets = [{"labeled": 0, "acted": 0} for _ in range(n_buckets)]
+        for r in labeled:
+            b = _bucket_index(r["score"])
+            buckets[b]["labeled"] += 1
+            if r["outcome"] in _ACTED_OUTCOMES:
+                buckets[b]["acted"] += 1
+        return {
+            "buckets": [
+                {
+                    "label": _bucket_label(i),
+                    "labeled": b["labeled"],
+                    "acted": b["acted"],
+                    "acted_rate": (
+                        round(b["acted"] / b["labeled"], 4) if b["labeled"] else 0.0
+                    ),
+                }
+                for i, b in enumerate(buckets)
+            ]
+        }
+
+    def decay_regret(self, since=None, limit=None) -> dict:
+        """Injected-then-regretted vs injected-then-acted, by score bucket.
+
+        "Regret" = injected but the outcome was ``dismissed`` or
+        ``contradicted`` (surfaced but wrong). Contrasted with ``acted``. This
+        is the first empirical feedback signal for the decay magic numbers.
+
+        Returns ``{regret, acted, regret_rate, by_bucket: [...]}``.
+        """
+        rows = self._joined_injections(self.load_events(since=since, limit=limit))
+        labeled = [r for r in rows if r["outcome"] is not None]
+        regret = sum(1 for r in labeled if r["outcome"] in _REGRET_OUTCOMES)
+        acted = sum(1 for r in labeled if r["outcome"] in _ACTED_OUTCOMES)
+
+        n_buckets = len(CALIBRATION_BUCKET_EDGES) + 1
+        by_bucket = [{"regret": 0, "acted": 0} for _ in range(n_buckets)]
+        for r in labeled:
+            b = _bucket_index(r["score"])
+            if r["outcome"] in _REGRET_OUTCOMES:
+                by_bucket[b]["regret"] += 1
+            elif r["outcome"] in _ACTED_OUTCOMES:
+                by_bucket[b]["acted"] += 1
+
+        denom = regret + acted
+        return {
+            "regret": regret,
+            "acted": acted,
+            "regret_rate": round(regret / denom, 4) if denom else 0.0,
+            "by_bucket": [
+                {
+                    "label": _bucket_label(i),
+                    "regret": b["regret"],
+                    "acted": b["acted"],
+                }
+                for i, b in enumerate(by_bucket)
+            ],
+        }
+
+    def report(self, since=None, limit=None) -> str:
+        """Render the v1 telemetry report as markdown.
+
+        Style mirrors the sweep reports: a headline table plus per-analysis
+        breakdowns. Read-only; safe to run against a live store.
+        """
+        events = self.load_events(since=since, limit=limit)
+        precision = self.injection_precision(since=since, limit=limit)
+        calibration = self.confidence_calibration(since=since, limit=limit)
+        regret = self.decay_regret(since=since, limit=limit)
+
+        scope = (
+            f"agent_id={self.agent_id!r}" if self.agent_id is not None else "all agents"
+        )
+        lines = [
+            "# Live-agent memory telemetry report",
+            "",
+            f"Scope: {scope} · events: {len(events)} · "
+            f"injected: {precision['injected']} · labeled: {precision['labeled']} "
+            f"· pending: {precision['pending']}",
+            "",
+            "## Injection precision",
+            "",
+            f"- acted_rate: {precision['acted_rate']}",
+            f"- acted_or_used_rate: {precision['acted_or_used_rate']}",
+            "",
+            "| rank | labeled | acted_rate |",
+            "|---|---|---|",
+        ]
+        for rank, stats in precision["by_rank"].items():
+            lines.append(f"| {rank} | {stats['labeled']} | {stats['acted_rate']} |")
+
+        lines += [
+            "",
+            "## Confidence calibration (acted-rate by injection score)",
+            "",
+            "| score bucket | labeled | acted | acted_rate |",
+            "|---|---|---|---|",
+        ]
+        for b in calibration["buckets"]:
+            lines.append(
+                f"| {b['label']} | {b['labeled']} | {b['acted']} | {b['acted_rate']} |"
+            )
+
+        lines += [
+            "",
+            "## Decay regret (injected-then-wrong vs injected-then-acted)",
+            "",
+            f"- regret_rate: {regret['regret_rate']} "
+            f"(regret={regret['regret']}, acted={regret['acted']})",
+            "",
+            "| score bucket | regret | acted |",
+            "|---|---|---|",
+        ]
+        for b in regret["by_bucket"]:
+            lines.append(f"| {b['label']} | {b['regret']} | {b['acted']} |")
+
+        lines += [
+            "",
+            "_Fusion-disagreement and refusal-threshold analyses are fast-follows "
+            "(the trace already stores the fused score). Not self-benchmarking: this "
+            "is evidence for maintainer-reserved policy-default decisions._",
+        ]
+        return "\n".join(lines)

--- a/src/popoto/recipes/memory_telemetry.py
+++ b/src/popoto/recipes/memory_telemetry.py
@@ -212,14 +212,19 @@ class TelemetryRecorder:
     def assemble(self, query_cues=None, agent_id=None, **kwargs):
         """Delegate to the wrapped assembler, recording one event per call.
 
-        Forces ``emit_trace=True`` on the inner call (overriding any caller
-        value) so the injection trace is available. Returns the inner
-        ``AssemblyResult`` unchanged apart from an added
-        ``metadata["telemetry_event_id"]`` when an event was written.
+        The sampling decision is made *before* the inner call: only when this
+        call will be recorded is ``emit_trace=True`` forced on the assembler,
+        so sampled-out calls pay no trace-proxy cost — ``sample_rate`` genuinely
+        protects hot-path latency. A caller that passes its own ``emit_trace``
+        is respected on sampled-out calls. Returns the inner ``AssemblyResult``
+        unchanged apart from an added ``metadata["telemetry_event_id"]`` when an
+        event was written.
         """
-        kwargs["emit_trace"] = True
+        record_this = self._should_sample()
+        if record_this:
+            kwargs["emit_trace"] = True
         result = self.inner.assemble(query_cues=query_cues, agent_id=agent_id, **kwargs)
-        if self._should_sample():
+        if record_this:
             self._record(result, query_cues, agent_id)
         return result
 
@@ -228,9 +233,17 @@ class TelemetryRecorder:
         """Measured telemetry overhead across recorded calls.
 
         Returns a dict ``{count, mean_ms, p95_ms, max_ms}`` over the full
-        per-call ``_record`` wall time (preparation + Redis write). Empty
-        history yields zeros. This is the "record the cost" report the issue
-        requires — so telemetry can be shown not to distort #460's latency.
+        per-call ``_record`` wall time — building the injected list plus the
+        Redis ``save()``. Empty history yields zeros. This is the "record the
+        cost" report the issue requires — so telemetry can be shown not to
+        distort #460's latency.
+
+        Scope note: the ``emit_trace`` score-proxy runs *inside*
+        ``inner.assemble()``, so its cost is already reflected in each event's
+        ``latency_ms`` (the assemble wall time), not double-counted here. The
+        per-event ``overhead_ms`` field is the preparation cost only (it is
+        written into the event, so it cannot include that event's own
+        ``save()``); ``overhead_stats`` is the fuller per-call figure.
         """
         samples = self._overhead_samples
         if not samples:

--- a/tests/test_memory_telemetry.py
+++ b/tests/test_memory_telemetry.py
@@ -1,0 +1,380 @@
+"""Tests for the live-agent memory telemetry recipe (issue #464).
+
+Covers the event-record write, the opt-in content-capture flag, the
+off-by-default ``emit_trace`` hook on ``ContextAssembler.assemble()``, the
+fail-open guarantee, sampling, the ``report_outcomes()`` join, the offline
+analyzer, and overhead reporting.
+
+Uses the pytest plugin's DB-15 isolation (each test gets a clean DB); no manual
+flush fixture is needed.
+"""
+
+import random
+
+import pytest
+
+from popoto import KeyField, Model, SortedField, StringField
+from popoto.recipes.context_assembler import ContextAssembler
+from popoto.recipes.memory_telemetry import (
+    DEFAULT_EVENT_TTL,
+    AssemblyEvent,
+    TelemetryAnalyzer,
+    TelemetryRecorder,
+    report_outcomes,
+)
+from popoto.redis_db import POPOTO_REDIS_DB
+
+
+class TeleMem(Model):
+    mem_id = KeyField()
+    agent_id = KeyField(null=True)
+    content = StringField(null=True)
+    # Plain SortedField with scores in [0, 1] so calibration buckets are
+    # deterministic; partition_by exercises the partition-aware score capture.
+    relevance = SortedField(type=float, partition_by="agent_id")
+
+
+# Descending relevance so top-k selection is deterministic.
+_SCORES = (0.9, 0.7, 0.5, 0.3, 0.1)
+
+
+def _seed(agent="a1", scores=_SCORES):
+    mems = []
+    for i, s in enumerate(scores):
+        m = TeleMem(mem_id=f"m{i}", agent_id=agent, content=f"note {i}", relevance=s)
+        m.save()
+        mems.append(m)
+    return mems
+
+
+def _assembler(max_items=3):
+    return ContextAssembler(
+        TeleMem, score_weights={"relevance": 1.0}, max_items=max_items
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Event write, ids-only
+# ---------------------------------------------------------------------------
+
+
+def test_event_write_ids_only():
+    _seed()
+    rec = TelemetryRecorder(_assembler(), capture="ids")
+    result = rec.assemble({"topic": "note"}, agent_id="a1")
+
+    assert len(result.records) == 3
+    event_id = result.metadata["telemetry_event_id"]
+
+    events = list(AssemblyEvent.query.all())
+    assert len(events) == 1
+    ev = events[0]
+
+    assert ev.event_id == event_id
+    assert ev.agent_id == "a1"
+    assert ev.model_name == "TeleMem"
+    assert ev.retrieval_mode == "composite"
+    assert ev.capture == "ids"
+    assert ev.budget_items == 3
+    assert ev.budget_tokens >= 0
+    assert ev.latency_ms is not None and ev.latency_ms >= 0.0
+
+    # Injected set: ids/ranks/scores/source, in descending-score rank order.
+    assert [i["rank"] for i in ev.injected] == [0, 1, 2]
+    assert [i["source"] for i in ev.injected] == ["pull", "pull", "pull"]
+    scores = [i["score"] for i in ev.injected]
+    # Partition-aware capture returns the real (non-zero) sorted-field scores.
+    assert scores == sorted(scores, reverse=True)
+    assert scores[0] > 0.0
+    # ids-only: no content, no query_text.
+    assert all("content" not in i for i in ev.injected)
+    assert ev.query_text is None
+
+    # TTL is set (mandatory bound).
+    ttl = POPOTO_REDIS_DB.ttl(ev.db_key.redis_key)
+    assert 0 < ttl <= DEFAULT_EVENT_TTL
+
+
+# ---------------------------------------------------------------------------
+# 2. Content capture opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_content_capture_opt_in():
+    _seed()
+    rec = TelemetryRecorder(_assembler(), capture="content")
+    result = rec.assemble({"topic": "note"}, agent_id="a1")
+    ev = AssemblyEvent.query.get(event_id=result.metadata["telemetry_event_id"])
+
+    assert ev.capture == "content"
+    assert ev.query_text == "note"
+    assert all("content" in i for i in ev.injected)
+    assert ev.injected[0]["content"]["content"].startswith("note")
+
+
+def test_ids_capture_never_leaks_content():
+    _seed()
+    rec = TelemetryRecorder(_assembler(), capture="ids")  # default is also ids
+    result = rec.assemble({"topic": "note"}, agent_id="a1")
+    ev = AssemblyEvent.query.get(event_id=result.metadata["telemetry_event_id"])
+    assert ev.query_text is None
+    assert all("content" not in i for i in ev.injected)
+
+
+def test_unknown_capture_raises():
+    with pytest.raises(ValueError):
+        TelemetryRecorder(_assembler(), capture="everything")
+
+
+def test_default_capture_is_ids():
+    rec = TelemetryRecorder(_assembler())
+    assert rec.capture == "ids"
+
+
+# ---------------------------------------------------------------------------
+# 3. emit_trace parity
+# ---------------------------------------------------------------------------
+
+
+def test_emit_trace_off_by_default_is_inert():
+    _seed()
+    asm = _assembler()
+    baseline = asm.assemble({"topic": "note"}, agent_id="a1")
+    explicit_off = asm.assemble({"topic": "note"}, agent_id="a1", emit_trace=False)
+
+    assert "trace" not in baseline.metadata
+    assert "trace" not in explicit_off.metadata
+    # Same metadata key set with and without the (off) kwarg.
+    assert set(baseline.metadata) == set(explicit_off.metadata)
+
+
+def test_emit_trace_adds_only_trace():
+    _seed()
+    asm = _assembler()
+    off = asm.assemble({"topic": "note"}, agent_id="a1")
+    on = asm.assemble({"topic": "note"}, agent_id="a1", emit_trace=True)
+
+    assert set(on.metadata) - set(off.metadata) == {"trace"}
+    trace = on.metadata["trace"]
+    assert len(trace) == len(on.records)
+    for rank, entry in enumerate(trace):
+        assert set(entry) == {"key", "rank", "score", "source"}
+        assert entry["rank"] == rank
+        assert entry["source"] in ("pull", "push")
+
+
+# ---------------------------------------------------------------------------
+# 4. Fail-open
+# ---------------------------------------------------------------------------
+
+
+def test_recorder_is_fail_open(monkeypatch):
+    _seed()
+
+    def _boom(self, *a, **k):
+        raise RuntimeError("redis exploded")
+
+    monkeypatch.setattr(AssemblyEvent, "save", _boom, raising=True)
+    rec = TelemetryRecorder(_assembler(), capture="ids")
+
+    # Must not raise, must return the real assembly result.
+    result = rec.assemble({"topic": "note"}, agent_id="a1")
+    assert len(result.records) == 3
+    # No event id was recorded because the write failed.
+    assert "telemetry_event_id" not in result.metadata
+    # Overhead was still measured (finally-block).
+    assert rec.overhead_stats["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Sampling
+# ---------------------------------------------------------------------------
+
+
+def test_sample_rate_zero_records_nothing():
+    _seed()
+    rec = TelemetryRecorder(_assembler(), sample_rate=0.0)
+    for _ in range(5):
+        rec.assemble({"topic": "note"}, agent_id="a1")
+    assert len(list(AssemblyEvent.query.all())) == 0
+
+
+def test_sample_rate_one_records_every_call():
+    _seed()
+    rec = TelemetryRecorder(_assembler(), sample_rate=1.0)
+    for _ in range(5):
+        rec.assemble({"topic": "note"}, agent_id="a1")
+    assert len(list(AssemblyEvent.query.all())) == 5
+
+
+def test_sample_rate_fractional_is_deterministic_with_seeded_rng():
+    _seed()
+    rec = TelemetryRecorder(_assembler(), sample_rate=0.5, rng=random.Random(1234))
+    for _ in range(20):
+        rec.assemble({"topic": "note"}, agent_id="a1")
+    n = len(list(AssemblyEvent.query.all()))
+    # Some but not all calls sampled; the exact count is reproducible.
+    assert 0 < n < 20
+
+
+def test_invalid_sample_rate_raises():
+    with pytest.raises(ValueError):
+        TelemetryRecorder(_assembler(), sample_rate=1.5)
+
+
+# ---------------------------------------------------------------------------
+# 6. Outcome join
+# ---------------------------------------------------------------------------
+
+
+def test_report_outcomes_joins_injected_keys():
+    _seed()
+    rec = TelemetryRecorder(_assembler())
+    result = rec.assemble({"topic": "note"}, agent_id="a1")
+    event_id = result.metadata["telemetry_event_id"]
+    injected_keys = [i["key"] for i in result.metadata["trace"]]
+
+    updated = report_outcomes(
+        event_id,
+        {injected_keys[0]: "acted", injected_keys[1]: "dismissed"},
+    )
+    assert updated is not None
+    outcomes = {o["key"]: o["outcome"] for o in updated.outcomes}
+    assert outcomes == {
+        injected_keys[0]: "acted",
+        injected_keys[1]: "dismissed",
+    }
+    assert all("at" in o for o in updated.outcomes)
+
+
+def test_report_outcomes_ignores_non_injected_keys():
+    _seed()
+    rec = TelemetryRecorder(_assembler())
+    result = rec.assemble({"topic": "note"}, agent_id="a1")
+    event_id = result.metadata["telemetry_event_id"]
+
+    updated = report_outcomes(event_id, {"TeleMem:a1:not-injected": "acted"})
+    assert updated.outcomes == []
+
+
+def test_report_outcomes_invalid_outcome_raises():
+    _seed()
+    rec = TelemetryRecorder(_assembler())
+    result = rec.assemble({"topic": "note"}, agent_id="a1")
+    event_id = result.metadata["telemetry_event_id"]
+    with pytest.raises(ValueError):
+        report_outcomes(event_id, {"TeleMem:a1:m0": "loved-it"})
+
+
+def test_report_outcomes_missing_event_is_noop():
+    # No event with this id exists (e.g., TTL expired).
+    assert report_outcomes("does-not-exist", {"TeleMem:a1:m0": "acted"}) is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Offline analyzer
+# ---------------------------------------------------------------------------
+
+
+def _record_with_outcomes(agent, outcomes_by_rank):
+    """Assemble once and join a per-rank outcome map. Returns injected keys."""
+    rec = TelemetryRecorder(_assembler(), capture="ids")
+    result = rec.assemble({"topic": "note"}, agent_id=agent)
+    injected = result.metadata["trace"]
+    outcome_map = {
+        injected[rank]["key"]: outcome
+        for rank, outcome in outcomes_by_rank.items()
+        if rank < len(injected)
+    }
+    report_outcomes(result.metadata["telemetry_event_id"], outcome_map)
+    return injected
+
+
+def test_analyzer_injection_precision():
+    _seed("a1")
+    # ranks: 0.9->acted, 0.7->acted, 0.5->dismissed
+    _record_with_outcomes("a1", {0: "acted", 1: "acted", 2: "dismissed"})
+
+    an = TelemetryAnalyzer(agent_id="a1")
+    prec = an.injection_precision()
+    assert prec["injected"] == 3
+    assert prec["labeled"] == 3
+    assert prec["pending"] == 0
+    assert prec["acted"] == 2
+    assert prec["acted_rate"] == pytest.approx(2 / 3, abs=1e-4)
+    assert prec["by_rank"][0]["acted_rate"] == 1.0
+    assert prec["by_rank"][2]["acted_rate"] == 0.0
+
+
+def test_analyzer_confidence_calibration_buckets_by_score():
+    _seed("a1")
+    # scores 0.9 (bucket [0.8,inf)), 0.7 ([0.6,0.8)), 0.5 ([0.4,0.6))
+    _record_with_outcomes("a1", {0: "acted", 1: "acted", 2: "dismissed"})
+
+    an = TelemetryAnalyzer(agent_id="a1")
+    buckets = {b["label"]: b for b in an.confidence_calibration()["buckets"]}
+    assert buckets["[0.8, inf)"]["labeled"] == 1
+    assert buckets["[0.8, inf)"]["acted_rate"] == 1.0
+    assert buckets["[0.6, 0.8)"]["labeled"] == 1
+    assert buckets["[0.6, 0.8)"]["acted_rate"] == 1.0
+    assert buckets["[0.4, 0.6)"]["labeled"] == 1
+    assert buckets["[0.4, 0.6)"]["acted_rate"] == 0.0
+
+
+def test_analyzer_decay_regret():
+    _seed("a1")
+    _record_with_outcomes("a1", {0: "acted", 1: "contradicted", 2: "dismissed"})
+
+    an = TelemetryAnalyzer(agent_id="a1")
+    regret = an.decay_regret()
+    assert regret["acted"] == 1
+    assert regret["regret"] == 2  # contradicted + dismissed
+    assert regret["regret_rate"] == pytest.approx(2 / 3, abs=1e-4)
+
+
+def test_analyzer_report_is_markdown():
+    _seed("a1")
+    _record_with_outcomes("a1", {0: "acted", 1: "dismissed"})
+    report = TelemetryAnalyzer(agent_id="a1").report()
+    assert "# Live-agent memory telemetry report" in report
+    assert "## Injection precision" in report
+    assert "## Confidence calibration" in report
+    assert "## Decay regret" in report
+
+
+def test_analyzer_partition_scopes_events():
+    _seed("a1")
+    _seed("b2")
+    _record_with_outcomes("a1", {0: "acted"})
+    _record_with_outcomes("b2", {0: "dismissed"})
+
+    a_events = TelemetryAnalyzer(agent_id="a1").load_events()
+    assert len(a_events) == 1
+    assert all(e.agent_id == "a1" for e in a_events)
+
+
+# ---------------------------------------------------------------------------
+# 8. Overhead reported
+# ---------------------------------------------------------------------------
+
+
+def test_overhead_stats_populated():
+    _seed()
+    rec = TelemetryRecorder(_assembler())
+    for _ in range(4):
+        rec.assemble({"topic": "note"}, agent_id="a1")
+    stats = rec.overhead_stats
+    assert stats["count"] == 4
+    assert stats["mean_ms"] >= 0.0
+    assert stats["p95_ms"] >= 0.0
+    assert stats["max_ms"] >= stats["mean_ms"]
+
+
+def test_overhead_stats_empty_when_no_samples():
+    rec = TelemetryRecorder(_assembler(), sample_rate=0.0)
+    assert rec.overhead_stats == {
+        "count": 0,
+        "mean_ms": 0.0,
+        "p95_ms": 0.0,
+        "max_ms": 0.0,
+    }

--- a/tests/test_memory_telemetry.py
+++ b/tests/test_memory_telemetry.py
@@ -144,8 +144,12 @@ def test_emit_trace_off_by_default_is_inert():
 
     assert "trace" not in baseline.metadata
     assert "trace" not in explicit_off.metadata
-    # Same metadata key set with and without the (off) kwarg.
+    # Same metadata key set AND values with and without the (off) kwarg
+    # (timing_ms is wall-clock and varies run-to-run, so exclude it).
     assert set(baseline.metadata) == set(explicit_off.metadata)
+    volatile = {"timing_ms"}
+    for k in set(baseline.metadata) - volatile:
+        assert baseline.metadata[k] == explicit_off.metadata[k]
 
 
 def test_emit_trace_adds_only_trace():
@@ -215,6 +219,16 @@ def test_sample_rate_fractional_is_deterministic_with_seeded_rng():
     n = len(list(AssemblyEvent.query.all()))
     # Some but not all calls sampled; the exact count is reproducible.
     assert 0 < n < 20
+
+
+def test_sampled_out_calls_skip_trace_cost():
+    # When a call is not sampled, emit_trace must not be forced on the inner
+    # assembler, so no trace-proxy work is done (sample_rate protects latency).
+    _seed()
+    rec = TelemetryRecorder(_assembler(), sample_rate=0.0)
+    result = rec.assemble({"topic": "note"}, agent_id="a1")
+    assert "trace" not in result.metadata
+    assert "telemetry_event_id" not in result.metadata
 
 
 def test_invalid_sample_rate_raises():


### PR DESCRIPTION
Closes #464. Part of #456 (Track A).

## What

Turns every live `ContextAssembler.assemble()` call into a durable, TTL-bounded,
Valkey-safe event record — the injected memory set (ids, ranks, scores),
retrieval mode, budget consumed, and latency — joinable to the later
`ObservationProtocol` outcome. An offline analyzer reads those into
injection-precision, confidence-calibration, and decay-regret reports. Every
live agent becomes a continuous, real-workload benchmark.

Plan: `docs/plans/live_agent_memory_telemetry.md`.

## Deliverables (new recipe `popoto.recipes.memory_telemetry`)

- **`AssemblyEvent`** — Popoto `Model` (msgpack, `Meta.ttl` = 7d) — one record
  per call. TTL-bounded so telemetry can never grow a store past the scale
  posture.
- **`TelemetryRecorder`** — wraps a `ContextAssembler` (mirrors
  `AdaptiveAssembler`); writes one event per call; **fail-open** (a telemetry
  error never breaks or slows `assemble()`); sampled; overhead measured and
  reported via `overhead_stats`.
- **`report_outcomes()`** — joins `acted/used/dismissed/deferred/contradicted`
  labels onto the matching event (keys match `instance.db_key.redis_key`).
- **`TelemetryAnalyzer`** — offline, read-only injection-precision /
  confidence-calibration / decay-regret / markdown `report()`.
- **`emit_trace`** — additive, **off-by-default** hook on
  `ContextAssembler.assemble()` (mirrors `assess_quality`); attaches
  `metadata["trace"]` with a partition-aware injection-score proxy. When off,
  behavior is bit-for-bit identical.

## Privacy (opt-in content capture)

Default `capture="ids"` records ids/ranks/scores/metadata only — never memory
content or query text. `capture="content"` is a per-store, code-set opt-in
(never a global env var / runtime toggle) for fully-open deployments whose
operator asserts the store is publishable. Docs state the operator's assertion
plainly.

## Constraints honored

- Valkey-safe: only core commands (read-only pipelined `ZSCORE` for the trace,
  ordinary model `save()` for the event). No modules, no Lua.
- Overhead measured and reported (`overhead_ms` per event + `overhead_stats`).
- TTL mandatory. Magic-number constants (TTL, sample rate, bucket edges), not
  user config.
- Not self-benchmarking: no before/after gates, no auto-tuning — produces
  *evidence* for maintainer-reserved policy-default decisions.
- ORM core untouched; the only shipped-file change is the additive off-by-default
  `emit_trace` kwarg on the (beta, recipe-layer) `ContextAssembler`.

Agent-side wiring (calling `report_outcomes()` in the live deployments, Sentry
routing, `capture` per store) is a documented handoff to the agent stack — not
in this repo.

## Tests

`tests/test_memory_telemetry.py` (23 tests): ids-only write, content opt-in,
no-leak, `emit_trace` parity, fail-open, sampling, outcome join, analyzer
metrics, overhead. Ran narrow-scope (rails: full suite from parallel worktrees
collides on shared Redis):

- `test_memory_telemetry.py` + `test_context_assembler.py` +
  `test_adaptive_assembler.py` → **81 passed** (`emit_trace` proven inert).
- `mkdocs build --strict` → exit 0 (reference page generates).
- `uv build` → exit 0.