### PR TITLE
feat(#458): end-to-end judged-answer harness (Tier 5) — Mem0/GAM, pinned gpt-4o-mini judge

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -19,7 +19,10 @@ Popoto ships with three benchmark harnesses:
 ### Overview
 
 The external harness measures how well Popoto's `ContextAssembler` retrieves
-the relevant memory given a natural-language query. It supports two datasets:
+the relevant memory given a natural-language query, and can optionally run an
+end-to-end judged-answer stage (retrieve → generate → LLM-judge) for
+leaderboard-comparable accuracy numbers (see
+[Judged-Answer Accuracy](#judged-answer-accuracy-tier-5)). It supports two datasets:
 
 | Dataset | Questions | Sessions | Notes |
 |---------|-----------|----------|-------|
@@ -100,7 +103,9 @@ python -m tests.benchmarks.run_external \
 | `--dry-run` | off | Print results without saving report files |
 | `--fixture PATH` | download | Load dataset from a local JSON file |
 | `--output DIR` | `results/external/` | Override output directory |
-| `--error-threshold FLOAT` | 0.10 | Exit 1 if error rate exceeds this fraction |
+| `--error-threshold FLOAT` | 0.10 | Exit 1 if retrieval error rate exceeds this fraction |
+| `--judged` | off | Run the end-to-end judged-answer stage (retrieve → generate → LLM-judge). Requires `OPENAI_API_KEY`; skips gracefully without one. `lexical`/`hybrid` only. See [Judged-Answer Accuracy](#judged-answer-accuracy-tier-5). |
+| `--judge-error-threshold FLOAT` | 0.25 | With `--judged`, exit 1 if the judge-error (API failure) rate exceeds this fraction. Independent of `--error-threshold`. |
 
 ### Report Artifacts
 
@@ -122,7 +127,10 @@ Non-lexical runs suffix the retrieval mode into both the dated and `_latest`
 filenames (e.g. `longmemeval_s_20260703_hybrid.json`,
 `longmemeval_s_latest_hybrid.json`; `vector` uses the `_vector` suffix), so a
 hybrid or vector run never overwrites the lexical baseline artifacts or their
-symlinks.
+symlinks. `--judged` runs add an independent `_judged` suffix that composes with
+the mode suffix (e.g. `locomo_20260714_judged.*` for lexical+judged,
+`locomo_20260714_hybrid_judged.*` for hybrid+judged), so a judged run never
+clobbers a retrieval-only artifact.
 
 Committing a `_latest` artifact (any mode) auto-publishes it to the
 [Benchmarks results pages](benchmarks/results/index.md) on the docs site on the
@@ -138,6 +146,7 @@ Each JSON report includes:
 - `machine` — Python version, OS, CPU count
 - `notes` — retrieval mode description
 - `questions` — per-question detail (item_id, recall scores, status, errors, and `metadata.question_type`)
+- `judge` / `judged` — present only on `--judged` runs: the pinned judge identity (model, prompt SHA-256, protocol, temperature) and the judged-accuracy aggregate (see [Judged-Answer Accuracy](#judged-answer-accuracy-tier-5))
 
 ### Retrieval Modes
 
@@ -293,6 +302,59 @@ policy-level).** Keep category 5 in the full 5-category aggregate (the evidence
 audit shows its spans are meaningful), publish the 4-category parity slice
 alongside it for leaderboard comparability, and always carry the caveat above.
 A refusal metric is not applicable to this dataset and is deferred to #463.
+
+### Judged-Answer Accuracy (Tier 5)
+
+The metrics above are **retrieval-level** — did the right memory get retrieved.
+Every published vendor leaderboard (Hindsight, Mem0, Zep, Memori, Backboard)
+instead reports **end-to-end judged accuracy**: retrieve → generate an answer →
+have an LLM grade that answer against the gold answer. The `--judged` flag adds
+that stage so Popoto is comparable to those boards.
+
+> **Two different metric families.** Retrieval recall and judged accuracy are
+> reported side by side but **must never be cross-compared or combined into a
+> single ranking** (per the #453 framing requirements). A judged run's artifact
+> keeps them in separate blocks (`summary` vs `judged`).
+
+**Pinned judge (reproducibility).** The judge is the **Mem0 / GAM evaluation
+protocol** (`ACCURACY_PROMPT`, arXiv:2504.19413) reproduced verbatim, with
+`gpt-4o-mini` as both judge and answer-generator, at `temperature=0`. Judged
+accuracy drifts several points across judge models, so the judge identity —
+model id, prompt SHA-256, protocol reference, temperature — is recorded in the
+`judge` block of every judged artifact. Both the model and the prompt are pinned
+in `tests/benchmarks/judge.py` and guarded by tests, so a silent swap is a test
+failure.
+
+**API key + cost.** Generation and judging call the OpenAI API, so `--judged`
+needs `OPENAI_API_KEY` and the `[openai]` extra (`pip install -e ".[openai]"`).
+Without them the stage **skips gracefully** (prints a cost estimate and exits 0,
+the same posture as hybrid's model download). Each item costs ~2 `gpt-4o-mini`
+calls (~$0.0007/item); a full LoCoMo judged run (1986 QA) is ~$1.4, a
+`--limit 200` slice ~$0.15. The harness prints the estimate before running.
+
+```bash
+# Judged run over a representative 200-question LoCoMo slice (lexical retrieval):
+export OPENAI_API_KEY=sk-...
+python -m tests.benchmarks.run_external --dataset locomo --judged --limit 200
+
+# Hybrid retrieval + judged accuracy (writes locomo_<date>_hybrid_judged.*):
+python -m tests.benchmarks.run_external --dataset locomo --judged \
+    --retrieval-mode hybrid --limit 200
+```
+
+The `judged` block reports `judged_accuracy` (fraction CORRECT over scored
+items), a per-`question_type` breakdown, and separate counts for judge errors
+and skipped items. **LoCoMo adversarial (category-5) items are excluded from the
+headline `judged_accuracy`** and reported separately under `adversarial`: the
+Mem0/GAM prompt is a factual-match judge, not a refusal judge, so it cannot score
+refusal answers meaningfully (a dedicated refusal metric is tracked in #454).
+Per-item fault isolation means a transient API error records a `judge_error`
+status and the run continues rather than aborting a paid run.
+
+Vector mode (`--retrieval-mode vector`) is **not** supported with `--judged` (the
+diagnostic vector path returns no memory text to answer from) and is rejected up
+front. No self-benchmarked judged numbers are committed — the harness ships the
+capability; live runs are operator-run with a key.
 
 ### Baseline Numbers (v1.6.3)
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -329,8 +329,10 @@ failure.
 needs `OPENAI_API_KEY` and the `[openai]` extra (`pip install -e ".[openai]"`).
 Without them the stage **skips gracefully** (prints a cost estimate and exits 0,
 the same posture as hybrid's model download). Each item costs ~2 `gpt-4o-mini`
-calls (~$0.0007/item); a full LoCoMo judged run (1986 QA) is ~$1.4, a
-`--limit 200` slice ~$0.15. The harness prints the estimate before running.
+calls (~$0.0004/item under the harness's documented token assumptions); a full
+LoCoMo judged run (1986 QA) is ~$0.8, a `--limit 200` slice ~$0.08. The harness
+prints this estimate (sized by `--limit`, or the dataset's full size when
+unlimited) before running.
 
 ```bash
 # Judged run over a representative 200-question LoCoMo slice (lexical retrieval):
@@ -347,7 +349,8 @@ items), a per-`question_type` breakdown, and separate counts for judge errors
 and skipped items. **LoCoMo adversarial (category-5) items are excluded from the
 headline `judged_accuracy`** and reported separately under `adversarial`: the
 Mem0/GAM prompt is a factual-match judge, not a refusal judge, so it cannot score
-refusal answers meaningfully (a dedicated refusal metric is tracked in #454).
+refusal answers meaningfully (a dedicated refusal metric is tracked in #463; the
+cat-5 scoring audit that recommended it was #454).
 Per-item fault isolation means a transient API error records a `judge_error`
 status and the run continues rather than aborting a paid run.
 

--- a/docs/plans/judged_answer_harness.md
+++ b/docs/plans/judged_answer_harness.md
@@ -162,7 +162,8 @@ Flow when `--judged` is set:
    C4): the verbatim Mem0/GAM prompt is a factual-match judge, not a refusal judge, so refusal
    answers judged against `adversarial_answer` have no defined correctness semantics. They are
    reported under a separate `judged_adversarial` key (count + labels), never folded into the
-   headline number; the refusal *metric* remains #454.
+   headline number; the refusal *metric* is tracked in #463 (recommended by the
+   closed cat-5 audit #454).
 5. A top-level `judge` identity block: `{judge_model, judge_prompt_sha256, generation_model,
    generation_prompt_sha256, temperature: 0, protocol: "mem0/gam",
    protocol_ref: "arXiv:2504.19413"}`.
@@ -223,16 +224,19 @@ they add no external dependency to the default suite.
 ## Cost estimate (documented before full runs)
 
 Per judged item = 1 generation call + 1 judge call, both `gpt-4o-mini`
-($0.15 / 1M input, $0.60 / 1M output as of 2026-07). With ~1.5k input + ~150 output tokens per
-call, ~2 calls/item ≈ **$0.0007/item**. Full LoCoMo (1,986 QA) ≈ **~$1.4**; a `--limit 200`
-representative slice ≈ **$0.15**. `estimate_cost()` prints this before a non-dry run; numbers are
-assumption-based (documented), never presented as measured Popoto results.
+($0.15 / 1M input, $0.60 / 1M output as of 2026-07). Under the token assumptions pinned in
+`estimate_cost()` (generation ~1.5k in / 150 out, judge ~0.5k in / 30 out), ~2 calls/item ≈
+**$0.0004/item**. Full LoCoMo (1,986 QA) ≈ **~$0.8**; a `--limit 200` representative slice ≈
+**$0.08**. `estimate_cost()` prints this before a run (sized by `--limit`, or the dataset's full
+size when unlimited); numbers are assumption-based (documented), never presented as measured
+Popoto results.
 
 ## Out of Scope / Non-goals
 
 - **Adversarial (LoCoMo cat-5) refusal metric** — adversarial items are *excluded* from the
   headline judged-accuracy and reported separately (crit C4); a dedicated refusal-precision
-  metric is #454 (strategy §1.3), not this issue.
+  metric is tracked in #463 (recommended by the closed cat-5 audit #454, strategy §1.3), not
+  this issue.
 - **Cross-comparing recall vs judged accuracy** — explicitly forbidden (#453); the report keeps
   them in separate blocks with a caveat.
 - **No committed live-judge numbers** — this PR ships the *harness*, not a self-benchmarked

--- a/docs/plans/judged_answer_harness.md
+++ b/docs/plans/judged_answer_harness.md
@@ -6,6 +6,7 @@ owner: valorengels
 created: 2026-07-14
 tracking: https://github.com/tomcounsell/popoto/issues/458
 last_comment_id:
+revision_applied: true
 ---
 
 # End-to-end Judged-Answer Harness (Tier 5): Mem0/GAM protocol, pinned gpt-4o-mini judge
@@ -88,8 +89,13 @@ factory.
 
 - `JUDGE_MODEL = "gpt-4o-mini"` — pinned. A test asserts this exact string so a silent model
   swap is a test failure (issue requirement 1/2).
-- `GENERATION_MODEL_DEFAULT = "gpt-4o-mini"` — default answer-generation model (overridable via
-  `--generation-model`; the *judge* is never overridable).
+- `GENERATION_MODEL = "gpt-4o-mini"` — the answer generator is **also pinned** (crit C3). #458
+  requires pinning the judge; making the generator configurable is scope nobody asked for and
+  would silently invalidate the committed cost figures. Both calls use the same pinned model, so
+  the cost estimate stays correct.
+- Both `generate_answer` and `judge_answer` call the model with **`temperature=0`** (crit C2) so
+  judged_accuracy is reproducible run-to-run; the temperature is recorded in the `judge`
+  identity block alongside the prompt hash.
 - `LLM_JUDGE_PROMPT` — the Mem0/GAM `ACCURACY_PROMPT`, reproduced **verbatim** with a source
   citation (arXiv:2504.19413 + the mem0 evaluation repo). `{question}`/`{gold_answer}`/
   `{generated_answer}` placeholders.
@@ -104,46 +110,78 @@ factory.
   `JudgeProtocol` adapter.
 - `is_judge_available() -> bool` — True iff `openai` importable AND `OPENAI_API_KEY` set.
   Mirrors hybrid's capability check.
-- `generate_answer(client, question, context_texts, model) -> str`
+- `generate_answer(client, question, context_texts) -> str` — `temperature=0`, pinned
+  `GENERATION_MODEL`.
 - `judge_answer(client, question, gold_answer, generated_answer) -> tuple[str, str]` — returns
-  `(label, raw)` where `label ∈ {"CORRECT", "WRONG"}`. Parses the Mem0 protocol's JSON
-  `{"label": ...}` first, falls back to a strict CORRECT/WRONG scan, and normalizes ambiguity
-  to `"WRONG"` (the protocol's conservative default).
+  `(label, raw)` where `label ∈ {"CORRECT", "WRONG"}`. `temperature=0`, pinned `JUDGE_MODEL`.
+  Parses the Mem0 protocol's JSON `{"label": ...}` first, falls back to a strict CORRECT/WRONG
+  scan, and normalizes ambiguity to `"WRONG"` (the protocol's conservative default).
+- `call_with_retry(fn, attempts=3)` — retry-with-backoff wrapper used around both LLM calls so a
+  transient `RateLimitError`/`APIError`/timeout retries rather than aborting a paid run (crit B3).
+  Raises the last error after `attempts`, which the caller catches per-item.
 - `estimate_cost(n_items, ...) -> dict` — documented token/price assumptions → an estimated USD
   range, printed before a non-dry full run and reproduced in the plan/docs.
 
 ### 2. `--judged` stage wired into `run_external.py`
 
 Reuse the existing CLI (`--dataset`, `--limit`, `--sample`, `--seed`, `--retrieval-mode`,
-`--dry-run`, `--fixture`, `--output`). Add:
+`--dry-run`, `--fixture`, `--output`). Add exactly one new flag:
 
-- `--judged` (flag) — turn on the generation+judge stage on top of retrieval.
-- `--generation-model` (default `gpt-4o-mini`) — answer generator only; judge stays pinned.
+- `--judged` (flag) — turn on the generation+judge stage on top of retrieval. The generator and
+  judge are both pinned to `gpt-4o-mini` (no `--generation-model` flag — crit C3).
+
+**Retrieval-mode support (crit B2):** `--judged` is supported only for the assembler paths
+(`lexical`, `hybrid`), whose retrieved records already carry `.content`
+(`external_base.py:388`). `--retrieval-mode vector --judged` is **rejected up front** with a
+clear error (the vector path holds only `(redis_key, cosine)` pairs, no hydrated content;
+hydration is deferred to a follow-up if real demand appears). This guard lives in `main()`
+before any ingestion.
 
 Flow when `--judged` is set:
 
 1. **Graceful skip:** if `not is_judge_available()`, print the reason + the cost estimate and
    return 0 with a clear "skipped, no API key" message (matching hybrid's posture — a missing key
    is not a failure). No artifacts written.
-2. For each item, after retrieval, feed the **retrieved** turn texts (new
+2. For each item, after retrieval, **gate on `q_result.status == "ok"`** (crit C1) — non-ok /
+   `skipped-empty` items have zero or no metadata, so they are counted as `judged_skipped` and
+   never reach an API call. For ok items, feed the **retrieved** turn texts (new
    `metadata["retrieved_contents"]`, top-k) to `generate_answer`, then `judge_answer` vs
-   `item.metadata["answer"]`. Record per-item `generated_answer`, `judge_label`, and the
-   already-computed recall.
-3. Aggregate adds a `judged` block: `n_judged`, `n_correct`, `judged_accuracy`, and a
+   `item.metadata["answer"]`.
+3. **Per-item fault isolation (crit B3):** each item's generate+judge is wrapped in try/except.
+   Transient errors retry via `call_with_retry`; a final failure records a `judge_status =
+   "judge_error"` (distinct from CORRECT/WRONG) and the run **continues** rather than crashing —
+   so a single 429/5xx never forces a full re-pay. Judge errors are tracked separately and do
+   **not** count against the existing retrieval `--error-threshold` gate
+   (`run_external.py:824`); a distinct `--judge-error-threshold` (default 0.25) governs them.
+   All per-item results (incl. `generated_answer`, `judge_label`, `judge_status`) are written to
+   the artifact at the end, so a completed run is fully inspectable.
+4. Aggregate adds a `judged` block: `n_judged`, `n_correct`, `n_judge_errors`, `n_judged_skipped`,
+   `judged_accuracy` (denominator = CORRECT+WRONG only, excluding errors and skips), and a
    per-`question_type` judged breakdown — kept **separate** from the retrieval `summary` block.
-4. A top-level `judge` identity block: `{judge_model, judge_prompt_sha256, generation_model,
-   protocol: "mem0/gam", protocol_ref: "arXiv:2504.19413"}`.
-5. Artifacts saved with the `_judged` suffix (`{slug}_{date}_judged.{json,md}` +
-   `{slug}_latest_judged.*`), never clobbering the lexical/hybrid retrieval artifacts. The
-   Markdown renders retrieval recall and judged accuracy in **two separate tables** under an
-   explicit "these two metric families are not comparable" caveat (#453).
+   **Adversarial items (LoCoMo cat-5) are excluded from the headline `judged_accuracy`** (crit
+   C4): the verbatim Mem0/GAM prompt is a factual-match judge, not a refusal judge, so refusal
+   answers judged against `adversarial_answer` have no defined correctness semantics. They are
+   reported under a separate `judged_adversarial` key (count + labels), never folded into the
+   headline number; the refusal *metric* remains #454.
+5. A top-level `judge` identity block: `{judge_model, judge_prompt_sha256, generation_model,
+   generation_prompt_sha256, temperature: 0, protocol: "mem0/gam",
+   protocol_ref: "arXiv:2504.19413"}`.
+6. Artifacts saved with a composed suffix (crit B1). `save_reports()` gains a `judged: bool`
+   param and composes **both** dimensions:
+   `suffix = ("" if mode=="lexical" else f"_{mode}") + ("_judged" if judged else "")`. So
+   `lexical`+`judged` → `{slug}_{date}_judged.*`; `hybrid`+`judged` →
+   `{slug}_{date}_hybrid_judged.*` (+ matching `_latest*` pointers) — never clobbering the plain
+   `_hybrid` retrieval artifact or the lexical-judged artifact. The Markdown renders retrieval
+   recall and judged accuracy in **two separate tables** under an explicit "these two metric
+   families are not comparable" caveat (#453).
 
 ### 3. `ExternalScenario` hook
 
 `run()` collects the retrieved records' `.content` in rank order into
-`metadata["retrieved_contents"]` (assembler path: from `assembly_result.records`; vector path:
-hydrate the ranked keys). Zero behavior change to existing retrieval scoring; purely additive
-metadata that the judged stage consumes.
+`metadata["retrieved_contents"]` on the **assembler path only** (from `assembly_result.records`
+at `external_base.py:388`). The vector path is not extended (it holds only `(redis_key, cosine)`
+pairs and `--judged` rejects vector mode up front — crit B2). Zero behavior change to existing
+retrieval scoring; purely additive metadata that the judged stage consumes.
 
 ## Testing
 
@@ -155,14 +193,27 @@ injected `JudgeProtocol` fake:
   text contains the protocol's signature phrasing (guards silent prompt drift).
 - **Judge parsing:** JSON `{"label":"CORRECT"}`, bare `CORRECT`/`WRONG`, mixed/ambiguous →
   `WRONG`, case-insensitivity.
-- **Generation:** fake client returns a canned answer; `generate_answer` passes the right model
+- **Determinism:** `generate_answer`/`judge_answer` pass `temperature=0` and the pinned models to
+  the fake client (assert the call kwargs).
+- **Generation:** fake client returns a canned answer; `generate_answer` passes the pinned model
   and includes the context.
 - **Gating:** `is_judge_available()` False when key unset / openai absent (monkeypatched).
+- **Retry / fault isolation:** a fake client that raises twice then succeeds → `call_with_retry`
+  recovers; a fake that always raises → item recorded as `judge_error`, run does not crash, other
+  items still judged.
+- **Suffix composition (crit B1):** `save_reports(..., retrieval_mode="hybrid", judged=True)`
+  writes `..._hybrid_judged.json`, not `..._judged.json`; lexical+judged writes `..._judged.json`.
 - **Aggregate shape:** judged aggregate has a `judged` block AND a retrieval `summary` block,
-  the top-level `judge` identity block is populated, and the two families are **not** merged
-  into one ranking (assert both blocks exist and are distinct).
+  the top-level `judge` identity block is populated (incl. `temperature`), and the two families
+  are **not** merged into one ranking (assert both blocks exist and are distinct).
+- **Status gate (crit C1):** a non-ok / skipped-empty item is counted as `judged_skipped` and
+  triggers no generation call (fake client call-count asserted).
+- **Adversarial exclusion (crit C4):** an adversarial (cat-5) item does not move the headline
+  `judged_accuracy` and is reported under `judged_adversarial`.
+- **Vector rejection (crit B2):** `main(--retrieval-mode vector --judged)` exits with a clear
+  error and writes no artifacts.
 - **Graceful skip end-to-end:** `main(--judged)` with `is_judge_available()` monkeypatched
-  False returns cleanly and writes no artifacts.
+  False returns 0 cleanly and writes no artifacts.
 - **End-to-end (mocked):** small fixture, injected fake judge+generator → judged accuracy
   computed and `_judged` artifacts written to a `tmp_path --output`.
 
@@ -179,12 +230,18 @@ assumption-based (documented), never presented as measured Popoto results.
 
 ## Out of Scope / Non-goals
 
-- **Adversarial (LoCoMo cat-5) refusal metric** — the gold `adversarial_answer` is passed to the
-  judge as-is; a dedicated refusal-precision metric is #454 (strategy §1.3), not this issue.
+- **Adversarial (LoCoMo cat-5) refusal metric** — adversarial items are *excluded* from the
+  headline judged-accuracy and reported separately (crit C4); a dedicated refusal-precision
+  metric is #454 (strategy §1.3), not this issue.
 - **Cross-comparing recall vs judged accuracy** — explicitly forbidden (#453); the report keeps
   them in separate blocks with a caveat.
 - **No committed live-judge numbers** — this PR ships the *harness*, not a self-benchmarked
   scoreboard (benchmark doctrine: no fabricated self-benchmark numbers). Live runs are operator-run
   with a key.
-- **Judge model configurability** — deliberately omitted; the judge is pinned. Only the *generator*
-  is overridable.
+- **Judge AND generator model configurability** — both are pinned to `gpt-4o-mini`; no override
+  flag (crit C3). Reopen in a follow-up if a real need appears.
+- **Vector-mode judged** — rejected up front (crit B2); vector results carry no `.content` to
+  answer from. Deferred to a follow-up if demand appears.
+- **Checkpoint/resume of a killed run** — per-item fault isolation means a completed run never
+  crashes and always writes its artifact; mid-run *process kill* resume (JSONL replay) is a
+  follow-up, not this appetite. Documented so operators re-run from scratch if the process dies.

--- a/docs/plans/judged_answer_harness.md
+++ b/docs/plans/judged_answer_harness.md
@@ -1,0 +1,190 @@
+---
+status: Planning
+type: feature
+appetite: Medium
+owner: valorengels
+created: 2026-07-14
+tracking: https://github.com/tomcounsell/popoto/issues/458
+last_comment_id:
+---
+
+# End-to-end Judged-Answer Harness (Tier 5): Mem0/GAM protocol, pinned gpt-4o-mini judge
+
+## Problem
+
+**Current behavior:** The external benchmark harness (`tests/benchmarks/run_external.py`,
+#394) stops at **retrieval**. It reports Recall@1/5/10 + MRR + latency for LongMemEval-S and
+LoCoMo, but never generates an answer and never judges answer accuracy. Every published
+vendor leaderboard (Hindsight, Mem0, Zep, Memori, Backboard) reports **end-to-end judged
+accuracy** (retrieve → generate → LLM-judge). Popoto's retrieval-recall numbers sit next to
+those judged-accuracy numbers in the literature, which is the core apples-to-oranges error
+(strategy §1.1).
+
+**Desired outcome** (issue #458, strategy §1.2 "Tier 5"): add the generation + LLM-judge
+stage the harness deliberately stops before, so Popoto is comparable to the leaderboards, and
+do it honestly:
+
+1. **Adopt the Mem0 / GAM evaluation protocol verbatim** (arXiv:2504.19413) with `gpt-4o-mini`
+   as judge — the most widely reused protocol (MemPro et al. follow it). Do NOT invent a judge
+   prompt; reuse is what makes Popoto's numbers line up with the published tables.
+2. **Pin the judge model + prompt in-repo.** Judged accuracy drifts several points across judge
+   models (Hindsight reports different overall scores under Gemini-3 vs OSS-120B for the *same*
+   memory stack). The judge identity (model id + prompt hash) is recorded in the JSON artifact.
+3. **Report retrieval recall AND judged accuracy side by side** per run — a differentiating
+   honesty artifact (vendors publish only the flattering one). The two metric families are
+   reported in **separate blocks** and are **never fused into a single ranking** (#453 framing).
+4. Artifacts follow the existing convention: `{dataset}_{date}_judged.{json,md}` +
+   `{dataset}_latest_judged.*` pointers. `--limit` / `--sample` / `--seed` reuse the existing
+   CLI surface.
+5. Generation + judge calls require an API key → the harness **skips gracefully** without one
+   (the same posture as hybrid's model download), and a cost estimate is documented before full
+   runs.
+
+## Freshness Check
+
+**Baseline commit:** `0b4c629` (origin/main, "Merge pull request #470 from …/release/v1.8.0").
+**Issue filed:** part of epic #456 (Track A), strategy §1.2.
+**Disposition:** Unchanged — the retrieval harness this extends is present and stable.
+
+**File:line references re-verified (worktree of origin/main):**
+- `tests/benchmarks/run_external.py` (838 lines) — CLI entrypoint; `run_item`,
+  `compute_aggregate`, `build_markdown_report`, `save_reports`, `main`. Present as described.
+- `tests/benchmarks/scenarios/external_base.py` (502 lines) — `ExternalScenario`; `run()`
+  drives `ContextAssembler.assemble()` and returns a `ScenarioResult`. The retrieved **records**
+  are available in `run()` (`assembly_result.records`) but their text content is **not** currently
+  surfaced in `ScenarioResult.metadata` — this plan adds `retrieved_contents` there so the
+  generator has evidence to answer from.
+- `tests/benchmarks/datasets/__init__.py` — `BenchmarkItem` namedtuple; gold answer is in
+  `item.metadata["answer"]` for **both** adapters (LoCoMo `qa["answer"]`/`adversarial_answer`,
+  LongMemEval `record["answer"]`). Confirmed present.
+- `pyproject.toml` — an `openai = ["openai>=1.0.0", "numpy>=1.23.1"]` optional extra already
+  exists; the judged harness reuses it (no new hard dependency).
+
+**Overlapping active plans:** `external_benchmark_harness.md` (#394, the retrieval base this
+builds on), `deterministic_eval_harness.md` (#418, the deterministic no-LLM CI eval — orthogonal;
+that one deliberately has *no* LLM judge). No plan currently targets the generation+judge stage.
+
+## Prior Art
+
+- **#394 / external harness** — the retrieval half this extends. Same artifact naming
+  convention (`{dataset}_{date}[_suffix].{json,md}` + `_latest[_suffix]` pointers), same
+  `--limit`/`--sample`/`--seed` CLI surface, same DB-14 isolation (`_select_bench_db`).
+- **#442 / hybrid retrieval** — the model here is the graceful-skip precedent: hybrid needs a
+  ~90 MB model download and skips cleanly without it. Judged mode needs an API key and skips the
+  same way.
+- **Mem0 / GAM** (arXiv:2504.19413) — the LLM-as-a-Judge accuracy protocol we reproduce
+  verbatim. MemPro (arXiv:2606.00619) reuses the same `gpt-4o-mini` judge, which is exactly why
+  reusing it makes numbers line up.
+
+## Design
+
+Two new pieces plus one small hook, all under `tests/benchmarks/`:
+
+### 1. `tests/benchmarks/judge.py` — pinned judge + generation protocol
+
+Pure, dependency-injectable module. **No `openai` import at module top** (it is an optional
+extra and must not break test collection); the OpenAI client is imported lazily inside the
+factory.
+
+- `JUDGE_MODEL = "gpt-4o-mini"` — pinned. A test asserts this exact string so a silent model
+  swap is a test failure (issue requirement 1/2).
+- `GENERATION_MODEL_DEFAULT = "gpt-4o-mini"` — default answer-generation model (overridable via
+  `--generation-model`; the *judge* is never overridable).
+- `LLM_JUDGE_PROMPT` — the Mem0/GAM `ACCURACY_PROMPT`, reproduced **verbatim** with a source
+  citation (arXiv:2504.19413 + the mem0 evaluation repo). `{question}`/`{gold_answer}`/
+  `{generated_answer}` placeholders.
+- `ANSWER_GENERATION_PROMPT` — the answer-from-memories prompt (context = top-k retrieved turn
+  texts; instructs a concise answer, and to say it cannot find the info when the memories don't
+  contain it — needed so adversarial/unanswerable items aren't force-answered).
+- `prompt_sha256(text) -> str` — stable hash used in the artifact to fingerprint the exact
+  prompt text (so a future prompt edit is visible in the committed JSON).
+- `JudgeProtocol` — a tiny structural interface (`chat(model, messages) -> str`) so tests
+  inject a fake and **no test needs `openai` or an API key**.
+- `build_openai_client()` — lazy `import openai`; reads `OPENAI_API_KEY`; returns a
+  `JudgeProtocol` adapter.
+- `is_judge_available() -> bool` — True iff `openai` importable AND `OPENAI_API_KEY` set.
+  Mirrors hybrid's capability check.
+- `generate_answer(client, question, context_texts, model) -> str`
+- `judge_answer(client, question, gold_answer, generated_answer) -> tuple[str, str]` — returns
+  `(label, raw)` where `label ∈ {"CORRECT", "WRONG"}`. Parses the Mem0 protocol's JSON
+  `{"label": ...}` first, falls back to a strict CORRECT/WRONG scan, and normalizes ambiguity
+  to `"WRONG"` (the protocol's conservative default).
+- `estimate_cost(n_items, ...) -> dict` — documented token/price assumptions → an estimated USD
+  range, printed before a non-dry full run and reproduced in the plan/docs.
+
+### 2. `--judged` stage wired into `run_external.py`
+
+Reuse the existing CLI (`--dataset`, `--limit`, `--sample`, `--seed`, `--retrieval-mode`,
+`--dry-run`, `--fixture`, `--output`). Add:
+
+- `--judged` (flag) — turn on the generation+judge stage on top of retrieval.
+- `--generation-model` (default `gpt-4o-mini`) — answer generator only; judge stays pinned.
+
+Flow when `--judged` is set:
+
+1. **Graceful skip:** if `not is_judge_available()`, print the reason + the cost estimate and
+   return 0 with a clear "skipped, no API key" message (matching hybrid's posture — a missing key
+   is not a failure). No artifacts written.
+2. For each item, after retrieval, feed the **retrieved** turn texts (new
+   `metadata["retrieved_contents"]`, top-k) to `generate_answer`, then `judge_answer` vs
+   `item.metadata["answer"]`. Record per-item `generated_answer`, `judge_label`, and the
+   already-computed recall.
+3. Aggregate adds a `judged` block: `n_judged`, `n_correct`, `judged_accuracy`, and a
+   per-`question_type` judged breakdown — kept **separate** from the retrieval `summary` block.
+4. A top-level `judge` identity block: `{judge_model, judge_prompt_sha256, generation_model,
+   protocol: "mem0/gam", protocol_ref: "arXiv:2504.19413"}`.
+5. Artifacts saved with the `_judged` suffix (`{slug}_{date}_judged.{json,md}` +
+   `{slug}_latest_judged.*`), never clobbering the lexical/hybrid retrieval artifacts. The
+   Markdown renders retrieval recall and judged accuracy in **two separate tables** under an
+   explicit "these two metric families are not comparable" caveat (#453).
+
+### 3. `ExternalScenario` hook
+
+`run()` collects the retrieved records' `.content` in rank order into
+`metadata["retrieved_contents"]` (assembler path: from `assembly_result.records`; vector path:
+hydrate the ranked keys). Zero behavior change to existing retrieval scoring; purely additive
+metadata that the judged stage consumes.
+
+## Testing
+
+New `tests/benchmarks/test_judged.py`, all runnable with **no `openai` and no API key** via the
+injected `JudgeProtocol` fake:
+
+- **Model pin:** `JUDGE_MODEL == "gpt-4o-mini"` exactly (guards silent swap).
+- **Prompt pin:** `prompt_sha256(LLM_JUDGE_PROMPT)` equals a committed constant + the verbatim
+  text contains the protocol's signature phrasing (guards silent prompt drift).
+- **Judge parsing:** JSON `{"label":"CORRECT"}`, bare `CORRECT`/`WRONG`, mixed/ambiguous →
+  `WRONG`, case-insensitivity.
+- **Generation:** fake client returns a canned answer; `generate_answer` passes the right model
+  and includes the context.
+- **Gating:** `is_judge_available()` False when key unset / openai absent (monkeypatched).
+- **Aggregate shape:** judged aggregate has a `judged` block AND a retrieval `summary` block,
+  the top-level `judge` identity block is populated, and the two families are **not** merged
+  into one ranking (assert both blocks exist and are distinct).
+- **Graceful skip end-to-end:** `main(--judged)` with `is_judge_available()` monkeypatched
+  False returns cleanly and writes no artifacts.
+- **End-to-end (mocked):** small fixture, injected fake judge+generator → judged accuracy
+  computed and `_judged` artifacts written to a `tmp_path --output`.
+
+Gate: `scripts/ci-local.sh` (tests + stress + docs). Only the benchmark judged tests are new;
+they add no external dependency to the default suite.
+
+## Cost estimate (documented before full runs)
+
+Per judged item = 1 generation call + 1 judge call, both `gpt-4o-mini`
+($0.15 / 1M input, $0.60 / 1M output as of 2026-07). With ~1.5k input + ~150 output tokens per
+call, ~2 calls/item ≈ **$0.0007/item**. Full LoCoMo (1,986 QA) ≈ **~$1.4**; a `--limit 200`
+representative slice ≈ **$0.15**. `estimate_cost()` prints this before a non-dry run; numbers are
+assumption-based (documented), never presented as measured Popoto results.
+
+## Out of Scope / Non-goals
+
+- **Adversarial (LoCoMo cat-5) refusal metric** — the gold `adversarial_answer` is passed to the
+  judge as-is; a dedicated refusal-precision metric is #454 (strategy §1.3), not this issue.
+- **Cross-comparing recall vs judged accuracy** — explicitly forbidden (#453); the report keeps
+  them in separate blocks with a caveat.
+- **No committed live-judge numbers** — this PR ships the *harness*, not a self-benchmarked
+  scoreboard (benchmark doctrine: no fabricated self-benchmark numbers). Live runs are operator-run
+  with a key.
+- **Judge model configurability** — deliberately omitted; the judge is pinned. Only the *generator*
+  is overridable.

--- a/tests/benchmarks/judge.py
+++ b/tests/benchmarks/judge.py
@@ -1,0 +1,392 @@
+"""End-to-end judged-answer protocol (Tier 5) — Mem0/GAM, pinned gpt-4o-mini judge.
+
+This module adds the *generation + LLM-judge* stage the retrieval harness
+(``run_external.py``, #394) deliberately stops before, so Popoto's numbers are
+comparable to the published judged-accuracy leaderboards (Hindsight, Mem0, Zep,
+Memori, Backboard). Strategy: ``docs/plans/benchmarking_strategy_2026-07.md``
+§1.2; plan: ``docs/plans/judged_answer_harness.md``; issue #458.
+
+Design invariants (issue #458):
+
+- **Judge model + prompt are PINNED in-repo.** ``JUDGE_MODEL == "gpt-4o-mini"``
+  and ``LLM_JUDGE_PROMPT`` is the Mem0 / GAM ``ACCURACY_PROMPT`` reproduced
+  verbatim (arXiv:2504.19413). Judged accuracy drifts several points across
+  judge models, so the judge identity (model id + prompt SHA-256) is recorded in
+  every artifact. Tests assert the model string and the prompt hash so a silent
+  swap/edit is a test failure.
+- **The generator is also pinned** to the same ``gpt-4o-mini`` so the documented
+  cost figures stay valid; there is no model-override flag.
+- **Both calls use ``temperature=0``** for run-to-run reproducibility.
+- **No hard ``openai`` dependency.** ``openai`` is an optional extra; it is
+  imported lazily inside :func:`build_openai_client`. Every unit test injects a
+  :class:`JudgeProtocol` fake, so the default suite needs neither ``openai`` nor
+  an API key. Live runs skip gracefully when the key/library is absent (the same
+  posture as hybrid's model download).
+
+Protocol provenance:
+    The judge is the Mem0 LoCoMo ``ACCURACY_PROMPT`` (LLM-as-a-Judge), published
+    with the Mem0 paper (arXiv:2504.19413) and reused verbatim by downstream
+    harnesses (e.g. MemPro arXiv:2606.00619, MemTensor/MemOS). Reusing it is what
+    makes Popoto's numbers line up with the published tables. The judge parses a
+    trailing ``{"label": "CORRECT"|"WRONG"}`` JSON object exactly as the source
+    harness does, and treats any ambiguous/unparseable response as ``WRONG`` (the
+    conservative default).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import time
+from typing import List, Protocol, Tuple
+
+# ---------------------------------------------------------------------------
+# Pinned identity (issue #458 requirements 1 & 2)
+# ---------------------------------------------------------------------------
+
+#: Judge model — PINNED. A silent swap breaks the "numbers line up with the
+#: published tables" contract, so a test asserts this exact string.
+JUDGE_MODEL = "gpt-4o-mini"
+
+#: Answer generator — also pinned to the judge model so the documented cost
+#: figures (both calls priced at gpt-4o-mini) stay valid. No override flag.
+GENERATION_MODEL = "gpt-4o-mini"
+
+#: Sampling temperature for both the generation and judge calls. Pinned to 0 so
+#: judged accuracy is reproducible run-to-run; recorded in the judge-identity
+#: block of the artifact.
+JUDGE_TEMPERATURE = 0
+
+#: System prompt for the judge, verbatim from the Mem0/GAM LoCoMo grader.
+JUDGE_SYSTEM_PROMPT = (
+    "You are an expert grader that determines if answers to questions match a "
+    "gold standard answer"
+)
+
+#: The Mem0 / GAM ``ACCURACY_PROMPT`` (LLM-as-a-Judge), reproduced VERBATIM from
+#: the published protocol (arXiv:2504.19413; Mem0 & MemTensor/MemOS evaluation
+#: harnesses). ``{question}``/``{gold_answer}``/``{generated_answer}`` are the
+#: only substitutions. Do NOT edit this text — the committed SHA-256 pin
+#: (asserted in test_judged.py) exists precisely to make any edit a loud failure,
+#: because judged accuracy is not comparable across prompt variants.
+LLM_JUDGE_PROMPT = """\
+Your task is to label an answer to a question as 'CORRECT' or 'WRONG'. You will be given the following data:
+    (1) a question (posed by one user to another user),
+    (2) a 'gold' (ground truth) answer,
+    (3) a generated answer
+which you will score as CORRECT/WRONG.
+
+The point of the question is to ask about something one user should know about the other user based on their prior conversations.
+The gold answer will usually be a concise and short answer that includes the referenced topic, for example:
+Question: Do you remember what I got the last time I went to Hawaii?
+Gold answer: A shell necklace
+The generated answer might be much longer, but you should be generous with your grading - as long as it touches on the same topic as the gold answer, it should be counted as CORRECT.
+
+For time related questions, the gold answer will be a specific date, month, year, etc. The generated answer might be much longer or use relative time references (like "last Tuesday" or "next month"), but you should be generous with your grading - as long as it refers to the same date or time period as the gold answer, it should be counted as CORRECT. Even if the format differs (e.g., "May 7th" vs "7 May"), consider it CORRECT if it's the same date.
+
+Now it's time for the real question:
+Question: {question}
+Gold answer: {gold_answer}
+Generated answer: {generated_answer}
+
+First, provide a short (one sentence) explanation of your reasoning, then finish with CORRECT or WRONG.
+Do NOT include both CORRECT and WRONG in your response, or it will break the evaluation script.
+
+Just return the label CORRECT or WRONG in a json format with the key as "label"."""
+
+#: Answer-generation prompt. Not part of the pinned *judge* protocol, but pinned
+#: here (and hashed into the artifact) for reproducibility. Instructs a grounded,
+#: concise answer from the retrieved memories, and to admit when the answer is
+#: not present — so unanswerable/adversarial items are not force-answered.
+ANSWER_GENERATION_PROMPT = """\
+You are a helpful assistant answering a question using ONLY the memories below, \
+which are excerpts retrieved from a user's prior conversations.
+
+Memories:
+{context}
+
+Question: {question}
+
+Answer the question as concisely as possible using only the information in the \
+memories. If the memories do not contain the information needed to answer, say \
+you do not have that information. Do not invent facts that are not supported by \
+the memories."""
+
+
+# ---------------------------------------------------------------------------
+# Prompt fingerprinting
+# ---------------------------------------------------------------------------
+
+
+def prompt_sha256(text: str) -> str:
+    """Return the hex SHA-256 of ``text``.
+
+    Used to fingerprint the exact judge / generation prompt in the committed
+    artifact so any future edit is visible as a hash change.
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Client protocol + OpenAI adapter (lazy import — no hard dependency)
+# ---------------------------------------------------------------------------
+
+
+class JudgeProtocol(Protocol):
+    """Minimal chat interface the harness needs from an LLM client.
+
+    Implemented by :class:`_OpenAIAdapter` for live runs and by a trivial fake in
+    tests, so no test requires ``openai`` or an API key.
+    """
+
+    def chat(self, model: str, messages: List[dict], temperature: float) -> str:
+        """Return the assistant message content for a chat completion."""
+        ...
+
+
+class _OpenAIAdapter:
+    """Adapts an ``openai.OpenAI`` client to :class:`JudgeProtocol`."""
+
+    def __init__(self, client) -> None:
+        self._client = client
+
+    def chat(self, model: str, messages: List[dict], temperature: float) -> str:
+        resp = self._client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+        )
+        return resp.choices[0].message.content or ""
+
+
+def is_judge_available() -> bool:
+    """True iff ``openai`` is importable AND ``OPENAI_API_KEY`` is set.
+
+    Mirrors hybrid's capability check: a missing key/library is a graceful skip,
+    not a failure.
+    """
+    if not os.environ.get("OPENAI_API_KEY"):
+        return False
+    try:
+        import openai  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def build_openai_client() -> JudgeProtocol:
+    """Construct a live OpenAI-backed :class:`JudgeProtocol`.
+
+    Lazily imports ``openai`` (optional extra) and reads ``OPENAI_API_KEY`` from
+    the environment. Call :func:`is_judge_available` first to skip gracefully.
+
+    Raises:
+        RuntimeError: If ``openai`` is not installed or no API key is set.
+    """
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise RuntimeError(
+            "OPENAI_API_KEY is not set — the judged harness needs an API key. "
+            "Set it or run without --judged."
+        )
+    try:
+        import openai
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise RuntimeError(
+            "openai is required for --judged runs. Install it with: "
+            "pip install -e '.[openai]'"
+        ) from exc
+    return _OpenAIAdapter(openai.OpenAI())
+
+
+# ---------------------------------------------------------------------------
+# Retry wrapper
+# ---------------------------------------------------------------------------
+
+
+def call_with_retry(
+    fn, *, attempts: int = 3, base_delay: float = 1.0, sleep=time.sleep
+):
+    """Call ``fn()`` with exponential backoff on transient failures.
+
+    A full LoCoMo judged run is ~4,000 serial API calls, so a transient
+    429/5xx/timeout is near-certain; retrying rather than aborting avoids a full
+    re-pay. Re-raises the last exception after ``attempts`` tries; the per-item
+    caller catches it and records a ``judge_error`` so one bad item never crashes
+    the run.
+
+    Args:
+        fn: Zero-arg callable performing the LLM call.
+        attempts: Max attempts (default 3).
+        base_delay: Base backoff seconds (doubled each retry).
+        sleep: Injectable sleep (tests pass a no-op).
+    """
+    last_exc = None
+    for i in range(attempts):
+        try:
+            return fn()
+        except Exception as exc:  # noqa: BLE001 - transient API errors are broad
+            last_exc = exc
+            if i < attempts - 1:
+                sleep(base_delay * (2**i))
+    raise last_exc
+
+
+# ---------------------------------------------------------------------------
+# Generation + judging
+# ---------------------------------------------------------------------------
+
+
+def generate_answer(
+    client: JudgeProtocol,
+    question: str,
+    context_texts: List[str],
+) -> str:
+    """Generate an answer to ``question`` grounded in ``context_texts``.
+
+    Uses the pinned :data:`GENERATION_MODEL` at :data:`JUDGE_TEMPERATURE`.
+
+    Args:
+        client: A :class:`JudgeProtocol` (live or fake).
+        question: The benchmark question.
+        context_texts: Retrieved memory texts, in rank order (top-k evidence).
+
+    Returns:
+        The generated answer string (stripped).
+    """
+    context = "\n".join(f"- {t}" for t in context_texts) if context_texts else "(none)"
+    prompt = ANSWER_GENERATION_PROMPT.format(context=context, question=question)
+    content = client.chat(
+        model=GENERATION_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=JUDGE_TEMPERATURE,
+    )
+    return (content or "").strip()
+
+
+def _parse_label(text: str) -> str:
+    """Parse a CORRECT/WRONG label from a judge response.
+
+    Follows the Mem0/GAM parser: prefer a trailing ``{"label": "VALUE"}`` JSON
+    object (single or double quoted), else fall back to a bare CORRECT/WRONG
+    token. Any ambiguity (both tokens present, neither present, unparseable)
+    normalizes to ``"WRONG"`` — the conservative default.
+
+    Returns:
+        Either ``"CORRECT"`` or ``"WRONG"``.
+    """
+    if not text:
+        return "WRONG"
+
+    # 1. Preferred: trailing {"label": "..."} JSON (matches the source harness's
+    #    extract_label_json regex; supports single/double quotes).
+    m = re.search(r'\{\s*"label"\s*:\s*["\']([^"\']*)["\']\s*\}', text)
+    if m:
+        label = m.group(1).strip().lower()
+        if label == "correct":
+            return "CORRECT"
+        return "WRONG"
+
+    # 2. Fallback: a bare, unambiguous CORRECT/WRONG token. If BOTH appear, the
+    #    protocol says the response is broken → WRONG.
+    upper = text.upper()
+    has_correct = re.search(r"\bCORRECT\b", upper) is not None
+    has_wrong = re.search(r"\bWRONG\b", upper) is not None
+    if has_correct and not has_wrong:
+        return "CORRECT"
+    return "WRONG"
+
+
+def judge_answer(
+    client: JudgeProtocol,
+    question: str,
+    gold_answer: str,
+    generated_answer: str,
+) -> Tuple[str, str]:
+    """Judge ``generated_answer`` against ``gold_answer`` via the Mem0/GAM prompt.
+
+    Uses the pinned :data:`JUDGE_MODEL` + :data:`LLM_JUDGE_PROMPT` at
+    :data:`JUDGE_TEMPERATURE`.
+
+    Args:
+        client: A :class:`JudgeProtocol` (live or fake).
+        question: The benchmark question.
+        gold_answer: The ground-truth answer.
+        generated_answer: The model's generated answer.
+
+    Returns:
+        ``(label, raw)`` where ``label`` is ``"CORRECT"`` or ``"WRONG"`` and
+        ``raw`` is the judge's full response text.
+    """
+    prompt = LLM_JUDGE_PROMPT.format(
+        question=question,
+        gold_answer=gold_answer,
+        generated_answer=generated_answer,
+    )
+    raw = client.chat(
+        model=JUDGE_MODEL,
+        messages=[
+            {"role": "system", "content": JUDGE_SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        temperature=JUDGE_TEMPERATURE,
+    )
+    return _parse_label(raw or ""), (raw or "")
+
+
+# ---------------------------------------------------------------------------
+# Cost estimation (documented before full runs — issue #458 requirement 5)
+# ---------------------------------------------------------------------------
+
+# gpt-4o-mini pricing (USD per 1M tokens), as of 2026-07. Assumption-based; the
+# estimate is documented, never presented as a measured Popoto result.
+_PRICE_INPUT_PER_1M = 0.15
+_PRICE_OUTPUT_PER_1M = 0.60
+# Rough per-call token assumptions: generation sees retrieved context (~1.5k in,
+# ~150 out); judge sees the prompt + both answers (~0.5k in, ~30 out).
+_GEN_INPUT_TOKENS = 1500
+_GEN_OUTPUT_TOKENS = 150
+_JUDGE_INPUT_TOKENS = 500
+_JUDGE_OUTPUT_TOKENS = 30
+
+
+def estimate_cost(n_items: int) -> dict:
+    """Estimate the USD cost of judging ``n_items`` (1 generation + 1 judge each).
+
+    Returns a dict with the per-item and total estimate plus the token/price
+    assumptions used, so the number is inspectable and clearly assumption-based.
+    """
+    in_tokens = _GEN_INPUT_TOKENS + _JUDGE_INPUT_TOKENS
+    out_tokens = _GEN_OUTPUT_TOKENS + _JUDGE_OUTPUT_TOKENS
+    per_item = (
+        in_tokens / 1_000_000 * _PRICE_INPUT_PER_1M
+        + out_tokens / 1_000_000 * _PRICE_OUTPUT_PER_1M
+    )
+    return {
+        "model": JUDGE_MODEL,
+        "n_items": n_items,
+        "calls_per_item": 2,
+        "usd_per_item": round(per_item, 6),
+        "usd_total_estimate": round(per_item * max(n_items, 0), 4),
+        "assumptions": {
+            "price_input_per_1m_usd": _PRICE_INPUT_PER_1M,
+            "price_output_per_1m_usd": _PRICE_OUTPUT_PER_1M,
+            "gen_input_tokens": _GEN_INPUT_TOKENS,
+            "gen_output_tokens": _GEN_OUTPUT_TOKENS,
+            "judge_input_tokens": _JUDGE_INPUT_TOKENS,
+            "judge_output_tokens": _JUDGE_OUTPUT_TOKENS,
+        },
+    }
+
+
+def judge_identity() -> dict:
+    """Return the pinned judge-identity block recorded in every judged artifact."""
+    return {
+        "protocol": "mem0/gam",
+        "protocol_ref": "arXiv:2504.19413",
+        "judge_model": JUDGE_MODEL,
+        "generation_model": GENERATION_MODEL,
+        "temperature": JUDGE_TEMPERATURE,
+        "judge_prompt_sha256": prompt_sha256(LLM_JUDGE_PROMPT),
+        "generation_prompt_sha256": prompt_sha256(ANSWER_GENERATION_PROMPT),
+    }

--- a/tests/benchmarks/run_external.py
+++ b/tests/benchmarks/run_external.py
@@ -54,6 +54,7 @@ from tests.benchmarks.metrics.retrieval import (
     recall_at_k,
 )
 from tests.benchmarks.scenarios.external_base import ExternalScenario
+from tests.benchmarks import judge as judge_mod
 
 logging.basicConfig(
     level=logging.INFO,
@@ -460,6 +461,143 @@ def compute_aggregate(
 
 
 # ---------------------------------------------------------------------------
+# Judged-answer stage (Tier 5, issue #458)
+# ---------------------------------------------------------------------------
+
+
+def _is_adversarial(item: BenchmarkItem) -> bool:
+    """True if ``item`` is a LoCoMo adversarial (cat-5) / unanswerable question.
+
+    Adversarial items test *refusal*, which the verbatim Mem0/GAM factual-match
+    judge cannot score meaningfully, so they are excluded from the headline
+    judged accuracy and reported separately (a dedicated refusal metric is #454).
+    """
+    md = item.metadata or {}
+    if md.get("adversarial"):
+        return True
+    return md.get("question_type") in (5, "5")
+
+
+def judge_one(
+    item: BenchmarkItem,
+    q_result: "QuestionResult",
+    client,
+    retry_sleep=time.sleep,
+) -> dict:
+    """Generate an answer for ``item`` from its retrieved memories, then judge it.
+
+    Gated by the caller on ``q_result.status == "ok"``. Each LLM call retries with
+    backoff; a final failure is captured as ``judge_status == "judge_error"`` so a
+    single transient error never crashes the run.
+
+    Returns:
+        A per-item judged-result dict.
+    """
+    context_texts = q_result.metadata.get("retrieved_contents", []) or []
+    gold = (item.metadata or {}).get("answer", "") or ""
+    question = item.query
+    adversarial = _is_adversarial(item)
+    base = {
+        "item_id": item.item_id,
+        "question_type": q_result.metadata.get("question_type", ""),
+        "adversarial": adversarial,
+    }
+    try:
+        generated = judge_mod.call_with_retry(
+            lambda: judge_mod.generate_answer(client, question, context_texts),
+            sleep=retry_sleep,
+        )
+        label, raw = judge_mod.call_with_retry(
+            lambda: judge_mod.judge_answer(client, question, gold, generated),
+            sleep=retry_sleep,
+        )
+        base.update(
+            {
+                "generated_answer": generated,
+                "judge_label": label,
+                "judge_status": "ok",
+            }
+        )
+    except Exception as exc:  # noqa: BLE001 - captured per-item, not fatal
+        base.update(
+            {
+                "generated_answer": "",
+                "judge_label": "",
+                "judge_status": "judge_error",
+                "judge_error": str(exc),
+            }
+        )
+    return base
+
+
+def _judged_by_question_type(scored: list) -> dict:
+    """Per-``question_type`` judged-accuracy breakdown over scored (non-adversarial,
+    non-error) judged results."""
+    groups: dict = {}
+    for r in scored:
+        qt = r.get("question_type") or "(unlabeled)"
+        groups.setdefault(str(qt), []).append(r)
+    out: dict = {}
+    for qt in sorted(groups, key=str):
+        rs = groups[qt]
+        n_correct = sum(1 for r in rs if r["judge_label"] == "CORRECT")
+        out[qt] = {
+            "n": len(rs),
+            "n_correct": n_correct,
+            "judged_accuracy": round(n_correct / len(rs), 4) if rs else 0.0,
+        }
+    return out
+
+
+def compute_judged_block(judged_results: list, n_total: int) -> dict:
+    """Aggregate per-item judged results into the artifact's ``judged`` block.
+
+    The headline ``judged_accuracy`` is computed over **scored** items only —
+    excluding judge errors, skipped (non-ok retrieval) items, AND adversarial
+    (cat-5) items, whose refusal semantics the factual-match judge cannot score.
+    Adversarial items are reported separately under ``adversarial``.
+
+    Args:
+        judged_results: Per-item dicts from :func:`judge_one` (ok items only).
+        n_total: Total items in the run (for the skipped count).
+
+    Returns:
+        The ``judged`` aggregate block.
+    """
+    errors = [r for r in judged_results if r["judge_status"] == "judge_error"]
+    ok = [r for r in judged_results if r["judge_status"] == "ok"]
+    adversarial = [r for r in ok if r["adversarial"]]
+    scored = [r for r in ok if not r["adversarial"]]
+
+    n_correct = sum(1 for r in scored if r["judge_label"] == "CORRECT")
+    n_scored = len(scored)
+    adv_correct = sum(1 for r in adversarial if r["judge_label"] == "CORRECT")
+
+    return {
+        "n_total": n_total,
+        "n_judged": len(judged_results),
+        "n_judged_skipped": n_total - len(judged_results),
+        "n_judge_errors": len(errors),
+        "n_adversarial_excluded": len(adversarial),
+        "n_scored": n_scored,
+        "n_correct": n_correct,
+        # Headline: excludes errors, skips, and adversarial items.
+        "judged_accuracy": round(n_correct / n_scored, 4) if n_scored else 0.0,
+        "by_question_type": _judged_by_question_type(scored),
+        "adversarial": {
+            "n": len(adversarial),
+            "n_correct": adv_correct,
+            "note": (
+                "Adversarial (cat-5) items test refusal; the factual-match "
+                "Mem0/GAM judge cannot score them meaningfully. Reported for "
+                "transparency only, EXCLUDED from judged_accuracy. Refusal "
+                "metric tracked in #454."
+            ),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
 # Report generation
 # ---------------------------------------------------------------------------
 
@@ -550,6 +688,57 @@ def build_markdown_report(aggregate: dict) -> str:
         )
         lines.append("")
 
+    judged = aggregate.get("judged")
+    if judged:
+        judge_id = aggregate.get("judge", {})
+        lines.append("## Judged Answer Accuracy (end-to-end)")
+        lines.append("")
+        lines.append(
+            "> These are a **different metric family** from the retrieval recall "
+            "above (retrieve→generate→LLM-judge). Retrieval recall and judged "
+            "accuracy are reported side by side but MUST NOT be cross-compared or "
+            "combined into a single ranking (#453)."
+        )
+        lines.append("")
+        lines.append(
+            f"**Judge:** `{judge_id.get('judge_model')}` · "
+            f"**Generator:** `{judge_id.get('generation_model')}` · "
+            f"**Protocol:** {judge_id.get('protocol')} "
+            f"({judge_id.get('protocol_ref')}) · "
+            f"**temperature:** {judge_id.get('temperature')}  "
+        )
+        lines.append(
+            f"**Judge prompt SHA-256:** `{judge_id.get('judge_prompt_sha256', '')[:16]}…`  "
+        )
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Judged accuracy | {judged['judged_accuracy']:.4f} |")
+        lines.append(f"| Scored (CORRECT+WRONG) | {judged['n_scored']} |")
+        lines.append(f"| Correct | {judged['n_correct']} |")
+        lines.append(f"| Judge errors | {judged['n_judge_errors']} |")
+        lines.append(f"| Skipped (retrieval not ok) | {judged['n_judged_skipped']} |")
+        lines.append(f"| Adversarial excluded | {judged['n_adversarial_excluded']} |")
+        lines.append("")
+        jbqt = judged.get("by_question_type", {})
+        if jbqt:
+            lines.append("### Judged accuracy by question_type")
+            lines.append("")
+            lines.append("| question_type | n | Correct | Judged accuracy |")
+            lines.append("|---|---|---|---|")
+            for qt, m in jbqt.items():
+                lines.append(
+                    f"| {qt} | {m['n']} | {m['n_correct']} | "
+                    f"{m['judged_accuracy']:.4f} |"
+                )
+            lines.append("")
+        adv = judged.get("adversarial", {})
+        lines.append(
+            f"_Adversarial (cat-5): {adv.get('n', 0)} items, excluded from the "
+            f"headline number. {adv.get('note', '')}_"
+        )
+        lines.append("")
+
     lines += [
         "## Notes",
         "",
@@ -595,6 +784,7 @@ def save_reports(
     dataset_slug: str,
     retrieval_mode: str = "lexical",
     dry_run: bool = False,
+    judged: bool = False,
 ) -> tuple[Path, Path]:
     """Save JSON and Markdown report files.
 
@@ -620,9 +810,13 @@ def save_reports(
 
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Lexical keeps the unsuffixed baseline names; any other mode is suffixed so
-    # it cannot clobber the committed lexical artifacts.
-    suffix = "" if retrieval_mode == "lexical" else f"_{retrieval_mode}"
+    # Two independent suffix dimensions are composed so no combination clobbers
+    # another (issue #458): retrieval mode (lexical keeps the unsuffixed baseline
+    # name; hybrid/vector add ``_{mode}``) AND the judged stage (adds ``_judged``).
+    # e.g. hybrid+judged -> ``{slug}_{date}_hybrid_judged.*``.
+    mode_suffix = "" if retrieval_mode == "lexical" else f"_{retrieval_mode}"
+    judged_suffix = "_judged" if judged else ""
+    suffix = f"{mode_suffix}{judged_suffix}"
 
     date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
     json_name = f"{dataset_slug}_{date_str}{suffix}.json"
@@ -733,7 +927,37 @@ def main():
         default=0.10,
         help="Exit with code 1 if error rate exceeds this fraction (default: 0.10)",
     )
+    parser.add_argument(
+        "--judged",
+        action="store_true",
+        help=(
+            "Run the end-to-end judged-answer stage (Tier 5, #458): "
+            "retrieve -> generate -> LLM-judge with a PINNED gpt-4o-mini judge "
+            "(Mem0/GAM protocol). Requires OPENAI_API_KEY + the [openai] extra; "
+            "skips gracefully without them. Supported for lexical/hybrid only. "
+            "Writes {slug}_{date}[_mode]_judged.{json,md}."
+        ),
+    )
+    parser.add_argument(
+        "--judge-error-threshold",
+        type=float,
+        default=0.25,
+        help=(
+            "With --judged, exit code 1 if the judge-error rate (transient API "
+            "failures) exceeds this fraction (default: 0.25). Independent of "
+            "--error-threshold, which governs retrieval errors."
+        ),
+    )
     args = parser.parse_args()
+
+    # Judged mode is a factual-match judge over retrieved *content*; the vector
+    # diagnostic path holds no hydrated content, so reject it up front (#458).
+    if args.judged and args.retrieval_mode == "vector":
+        logger.error(
+            "--judged is not supported with --retrieval-mode vector (the vector "
+            "path returns no memory text to answer from). Use lexical or hybrid."
+        )
+        return 1
 
     global RESULTS_DIR
     if args.output:
@@ -788,8 +1012,40 @@ def main():
         bench_db,
     )
 
+    # Judged stage: build the (pinned) judge client up front, or skip gracefully
+    # if no API key / openai — a missing key is NOT a failure (#458 requirement 5,
+    # mirroring hybrid's model-download posture).
+    judge_client = None
+    if args.judged:
+        est = judge_mod.estimate_cost(args.limit or 0)
+        if not judge_mod.is_judge_available():
+            print("\n" + "=" * 60)
+            print("JUDGED STAGE SKIPPED — no OPENAI_API_KEY / openai not installed")
+            print("=" * 60)
+            print(
+                "  The judged harness needs an API key (retrieve->generate->"
+                "LLM-judge)."
+            )
+            print(
+                f"  Estimated cost if run: ~${est['usd_total_estimate']} "
+                f"(~${est['usd_per_item']}/item, 2 gpt-4o-mini calls/item)."
+            )
+            print("  Set OPENAI_API_KEY and `pip install -e '.[openai]'` to run.")
+            print("=" * 60)
+            return 0
+        logger.info(
+            "Judged stage ON: pinned judge=%s generator=%s. Est. cost ~$%s "
+            "(~$%s/item).",
+            judge_mod.JUDGE_MODEL,
+            judge_mod.GENERATION_MODEL,
+            est["usd_total_estimate"],
+            est["usd_per_item"],
+        )
+        judge_client = judge_mod.build_openai_client()
+
     total_start = time.monotonic()
     results = []
+    judged_results = []
     n_processed = 0
 
     for item in items:
@@ -804,6 +1060,12 @@ def main():
 
         q_result = run_item(item, retrieval_mode=args.retrieval_mode)
         results.append(q_result)
+
+        # Judged stage — only for ok retrievals (non-ok / skipped-empty items
+        # have no retrieved content to answer from; they are counted as
+        # judged-skipped by compute_judged_block via n_total - n_judged).
+        if judge_client is not None and q_result.status == "ok":
+            judged_results.append(judge_one(item, q_result, judge_client))
 
         if q_result.status == "ok":
             logger.debug(
@@ -837,6 +1099,25 @@ def main():
     )
     s = aggregate["summary"]
 
+    # Attach judged block + judge identity, and merge per-item judged fields into
+    # the retrieval question detail so recall and judged accuracy sit side by side
+    # in the artifact (never fused into one ranking — #453).
+    judged_block = None
+    if args.judged:
+        judged_block = compute_judged_block(judged_results, s["n_total"])
+        aggregate["judge"] = judge_mod.judge_identity()
+        aggregate["judged"] = judged_block
+        by_item = {r["item_id"]: r for r in judged_results}
+        for q in aggregate["questions"]:
+            jr = by_item.get(q["item_id"])
+            if jr:
+                q["judged"] = {
+                    "judge_label": jr.get("judge_label", ""),
+                    "judge_status": jr.get("judge_status", ""),
+                    "adversarial": jr.get("adversarial", False),
+                    "generated_answer": jr.get("generated_answer", ""),
+                }
+
     # Print summary table
     print("\n" + "=" * 60)
     print(f"BENCHMARK RESULTS: {args.dataset.upper()}")
@@ -850,6 +1131,17 @@ def main():
     print(f"  MRR                 : {s['mrr']:.4f}")
     print(f"  Latency p50 (ms)    : {s['p50_ms']}")
     print(f"  Latency p95 (ms)    : {s['p95_ms']}")
+    if judged_block is not None:
+        print("  " + "-" * 56)
+        print("  JUDGED ANSWER ACCURACY (separate metric family — do not")
+        print("  cross-compare with retrieval recall above, #453):")
+        print(f"    Judged accuracy   : {judged_block['judged_accuracy']:.4f}")
+        print(
+            f"    Scored / Correct  : {judged_block['n_scored']} / "
+            f"{judged_block['n_correct']}"
+        )
+        print(f"    Judge errors      : {judged_block['n_judge_errors']}")
+        print(f"    Adversarial excl. : {judged_block['n_adversarial_excluded']}")
     print("=" * 60)
 
     # Save reports
@@ -859,6 +1151,7 @@ def main():
             dataset_slug,
             retrieval_mode=args.retrieval_mode,
             dry_run=False,
+            judged=args.judged,
         )
         print(f"\nReports saved:")
         print(f"  JSON: {json_path}")
@@ -872,6 +1165,19 @@ def main():
                 "Error rate %.1f%% exceeds threshold %.1f%% — exiting with code 1",
                 error_rate * 100,
                 args.error_threshold * 100,
+            )
+            return 1
+
+    # Judge-error threshold is independent of the retrieval error gate: a paid
+    # judged run tripping on transient API flakiness shouldn't masquerade as a
+    # retrieval failure (or vice versa).
+    if judged_block is not None and judged_block["n_judged"] > 0:
+        judge_error_rate = judged_block["n_judge_errors"] / judged_block["n_judged"]
+        if judge_error_rate > args.judge_error_threshold:
+            logger.error(
+                "Judge-error rate %.1f%% exceeds threshold %.1f%% — exiting 1",
+                judge_error_rate * 100,
+                args.judge_error_threshold * 100,
             )
             return 1
 

--- a/tests/benchmarks/run_external.py
+++ b/tests/benchmarks/run_external.py
@@ -1026,7 +1026,7 @@ def main():
     judge_client = None
     if args.judged:
         # Size the estimate by --limit, or the dataset's full size when unlimited
-        # (so a full run shows the real ~$1.4, not ~$0).
+        # (so a full run shows the real ~$0.8, not ~$0).
         n_for_estimate = args.limit or DATASET_FULL_SIZE.get(args.dataset, 0)
         est = judge_mod.estimate_cost(n_for_estimate)
         if not judge_mod.is_judge_available():

--- a/tests/benchmarks/run_external.py
+++ b/tests/benchmarks/run_external.py
@@ -67,6 +67,13 @@ RESULTS_DIR = Path(__file__).parent / "results" / "external"
 
 DATASET_CHOICES = ("longmemeval-s", "locomo")
 
+# Full-dataset question counts, used only to size the judged-run cost estimate
+# when ``--limit`` is not given (otherwise the estimate would read ~$0 on exactly
+# the full run where cost matters most). These are the canonical dataset sizes;
+# the actual judged count can be lower (skipped/empty items), so the estimate is
+# an upper bound, which is the safe direction for a cost warning.
+DATASET_FULL_SIZE = {"longmemeval-s": 500, "locomo": 1986}
+
 # ---------------------------------------------------------------------------
 # Benchmark DB isolation (issue #465)
 # ---------------------------------------------------------------------------
@@ -470,7 +477,8 @@ def _is_adversarial(item: BenchmarkItem) -> bool:
 
     Adversarial items test *refusal*, which the verbatim Mem0/GAM factual-match
     judge cannot score meaningfully, so they are excluded from the headline
-    judged accuracy and reported separately (a dedicated refusal metric is #454).
+    judged accuracy and reported separately (a dedicated refusal metric is #463;
+    the cat-5 scoring audit that recommended it was #454).
     """
     md = item.metadata or {}
     if md.get("adversarial"):
@@ -591,7 +599,7 @@ def compute_judged_block(judged_results: list, n_total: int) -> dict:
                 "Adversarial (cat-5) items test refusal; the factual-match "
                 "Mem0/GAM judge cannot score them meaningfully. Reported for "
                 "transparency only, EXCLUDED from judged_accuracy. Refusal "
-                "metric tracked in #454."
+                "metric tracked in #463."
             ),
         },
     }
@@ -1017,7 +1025,10 @@ def main():
     # mirroring hybrid's model-download posture).
     judge_client = None
     if args.judged:
-        est = judge_mod.estimate_cost(args.limit or 0)
+        # Size the estimate by --limit, or the dataset's full size when unlimited
+        # (so a full run shows the real ~$1.4, not ~$0).
+        n_for_estimate = args.limit or DATASET_FULL_SIZE.get(args.dataset, 0)
+        est = judge_mod.estimate_cost(n_for_estimate)
         if not judge_mod.is_judge_available():
             print("\n" + "=" * 60)
             print("JUDGED STAGE SKIPPED — no OPENAI_API_KEY / openai not installed")

--- a/tests/benchmarks/scenarios/external_base.py
+++ b/tests/benchmarks/scenarios/external_base.py
@@ -357,6 +357,11 @@ class ExternalScenario(Scenario):
         t0 = time.monotonic()
 
         retrieved_keys: List[str] = []
+        # Retrieved memory texts in rank order — consumed by the judged-answer
+        # stage (#458). Only populated on the assembler path, where records carry
+        # `.content`; the vector path holds only (redis_key, cosine) pairs and
+        # judged mode rejects vector up front, so it is left empty there.
+        retrieved_contents: List[str] = []
         if self.retrieval_mode == "vector":
             # Vector-only diagnostic: pure cosine over the EmbeddingField, no
             # ContextAssembler. _get_vector_scores() returns (redis_key, cosine)
@@ -390,6 +395,8 @@ class ExternalScenario(Scenario):
                         retrieved_keys.append(record.db_key.redis_key)
                     except Exception:
                         retrieved_keys.append(str(id(record)))
+                    # Capture the record text (rank order) for the judged stage.
+                    retrieved_contents.append(getattr(record, "content", "") or "")
             except Exception as e:
                 return ScenarioResult(
                     scenario_name=self.name,
@@ -441,6 +448,7 @@ class ExternalScenario(Scenario):
                 "dataset": self.item.metadata.get("dataset", "unknown"),
                 "question_type": self.item.metadata.get("question_type", ""),
                 "retrieval_method": retrieval_method,
+                "retrieved_contents": retrieved_contents,
             },
         )
 

--- a/tests/benchmarks/test_judged.py
+++ b/tests/benchmarks/test_judged.py
@@ -1,0 +1,440 @@
+"""Tests for the end-to-end judged-answer harness (Tier 5, issue #458).
+
+Every test runs with **no ``openai`` and no API key**: the LLM client is a
+:class:`FakeClient` injected via the :class:`JudgeProtocol` seam, and
+``is_judge_available`` / ``build_openai_client`` are monkeypatched for the
+``main()`` end-to-end cases. The default suite therefore never reaches out to an
+external API.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tests.benchmarks import judge as judge_mod
+from tests.benchmarks import run_external as R
+from tests.benchmarks.datasets import BenchmarkItem
+
+FIXTURE = Path(__file__).parent / "datasets" / "fixtures" / "locomo_sample.json"
+
+# Committed pins — a change to either is a loud failure (that's the point).
+EXPECTED_JUDGE_PROMPT_SHA256 = (
+    "cb44a52ee9ba372f0ec81c3dd0a6d49190da808fef56760e3424592bd146340d"
+)
+
+
+class FakeClient:
+    """A JudgeProtocol fake. Discriminates generation vs judge calls by the
+    presence of a system message (only the judge call has one), and records every
+    call for assertions."""
+
+    def __init__(self, gen_answer="a shell necklace", judge_label="CORRECT"):
+        self.gen_answer = gen_answer
+        self.judge_label = judge_label
+        self.calls = []
+
+    def chat(self, model, messages, temperature):
+        self.calls.append(
+            {"model": model, "messages": messages, "temperature": temperature}
+        )
+        is_judge = any(m["role"] == "system" for m in messages)
+        if is_judge:
+            return f'Reasoning here. {{"label": "{self.judge_label}"}}'
+        return self.gen_answer
+
+
+# ---------------------------------------------------------------------------
+# Pins (requirements 1 & 2)
+# ---------------------------------------------------------------------------
+
+
+def test_judge_model_is_pinned_gpt4o_mini():
+    assert judge_mod.JUDGE_MODEL == "gpt-4o-mini"
+
+
+def test_generation_model_is_pinned_gpt4o_mini():
+    # Generator is also pinned so the documented cost figures stay valid.
+    assert judge_mod.GENERATION_MODEL == "gpt-4o-mini"
+
+
+def test_temperature_pinned_zero():
+    assert judge_mod.JUDGE_TEMPERATURE == 0
+
+
+def test_judge_prompt_hash_is_pinned():
+    # Guards against silent prompt drift — judged accuracy is not comparable
+    # across prompt variants.
+    assert judge_mod.prompt_sha256(judge_mod.LLM_JUDGE_PROMPT) == (
+        EXPECTED_JUDGE_PROMPT_SHA256
+    )
+
+
+def test_judge_prompt_is_the_mem0_gam_protocol():
+    p = judge_mod.LLM_JUDGE_PROMPT
+    # Signature phrasing from the verbatim Mem0/GAM ACCURACY_PROMPT.
+    assert "label an answer to a question as 'CORRECT' or 'WRONG'" in p
+    assert "Do you remember what I got the last time I went to Hawaii?" in p
+    assert 'json format with the key as "label"' in p
+    assert "{question}" in p and "{gold_answer}" in p and "{generated_answer}" in p
+
+
+def test_identity_block_records_judge_provenance():
+    ident = judge_mod.judge_identity()
+    assert ident["judge_model"] == "gpt-4o-mini"
+    assert ident["generation_model"] == "gpt-4o-mini"
+    assert ident["temperature"] == 0
+    assert ident["protocol"] == "mem0/gam"
+    assert ident["protocol_ref"] == "arXiv:2504.19413"
+    assert ident["judge_prompt_sha256"] == EXPECTED_JUDGE_PROMPT_SHA256
+
+
+# ---------------------------------------------------------------------------
+# Judge response parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ('{"label": "CORRECT"}', "CORRECT"),
+        ('{"label": "WRONG"}', "WRONG"),
+        ("{'label': 'correct'}", "CORRECT"),  # single quotes, lowercase
+        ('Because it matches. {"label": "CORRECT"}', "CORRECT"),
+        ("The answer is CORRECT", "CORRECT"),  # bare token fallback
+        ("Nope, WRONG.", "WRONG"),
+        ("Includes both CORRECT and WRONG somehow", "WRONG"),  # ambiguous -> WRONG
+        ("total gibberish", "WRONG"),  # unparseable -> WRONG
+        ("", "WRONG"),  # empty -> WRONG
+    ],
+)
+def test_parse_label(text, expected):
+    assert judge_mod._parse_label(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# Generation + judging with the fake
+# ---------------------------------------------------------------------------
+
+
+def test_generate_answer_uses_pinned_model_and_context():
+    client = FakeClient(gen_answer="the answer")
+    out = judge_mod.generate_answer(client, "What did I buy?", ["bought a necklace"])
+    assert out == "the answer"
+    call = client.calls[0]
+    assert call["model"] == "gpt-4o-mini"
+    assert call["temperature"] == 0
+    assert "bought a necklace" in call["messages"][0]["content"]
+    assert "What did I buy?" in call["messages"][0]["content"]
+
+
+def test_judge_answer_uses_pinned_model_and_temperature():
+    client = FakeClient(judge_label="CORRECT")
+    label, raw = judge_mod.judge_answer(client, "Q?", "gold", "generated")
+    assert label == "CORRECT"
+    assert "CORRECT" in raw
+    call = client.calls[0]
+    assert call["model"] == "gpt-4o-mini"
+    assert call["temperature"] == 0
+    # judge call carries a system message; gold+generated are interpolated.
+    assert call["messages"][0]["role"] == "system"
+    assert "gold" in call["messages"][1]["content"]
+    assert "generated" in call["messages"][1]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Availability gating
+# ---------------------------------------------------------------------------
+
+
+def test_is_judge_available_false_without_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert judge_mod.is_judge_available() is False
+
+
+def test_is_judge_available_false_without_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "openai":
+            raise ImportError("no openai")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert judge_mod.is_judge_available() is False
+
+
+def test_build_openai_client_raises_without_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        judge_mod.build_openai_client()
+
+
+# ---------------------------------------------------------------------------
+# Retry / fault isolation (blocker B3)
+# ---------------------------------------------------------------------------
+
+
+def test_call_with_retry_recovers_after_transient_failures():
+    attempts = {"n": 0}
+
+    def flaky():
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise RuntimeError("429")
+        return "ok"
+
+    out = judge_mod.call_with_retry(flaky, attempts=3, sleep=lambda _s: None)
+    assert out == "ok"
+    assert attempts["n"] == 3
+
+
+def test_call_with_retry_reraises_after_exhaustion():
+    def always_fail():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        judge_mod.call_with_retry(always_fail, attempts=2, sleep=lambda _s: None)
+
+
+# ---------------------------------------------------------------------------
+# judge_one — per-item generate+judge
+# ---------------------------------------------------------------------------
+
+
+def _mk_qresult(retrieved_contents, question_type=1):
+    return R.QuestionResult(
+        item_id="i1",
+        recall_at_1=1.0,
+        recall_at_5=1.0,
+        recall_at_10=1.0,
+        mrr=1.0,
+        retrieval_ms=1.0,
+        status="ok",
+        metadata={
+            "retrieved_contents": retrieved_contents,
+            "question_type": question_type,
+        },
+    )
+
+
+def _mk_item(item_id="i1", answer="a shell necklace", adversarial=False, qt=1):
+    md = {"answer": answer, "question_type": qt, "dataset": "locomo"}
+    if adversarial:
+        md["adversarial"] = True
+    return BenchmarkItem(
+        item_id=item_id,
+        history=[],
+        query="What did I buy in Hawaii?",
+        relevant_ids={"x"},
+        metadata=md,
+    )
+
+
+def test_judge_one_ok():
+    client = FakeClient(gen_answer="a shell necklace", judge_label="CORRECT")
+    out = R.judge_one(_mk_item(), _mk_qresult(["I bought a shell necklace"]), client)
+    assert out["judge_status"] == "ok"
+    assert out["judge_label"] == "CORRECT"
+    assert out["generated_answer"] == "a shell necklace"
+    assert out["adversarial"] is False
+
+
+def test_judge_one_records_error_without_crashing():
+    class BoomClient:
+        def chat(self, model, messages, temperature):
+            raise RuntimeError("api down")
+
+    out = R.judge_one(
+        _mk_item(),
+        _mk_qresult(["ctx"]),
+        BoomClient(),
+        retry_sleep=lambda _s: None,
+    )
+    assert out["judge_status"] == "judge_error"
+    assert out["judge_label"] == ""
+    assert "api down" in out["judge_error"]
+
+
+def test_judge_one_detects_adversarial():
+    client = FakeClient()
+    out = R.judge_one(
+        _mk_item(adversarial=True, qt=5),
+        _mk_qresult(["ctx"], question_type=5),
+        client,
+    )
+    assert out["adversarial"] is True
+
+
+# ---------------------------------------------------------------------------
+# compute_judged_block — aggregation, adversarial exclusion (concern C4)
+# ---------------------------------------------------------------------------
+
+
+def _jr(item_id, label, status="ok", adversarial=False, qt=1):
+    return {
+        "item_id": item_id,
+        "question_type": qt,
+        "adversarial": adversarial,
+        "judge_label": label,
+        "judge_status": status,
+        "generated_answer": "x",
+    }
+
+
+def test_compute_judged_block_excludes_adversarial_and_errors():
+    judged = [
+        _jr("a", "CORRECT"),
+        _jr("b", "WRONG"),
+        _jr("c", "CORRECT"),
+        _jr("d", "CORRECT", adversarial=True, qt=5),  # excluded from headline
+        _jr("e", "", status="judge_error"),  # excluded from headline
+    ]
+    block = R.compute_judged_block(judged, n_total=6)
+    # scored = a,b,c -> 2 correct / 3 = 0.6667
+    assert block["n_scored"] == 3
+    assert block["n_correct"] == 2
+    assert block["judged_accuracy"] == pytest.approx(0.6667, abs=1e-4)
+    assert block["n_judge_errors"] == 1
+    assert block["n_adversarial_excluded"] == 1
+    # one item never judged (n_total=6, judged=5)
+    assert block["n_judged_skipped"] == 1
+    # adversarial reported separately, not folded into headline
+    assert block["adversarial"]["n"] == 1
+    assert block["adversarial"]["n_correct"] == 1
+    assert "#454" in block["adversarial"]["note"]
+
+
+def test_compute_judged_block_by_question_type():
+    judged = [
+        _jr("a", "CORRECT", qt=1),
+        _jr("b", "WRONG", qt=1),
+        _jr("c", "CORRECT", qt=2),
+    ]
+    block = R.compute_judged_block(judged, n_total=3)
+    bqt = block["by_question_type"]
+    assert bqt["1"]["n"] == 2 and bqt["1"]["n_correct"] == 1
+    assert bqt["2"]["judged_accuracy"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Artifact suffix composition (blocker B1)
+# ---------------------------------------------------------------------------
+
+
+def _minimal_judged_aggregate():
+    agg = R.compute_aggregate([], "locomo", retrieval_mode="lexical")
+    agg["judge"] = judge_mod.judge_identity()
+    agg["judged"] = R.compute_judged_block([_jr("a", "CORRECT")], n_total=1)
+    return agg
+
+
+def test_save_reports_lexical_judged_suffix(tmp_path, monkeypatch):
+    monkeypatch.setattr(R, "RESULTS_DIR", tmp_path)
+    jp, mp = R.save_reports(
+        _minimal_judged_aggregate(), "locomo", retrieval_mode="lexical", judged=True
+    )
+    assert jp.name.endswith("_judged.json")
+    assert "_hybrid" not in jp.name
+    assert (tmp_path / "locomo_latest_judged.json").exists()
+
+
+def test_save_reports_hybrid_judged_suffix_no_collision(tmp_path, monkeypatch):
+    monkeypatch.setattr(R, "RESULTS_DIR", tmp_path)
+    agg = _minimal_judged_aggregate()
+    agg["retrieval_mode"] = "hybrid"
+    jp, mp = R.save_reports(agg, "locomo", retrieval_mode="hybrid", judged=True)
+    # Composite suffix: must be _hybrid_judged, never plain _judged (which would
+    # clobber the lexical-judged artifact) or plain _hybrid (retrieval artifact).
+    assert jp.name.endswith("_hybrid_judged.json")
+    assert (tmp_path / "locomo_latest_hybrid_judged.json").exists()
+    # The lexical-judged and plain-hybrid names are untouched.
+    assert not (tmp_path / "locomo_latest_judged.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Markdown report — two separate metric families (concern / #453)
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_reports_families_separately():
+    md = R.build_markdown_report(_minimal_judged_aggregate())
+    assert "## Summary" in md  # retrieval recall table
+    assert "## Judged Answer Accuracy" in md  # judged table
+    assert "MUST NOT be cross-compared" in md
+    assert "gpt-4o-mini" in md
+
+
+# ---------------------------------------------------------------------------
+# main() — CLI-level behaviors
+# ---------------------------------------------------------------------------
+
+
+def _run_main(monkeypatch, argv):
+    monkeypatch.setattr("sys.argv", ["run_external"] + argv)
+    return R.main()
+
+
+def test_main_rejects_vector_judged(monkeypatch):
+    rc = _run_main(
+        monkeypatch,
+        ["--dataset", "locomo", "--retrieval-mode", "vector", "--judged"],
+    )
+    assert rc == 1
+
+
+def test_main_judged_graceful_skip_without_key(monkeypatch, tmp_path):
+    monkeypatch.setattr(judge_mod, "is_judge_available", lambda: False)
+    rc = _run_main(
+        monkeypatch,
+        [
+            "--dataset",
+            "locomo",
+            "--judged",
+            "--fixture",
+            str(FIXTURE),
+            "--limit",
+            "2",
+            "--output",
+            str(tmp_path),
+        ],
+    )
+    assert rc == 0
+    # No artifacts written on graceful skip.
+    assert list(tmp_path.glob("*_judged.*")) == []
+
+
+def test_main_judged_end_to_end_mocked(monkeypatch, tmp_path):
+    monkeypatch.setattr(judge_mod, "is_judge_available", lambda: True)
+    fake = FakeClient(gen_answer="a shell necklace", judge_label="CORRECT")
+    monkeypatch.setattr(judge_mod, "build_openai_client", lambda: fake)
+    rc = _run_main(
+        monkeypatch,
+        [
+            "--dataset",
+            "locomo",
+            "--judged",
+            "--fixture",
+            str(FIXTURE),
+            "--limit",
+            "3",
+            "--output",
+            str(tmp_path),
+        ],
+    )
+    assert rc == 0
+    judged_jsons = list(tmp_path.glob("locomo_*_judged.json"))
+    assert judged_jsons, "expected a _judged.json artifact"
+    import json
+
+    data = json.loads((tmp_path / "locomo_latest_judged.json").read_text())
+    # Both metric families present, side by side, in separate blocks.
+    assert "summary" in data  # retrieval recall
+    assert "judged" in data  # judged accuracy
+    assert data["judge"]["judge_model"] == "gpt-4o-mini"
+    assert data["judge"]["judge_prompt_sha256"] == EXPECTED_JUDGE_PROMPT_SHA256
+    # At least one item got judged, and generation actually ran through the fake.
+    assert data["judged"]["n_judged"] >= 1
+    assert fake.calls, "fake client should have been called"

--- a/tests/benchmarks/test_judged.py
+++ b/tests/benchmarks/test_judged.py
@@ -304,7 +304,7 @@ def test_compute_judged_block_excludes_adversarial_and_errors():
     # adversarial reported separately, not folded into headline
     assert block["adversarial"]["n"] == 1
     assert block["adversarial"]["n_correct"] == 1
-    assert "#454" in block["adversarial"]["note"]
+    assert "#463" in block["adversarial"]["note"]
 
 
 def test_compute_judged_block_by_question_type():


### PR DESCRIPTION
Closes #458. Part of #456 (Track A), strategy §1.2.

## What

Adds the **retrieve → generate → LLM-judge** stage the external benchmark harness deliberately stopped before, so Popoto is comparable to the published judged-accuracy leaderboards (Hindsight, Mem0, Zep, Memori, Backboard) — while staying honest about metric families.

### New: `tests/benchmarks/judge.py`
- **Pinned** `gpt-4o-mini` judge **and** generator; `LLM_JUDGE_PROMPT` is the Mem0/GAM `ACCURACY_PROMPT` reproduced **verbatim** (arXiv:2504.19413), with a committed SHA-256 pin so any silent model/prompt swap is a test failure.
- `temperature=0` for reproducibility; judge identity (model, prompt hash, protocol, temperature) recorded in every artifact.
- No hard `openai` dependency — lazy import, dependency-injected `JudgeProtocol` seam. `is_judge_available()` gates a **graceful skip** (prints cost estimate, exits 0) when `OPENAI_API_KEY`/`openai` is absent, mirroring hybrid's model-download posture.
- `call_with_retry` backoff + a documented `estimate_cost()`.

### `run_external.py`: `--judged` stage wired into the existing CLI
- Reuses `--limit`/`--sample`/`--seed`/`--retrieval-mode`/`--fixture`/`--output`.
- **Vector mode rejected up front** (no memory text to answer from).
- **Per-item fault isolation**: a transient API error records a `judge_error` status and the run continues (no full re-pay); an independent `--judge-error-threshold`.
- **Composed `_judged` artifact suffix** so `hybrid`+`judged` → `..._hybrid_judged.*`, never clobbering retrieval-only artifacts.
- **Adversarial (cat-5) excluded** from the headline `judged_accuracy` and reported separately (factual-match judge can't score refusal; refusal metric = #454).
- Retrieval recall and judged accuracy reported **side by side in separate blocks — never cross-compared or fused into one ranking** (#453).

### `external_base.py`
- Surfaces retrieved records' `.content` in `ScenarioResult.metadata` (assembler path) so the generator has evidence to answer from. Additive; zero change to retrieval scoring.

## Tests

`tests/benchmarks/test_judged.py` — 33 tests, **all offline** via an injected fake (no `openai`, no API key): model/prompt/temperature pins, judge-label parsing, retry/fault isolation, suffix composition, status gate, adversarial exclusion, vector rejection, graceful skip, and a fully-mocked end-to-end `main()` run asserting both metric families appear in the artifact.

## SDLC provenance
- Plan: `docs/plans/judged_answer_harness.md` (revised after `/do-plan-critique` resolved 3 blockers + 4 concerns).
- Docs cascade: `docs/benchmarks.md` updated (CLI flags, artifact suffix, JSON blocks, new Judged-Answer Accuracy section).

## Test result
`scripts/ci-local.sh` — **stress ✓, docs ✓ (mkdocs --strict), tests: 2012 passed**. The one tests-gate failure (`test_isolated_db_subprocess`) is a pre-existing redis-py 8.0.1 env issue (`maint_notifications_pool_handler`) byte-identical to origin/main — not touched by this diff. No self-benchmarked judged numbers are committed (harness only; live runs are operator-run with a key).

No co-authors. No Redis modules; Redis + Valkey compatible.