### PR TITLE
feat(#461): first-class LLM memory-extraction path

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -15,6 +15,7 @@ Agent-memory primitives and recipes shipped in Popoto.
 | [ExistenceFilter](existence-filter.md) | Probabilistic membership pre-check (Bloom-style) | Stable |
 | [Hybrid Retrieval (BM25 + RRF)](hybrid-retrieval.md) | BM25 keyword search fused with vector scores via RRF | Stable |
 | [Kitchen Edge Case Demo](kitchen-edge-case-demo.md) | Worked examples covering edge cases across primitives | Reference |
+| [LLM Memory Extraction](llm-memory-extraction.md) | Pluggable extraction providers (heuristic default, opt-in Claude) for `SubconsciousMemory` | Stable |
 | [Metacognitive Layer](metacognitive-layer.md) | Retrieval quality scoring, FOK, `"used"` outcome, AdaptiveAssembler | Stable |
 | [ObservationProtocol](observation-protocol.md) | Outcome-driven memory effects: acted, dismissed, deferred, contradicted, used | Stable |
 | [ParametricSweep](parametric-sweep.md) | Automated benchmark sweeps for tuning numeric constants | Stable |

--- a/docs/features/llm-memory-extraction.md
+++ b/docs/features/llm-memory-extraction.md
@@ -1,0 +1,174 @@
+# LLM Memory Extraction
+
+A pluggable provider interface for turning raw LLM turn text into typed memory facts, used by `SubconsciousMemory.extract_memories()`.
+
+## Overview
+
+`SubconsciousMemory.extract_memories()` originally saved memories by splitting an LLM's response into sentences and filtering out short ones -- a zero-dependency heuristic with no notion of entities, importance, or confidence beyond what the caller passed in.
+
+The extraction path is now pluggable. `popoto.extraction` defines an `AbstractExtractionProvider` interface and an `ExtractedFact` dataclass; any provider that implements `extract(text) -> list[ExtractedFact]` can be passed to `SubconsciousMemory(extraction_provider=...)`. The built-in `HeuristicExtractionProvider` wraps the original sentence-splitting behavior exactly, so the default experience is unchanged. An opt-in `ClaudeExtractionProvider` (`popoto.extraction.claude`) calls the Anthropic Messages API with structured JSON-schema output to extract facts along with their entities, importance, and confidence.
+
+## The Provider Interface
+
+```python
+from popoto.extraction import AbstractExtractionProvider, ExtractedFact
+```
+
+### `ExtractedFact`
+
+A single fact extracted from turn text:
+
+| Field | Type | Description |
+|-------|------|--------------|
+| `text` | `str` | The fact's text content -- becomes the saved Memory record's content. |
+| `entities` | `list[str]` | Proper nouns / named entities mentioned in the fact. Empty if none identified (or the provider doesn't extract entities). |
+| `importance` | `float \| None` | Provider's opinion on importance, `[0.0, 1.0]`. `None` means "no opinion; use the caller-supplied default importance". |
+| `confidence` | `float \| None` | Provider's opinion on certainty, `[0.0, 1.0]`. `None` means "no opinion; leave the model's `ConfidenceField` at its default initial value". |
+
+### `AbstractExtractionProvider`
+
+```python
+class AbstractExtractionProvider(ABC):
+    @abstractmethod
+    def extract(self, text: str) -> list[ExtractedFact]:
+        ...
+```
+
+Implementations turn raw text into `ExtractedFact` records. Provider implementations should not raise for ordinary extraction failures -- return an empty list instead (see `ClaudeExtractionProvider`'s fail-open contract below). Write your own provider by subclassing this ABC and implementing `extract()`.
+
+## The Default: `HeuristicExtractionProvider`
+
+Zero-dependency, stdlib-only, and used automatically when no `extraction_provider` is passed to `SubconsciousMemory`. It splits text on sentence-ending punctuation (`.!?`) followed by whitespace or end-of-string, strips each sentence, and drops any shorter than `min_length` (default 10 chars). Every surviving sentence becomes an `ExtractedFact` with no entities and `importance=None`, `confidence=None` -- so downstream wiring always falls back to the caller-supplied `importance` and never touches `confidence_field`.
+
+**Behavior-preservation guarantee**: this reproduces `SubconsciousMemory.extract_memories()`'s pre-extraction-package behavior byte-for-byte. Existing code that doesn't pass any of the three new kwargs (`extraction_provider`, `confidence_field`, `co_occurrence_field`) sees no behavior change.
+
+## Opting Into Claude Extraction
+
+Install the optional extra:
+
+```bash
+pip install popoto[anthropic]
+```
+
+Construct a `ClaudeExtractionProvider` and pass it to `SubconsciousMemory`:
+
+```python
+from popoto.extraction.claude import ClaudeExtractionProvider
+from popoto.recipes.subconscious_memory import SubconsciousMemory
+
+sm = SubconsciousMemory(
+    model_class=Memory,
+    agent_id="agent-1",
+    score_weights={"relevance": 0.6, "confidence": 0.3},
+    extraction_provider=ClaudeExtractionProvider(api_key="your-key"),
+)
+```
+
+`ClaudeExtractionProvider` calls the Anthropic Messages API once per `extract()` call with structured JSON-schema output, so facts, entities, importance, and confidence come back typed -- no ad hoc parsing. `api_key` defaults to the `ANTHROPIC_API_KEY` env var (via the Anthropic SDK's normal resolution) if not passed.
+
+The model and prompt are pinned module constants (`EXTRACTION_MODEL`, `EXTRACTION_PROMPT` in `popoto/extraction/claude.py`) rather than constructor kwargs -- consistent with this project's convention that experimental-tuning constants live in-repo, not as user config surface.
+
+**`popoto.extraction.claude` is imported lazily.** `import popoto` and `import popoto.extraction` never import the `anthropic` package; only importing `popoto.extraction.claude` itself does. Constructing `ClaudeExtractionProvider` without `anthropic` installed raises `ImportError` with an install hint.
+
+**Fail-open on API/parse errors.** If the API call or response parsing fails for any reason, `extract()` logs a warning and returns an empty list rather than raising -- a flaky extraction call never crashes the caller's turn loop.
+
+## Seeding `confidence_field` and `co_occurrence_field`
+
+Two more optional `SubconsciousMemory` kwargs let extracted facts feed other memory-system primitives. Both are opt-in and no-ops unless set:
+
+```python
+sm = SubconsciousMemory(
+    model_class=Memory,
+    agent_id="agent-1",
+    score_weights={"relevance": 0.6, "confidence": 0.3},
+    extraction_provider=ClaudeExtractionProvider(),
+    confidence_field="certainty",         # name of a ConfidenceField on Memory
+    co_occurrence_field="associations",   # name of a CoOccurrenceField on Memory
+)
+```
+
+- **`confidence_field`**: if set, and a fact carries a `confidence` opinion (not `None`), `extract_memories()` calls [`ConfidenceField.update_confidence()`](confidence-field.md) on the saved instance with that opinion as the signal.
+- **`co_occurrence_field`**: if set, and a fact names two or more distinct entities, every unordered pair of (deduplicated) entity names is linked via [`CoOccurrenceField.link()`](co-occurrence-field.md). Entity name strings -- not the saved record's PK -- are used as graph nodes, since co-mention within one fact is an association between entities, and there is no record PK for an abstract entity.
+
+Since `HeuristicExtractionProvider` never sets `entities` or `confidence`, both kwargs are effectively inert with the default provider -- they only do work once an entity/confidence-emitting provider (like `ClaudeExtractionProvider`) is configured.
+
+### The Confidence Blend Nuance
+
+`ConfidenceField` has no per-instance "set initial value" API. When a `Memory` record is saved, its companion confidence hash is seeded with the field's fixed `initial_confidence` (a prior pseudo-observation), not with anything from the extracted fact. `_seed_confidence()`'s call to `update_confidence(signal=fact.confidence)` is therefore the **first evidence update against that prior**, not a hard override.
+
+Concretely, for the default `initial_confidence=0.5`, seeding with a fact confidence of `s` yields a stored confidence of:
+
+```
+(0.5 + s) / 2
+```
+
+not `s` verbatim. A fact extracted with `confidence=0.9` produces a stored confidence of `0.7`, not `0.9`. See [ConfidenceField's update formula](confidence-field.md#update-formula) for the full running-mean derivation -- the same blending applies here, it's just the first update rather than a later one.
+
+Don't write code that asserts `ConfidenceField.get_confidence(instance, field) == fact.confidence` after extraction -- it won't hold except by coincidence.
+
+## Example: End-to-End
+
+```python
+from popoto import (
+    Model, AutoKeyField, KeyField, StringField, FloatField,
+    DecayingSortedField, ConfidenceField,
+)
+from popoto.fields.co_occurrence_field import CoOccurrenceField
+from popoto.extraction.claude import ClaudeExtractionProvider
+from popoto.recipes.subconscious_memory import SubconsciousMemory
+
+class Memory(Model):
+    memory_id = AutoKeyField()
+    agent_id = KeyField()
+    content = StringField(default="")
+    importance = FloatField(default=1.0)
+    relevance = DecayingSortedField(base_score_field="importance", partition_by="agent_id")
+    certainty = ConfidenceField(initial_confidence=0.5)
+    associations = CoOccurrenceField(symmetric=True)
+
+sm = SubconsciousMemory(
+    model_class=Memory,
+    agent_id="agent-1",
+    score_weights={"relevance": 0.6, "confidence": 0.3},
+    extraction_provider=ClaudeExtractionProvider(),  # requires popoto[anthropic]
+    confidence_field="certainty",
+    co_occurrence_field="associations",
+)
+
+new_memories = sm.extract_memories(
+    "Alice met Bob at the AI conference in Paris. They discussed the new product launch."
+)
+# Each saved Memory's `certainty` field is now seeded (blended with the 0.5 prior),
+# and entity pairs mentioned together (e.g. "Alice"/"Bob", "Alice"/"Paris") are
+# linked in `associations`.
+```
+
+## Writing a Custom Provider
+
+Any object implementing `AbstractExtractionProvider.extract()` works -- you're not limited to the two built-ins:
+
+```python
+from popoto.extraction import AbstractExtractionProvider, ExtractedFact
+
+class MyProvider(AbstractExtractionProvider):
+    def extract(self, text: str) -> list[ExtractedFact]:
+        facts = my_extraction_call(text)  # e.g. a different LLM, a local NER model, ...
+        return [
+            ExtractedFact(text=f["text"], entities=f.get("entities", []),
+                           importance=f.get("importance"), confidence=f.get("confidence"))
+            for f in facts
+        ]
+
+sm = SubconsciousMemory(model_class=Memory, agent_id="agent-1",
+                         score_weights={"relevance": 1.0}, extraction_provider=MyProvider())
+```
+
+## Evaluation Status
+
+Judged-accuracy and recall comparison of `ClaudeExtractionProvider` against the `HeuristicExtractionProvider` default is **not yet measured**. It's tracked as follow-up work under epic #456 Track B: the existing benchmark harness (`tests/benchmarks/`) doesn't currently have a pluggable extraction seam in its ingestion path, and a real comparison requires a live Anthropic API key, which is out of scope for the default test suite. No evaluation numbers exist for this feature yet -- treat any claim otherwise as incorrect.
+
+## See Also
+
+- [SubconsciousMemory Recipe](../guides/subconscious-memory-recipe.md) -- the recipe that consumes extraction providers
+- [ConfidenceField](confidence-field.md) -- update formula and blending behavior
+- [CoOccurrenceField](co-occurrence-field.md) -- association graph seeded from co-mentioned entities

--- a/docs/guides/subconscious-memory-recipe.md
+++ b/docs/guides/subconscious-memory-recipe.md
@@ -129,11 +129,23 @@ The query cue is only meaningful in **query-sensitive** modes (lexical or hybrid
 
 ### Post-turn: `extract_memories(response_text, importance)`
 
+By default (no `extraction_provider` passed to the constructor):
+
 1. Splits the LLM response into sentences
 2. Filters out sentences shorter than `extraction_min_length` (default 10 chars)
 3. Saves each sentence as a new Memory record with the specified importance
 
-The built-in extraction uses a simple sentence-splitting heuristic. For more accurate extraction, override this method or extract facts using a secondary LLM call and save them directly via your model class.
+This is unchanged, byte-for-byte, from the original heuristic -- existing code that doesn't pass any of `extraction_provider`, `confidence_field`, or `co_occurrence_field` sees no behavior change.
+
+Extraction is now pluggable via a dedicated provider interface -- see the [LLM Memory Extraction](../features/llm-memory-extraction.md) feature doc for the full picture. In short:
+
+- **`extraction_provider`** (default `None` -> `HeuristicExtractionProvider`): pass an `AbstractExtractionProvider` instance (e.g. `ClaudeExtractionProvider` from `popoto.extraction.claude`, requires `pip install popoto[anthropic]`) for LLM-based extraction that also returns entities, an importance opinion, and a confidence opinion per fact.
+- **`confidence_field`** (default `None`, no-op unless set): name of a `ConfidenceField` on `model_class`. When set and a fact carries a confidence opinion, `extract_memories()` seeds that field via `ConfidenceField.update_confidence()`. Because `ConfidenceField` has no per-instance "set initial value" API, this is a *blend* with the field's `initial_confidence` prior, not a hard override -- see [the confidence blend nuance](../features/llm-memory-extraction.md#the-confidence-blend-nuance) before assuming the stored value equals the extracted confidence.
+- **`co_occurrence_field`** (default `None`, no-op unless set): name of a `CoOccurrenceField` on `model_class`. When set and a fact names two or more distinct entities, every unordered entity pair is linked in that field's association graph.
+
+Both `confidence_field` and `co_occurrence_field` are inert with the default `HeuristicExtractionProvider`, since it never populates `entities` or `confidence` on the facts it emits -- they only do work once an entity/confidence-emitting provider (like `ClaudeExtractionProvider`) is configured.
+
+For a fully custom extraction source (not implementing the provider interface), you can still subclass `SubconsciousMemory` and override `extract_memories()` directly -- see [Extensibility](#extensibility) below.
 
 ### Outcome: `report_outcomes(assembly_result, outcome)`
 
@@ -156,6 +168,9 @@ Reports how the agent used the injected memories via `ObservationProtocol.on_con
 | `system_preamble` | "You are a helpful assistant." | Prefix for auto-created system messages |
 | `content_field` | "content" | Name of the text content field on your model |
 | `importance_field` | "importance" | Name of the importance score field |
+| `extraction_provider` | `None` (-> `HeuristicExtractionProvider`) | `AbstractExtractionProvider` used by `extract_memories()`. See [LLM Memory Extraction](../features/llm-memory-extraction.md) |
+| `confidence_field` | `None` | Name of a `ConfidenceField` to seed from extracted facts' confidence opinions; no-op unless set |
+| `co_occurrence_field` | `None` | Name of a `CoOccurrenceField` to link co-mentioned entities in; no-op unless set |
 
 These constants can be tuned experimentally using the Tier 4 benchmark harness. See the [Tuning Magic Numbers](tuning-magic-numbers.md) guide for the full constant catalog, optimal ranges, and how to run parameter sweeps.
 
@@ -163,7 +178,28 @@ These constants can be tuned experimentally using the Tier 4 benchmark harness. 
 
 ### Custom Fact Extraction
 
-Subclass `SubconsciousMemory` and override `extract_memories()` for LLM-based extraction:
+The preferred way to customize extraction is to pass an `extraction_provider` -- either the built-in `ClaudeExtractionProvider` or your own `AbstractExtractionProvider` implementation -- rather than subclassing. See [LLM Memory Extraction](../features/llm-memory-extraction.md) for the full interface and a "writing a custom provider" example.
+
+```python
+from popoto.extraction import AbstractExtractionProvider, ExtractedFact
+
+class MyProvider(AbstractExtractionProvider):
+    def extract(self, text: str) -> list[ExtractedFact]:
+        facts = my_extraction_function(text)
+        return [
+            ExtractedFact(text=f["text"], importance=f.get("importance"))
+            for f in facts
+        ]
+
+sm = SubconsciousMemory(
+    model_class=Memory,
+    agent_id="agent-1",
+    score_weights={"relevance": 0.6, "confidence": 0.3},
+    extraction_provider=MyProvider(),
+)
+```
+
+If you need to change more than extraction itself (e.g. custom save logic, side effects beyond seeding confidence/co-occurrence), subclassing and overriding `extract_memories()` directly is still supported:
 
 ```python
 class SmartSubconsciousMemory(SubconsciousMemory):
@@ -189,6 +225,7 @@ The default implementation uses the last user message as the query cue. For more
 ## See Also
 
 - [Agent Memory Quickstart](agent-memory-quickstart.md) -- progressive adoption guide
+- [LLM Memory Extraction](../features/llm-memory-extraction.md) -- pluggable extraction providers, entities, importance/confidence opinions
 - [ContextAssembler](../features/context-assembler.md) -- retrieval-to-injection bridge
 - [PolicyCache Recipe](policy-cache-recipe.md) -- RL-style learned action selection
 - [Trajectory Memory Recipe](trajectory-memory-recipe.md) -- fingerprint-keyed procedural memory: cluster completed task trajectories and recall "what worked last time"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
           - Recipes:
                 - PolicyCache: 'guides/policy-cache-recipe.md'
                 - SubconsciousMemory: 'guides/subconscious-memory-recipe.md'
+                - LLM Memory Extraction: 'features/llm-memory-extraction.md'
                 - TrajectoryMemory: 'guides/trajectory-memory-recipe.md'
                 - RAG Chatbot: 'guides/rag-chatbot-recipe.md'
                 - Memory Telemetry: 'features/memory-telemetry.md'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ openai = [
     "openai>=1.0.0",
     "numpy>=1.23.1",
 ]
+anthropic = [
+    "anthropic>=0.40.0",
+]
 monitoring = [
     "sentry-sdk>=2.0.0",
 ]

--- a/src/popoto/extraction/__init__.py
+++ b/src/popoto/extraction/__init__.py
@@ -1,0 +1,152 @@
+"""
+Memory-extraction providers for Popoto's SubconsciousMemory recipe.
+
+This module provides the AbstractExtractionProvider interface, the
+ExtractedFact dataclass, and the built-in zero-dependency heuristic
+provider used to turn raw LLM turn text into typed memory facts.
+
+Providers are pluggable -- pass a provider instance to
+SubconsciousMemory(extraction_provider=...). The default
+HeuristicExtractionProvider preserves the historical sentence-splitting
+behavior exactly and requires no external dependencies.
+
+Available providers:
+    - HeuristicExtractionProvider: zero-dependency sentence-split heuristic
+      (the default; stdlib-only, eagerly imported here)
+    - ClaudeExtractionProvider (popoto.extraction.claude): opt-in LLM-based
+      extraction via the Anthropic API (requires the ``anthropic`` package;
+      imported lazily -- see popoto.extraction.claude, not re-exported here)
+"""
+
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+DEFAULT_MIN_LENGTH = 10
+"""Minimum sentence length (chars) to be considered a fact worth saving.
+
+Matches ``DEFAULT_EXTRACTION_MIN_LENGTH`` in
+``popoto.recipes.subconscious_memory`` -- the historical default preserved
+by ``HeuristicExtractionProvider``.
+"""
+
+
+@dataclass
+class ExtractedFact:
+    """A single fact extracted from LLM turn text.
+
+    Attributes:
+        text: The fact's text content -- becomes the saved Memory record's
+            content.
+        entities: Proper nouns / named entities mentioned in the fact.
+            Empty list means no entities were identified (or the provider
+            doesn't extract entities, e.g. the heuristic provider).
+        importance: Provider's opinion on this fact's importance, in
+            [0.0, 1.0]. ``None`` means "no opinion; use the caller-supplied
+            default importance instead" (importance-on-write fallback).
+        confidence: Provider's opinion on how certain this fact is, in
+            [0.0, 1.0]. ``None`` means "no opinion; leave the model's
+            ConfidenceField at its default initial value".
+    """
+
+    text: str
+    entities: List[str] = field(default_factory=list)
+    importance: Optional[float] = None
+    confidence: Optional[float] = None
+
+
+class AbstractExtractionProvider(ABC):
+    """Abstract interface for memory-extraction providers.
+
+    Implementations turn raw LLM response text into a list of
+    ``ExtractedFact`` records. ``SubconsciousMemory.extract_memories()``
+    delegates to a configured provider's ``extract()`` method.
+    """
+
+    @abstractmethod
+    def extract(self, text: str) -> List[ExtractedFact]:
+        """Extract facts from the given text.
+
+        Args:
+            text: Raw text to extract facts from (typically an LLM's
+                response text for one turn).
+
+        Returns:
+            List of ExtractedFact records. Empty list if no facts were
+            found, or on any recoverable failure -- implementations should
+            not raise for ordinary extraction failures (see
+            ClaudeExtractionProvider for the fail-open contract).
+        """
+        ...
+
+
+class HeuristicExtractionProvider(AbstractExtractionProvider):
+    """Zero-dependency sentence-splitting extraction provider.
+
+    Wraps the historical sentence-split + min-length-filter behavior of
+    ``SubconsciousMemory.extract_memories()`` exactly: splits on
+    sentence-ending punctuation (.!?) followed by whitespace or
+    end-of-string, strips each sentence, and drops any shorter than
+    ``min_length``. Every surviving sentence becomes an
+    ``ExtractedFact`` with no entities and no importance/confidence
+    opinion (both ``None``), so downstream wiring falls back to the
+    caller-supplied importance and leaves confidence untouched --
+    byte-identical behavior to the pre-extraction-package heuristic.
+
+    This is the default provider: no API key, no network call, no
+    optional dependency.
+
+    Args:
+        min_length: Minimum sentence length (chars) to keep. Default
+            ``DEFAULT_MIN_LENGTH`` (10).
+    """
+
+    def __init__(self, min_length: int = DEFAULT_MIN_LENGTH):
+        self._min_length = min_length
+
+    def extract(self, text: str) -> List[ExtractedFact]:
+        """Split text into sentences and filter by minimum length.
+
+        Args:
+            text: Input text to extract facts from.
+
+        Returns:
+            List of ExtractedFact, one per surviving sentence, each with
+            empty entities and ``importance=None``, ``confidence=None``.
+        """
+        if not text or not text.strip():
+            return []
+
+        sentences = self._split_sentences(text)
+        facts = []
+        for sentence in sentences:
+            sentence = sentence.strip()
+            if len(sentence) < self._min_length:
+                continue
+            facts.append(ExtractedFact(text=sentence))
+        return facts
+
+    @staticmethod
+    def _split_sentences(text: str) -> List[str]:
+        """Split text into sentences using a simple regex heuristic.
+
+        Splits on sentence-ending punctuation (.!?) followed by whitespace
+        or end-of-string. Preserves abbreviations like "e.g." and "Dr."
+        reasonably well for typical LLM output.
+
+        Args:
+            text: Input text to split.
+
+        Returns:
+            List of sentence strings.
+        """
+        parts = re.split(r"(?<=[.!?])\s+", text.strip())
+        return [p for p in parts if p]
+
+
+__all__ = [
+    "ExtractedFact",
+    "AbstractExtractionProvider",
+    "HeuristicExtractionProvider",
+]

--- a/src/popoto/extraction/claude.py
+++ b/src/popoto/extraction/claude.py
@@ -1,0 +1,203 @@
+"""
+Claude (Anthropic) memory-extraction provider.
+
+Wraps the Anthropic Messages API behind the AbstractExtractionProvider
+interface. Requires the anthropic package (pip install popoto[anthropic]).
+
+Opt-in only: ``import popoto`` and ``import popoto.extraction`` never
+import ``anthropic`` -- this module is imported lazily by callers who
+want LLM-based extraction, mirroring popoto.embeddings.openai's pattern.
+
+Example:
+    from popoto.extraction.claude import ClaudeExtractionProvider
+    provider = ClaudeExtractionProvider(api_key="your-key")
+    facts = provider.extract("Alice met Bob at the conference in Paris.")
+"""
+
+import json
+import logging
+from typing import List, Optional
+
+from . import AbstractExtractionProvider, ExtractedFact
+from ..fields.constants import Defaults
+
+try:
+    import anthropic as anthropic_module
+
+    _anthropic_available = True
+except ImportError:
+    _anthropic_available = False
+
+logger = logging.getLogger("POPOTO.extraction")
+
+# ---------------------------------------------------------------------------
+# Pinned, non-user-configurable constants.
+#
+# Per this project's convention (see popoto.fields.constants.Defaults'
+# module docstring and CLAUDE.md's "numeric constants are magic numbers for
+# experimental tuning, not dev/user config"), the model and prompt used for
+# extraction are pinned in-repo, not exposed as constructor kwargs.
+# ---------------------------------------------------------------------------
+
+EXTRACTION_MODEL = "claude-opus-4-8"
+"""Pinned model for Claude-based extraction. Not user-configurable."""
+
+EXTRACTION_PROMPT = """You are a memory-extraction engine for an AI agent. Given a \
+block of text (typically an LLM's response during a conversation), extract the \
+discrete, independently-useful facts it contains.
+
+For each fact:
+- "text": a short, self-contained statement of the fact, written so it makes sense \
+on its own without the surrounding conversation.
+- "entities": the proper nouns / named entities mentioned in the fact (people, \
+places, organizations, products, dates treated as named references, etc.). Use an \
+empty list if none are present.
+- "importance": a score from 0.0 to 1.0 for how important this fact is likely to be \
+to remember later (0.0 = trivial/filler, 1.0 = critical, load-bearing information).
+- "confidence": a score from 0.0 to 1.0 for how certain the source text is asserting \
+this fact (0.0 = highly speculative or hedged, 1.0 = stated as definite fact).
+
+Only extract facts that carry real informational content -- skip greetings, filler, \
+and purely conversational scaffolding. If the text contains no extractable facts, \
+return an empty "facts" array."""
+"""Pinned system prompt for Claude-based extraction. Not user-configurable."""
+
+FACTS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "facts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "entities": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "importance": {"type": "number"},
+                    "confidence": {"type": "number"},
+                },
+                "required": ["text", "entities", "importance", "confidence"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["facts"],
+    "additionalProperties": False,
+}
+"""JSON schema for structured extraction output. Not user-configurable."""
+
+
+def _clamp01(value, default: float) -> float:
+    """Clamp a value into [0.0, 1.0], falling back to ``default`` if invalid."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return default
+    if f != f:  # NaN check without importing math
+        return default
+    return max(0.0, min(1.0, f))
+
+
+class ClaudeExtractionProvider(AbstractExtractionProvider):
+    """Claude (Anthropic) memory-extraction provider.
+
+    Opt-in provider that calls the Anthropic Messages API once per
+    ``extract()`` call, using structured JSON-schema output
+    (``output_config.format``) to get typed facts back directly -- no
+    tool_use, no assistant-turn prefill (which 400s on this model
+    family).
+
+    Model and prompt are pinned module constants (``EXTRACTION_MODEL``,
+    ``EXTRACTION_PROMPT``), not constructor kwargs, per this project's
+    experimental-constant convention.
+
+    On any API or parse failure, ``extract()`` logs a warning and returns
+    an empty list -- it never raises, so a flaky extraction call never
+    crashes the caller's turn loop.
+
+    Args:
+        api_key: Anthropic API key. If None, reads from the
+            ``ANTHROPIC_API_KEY`` env var (via the anthropic SDK's normal
+            resolution).
+
+    Raises:
+        ImportError: If the ``anthropic`` package is not installed.
+    """
+
+    def __init__(self, api_key: Optional[str] = None):
+        if not _anthropic_available:
+            raise ImportError(
+                "anthropic is required to use ClaudeExtractionProvider. "
+                "Install it with: pip install popoto[anthropic]"
+            )
+        self._client = anthropic_module.Anthropic(api_key=api_key)
+
+    def extract(self, text: str) -> List[ExtractedFact]:
+        """Extract facts from text via one Claude API call.
+
+        Args:
+            text: Input text to extract facts from.
+
+        Returns:
+            List of ExtractedFact. Empty list if the text is empty/blank,
+            no facts were found, or the API call/parse failed (a warning
+            is logged in the failure case).
+        """
+        if not text or not text.strip():
+            return []
+
+        try:
+            response = self._client.messages.create(
+                model=EXTRACTION_MODEL,
+                max_tokens=4096,
+                system=EXTRACTION_PROMPT,
+                messages=[{"role": "user", "content": text}],
+                output_config={
+                    "format": {"type": "json_schema", "schema": FACTS_SCHEMA}
+                },
+            )
+            raw_text = next(
+                (block.text for block in response.content if block.type == "text"),
+                None,
+            )
+            if raw_text is None:
+                logger.warning("ClaudeExtractionProvider: no text block in response")
+                return []
+            parsed = json.loads(raw_text)
+        except Exception as e:
+            logger.warning("ClaudeExtractionProvider: extraction failed: %s", e)
+            return []
+
+        raw_facts = parsed.get("facts") if isinstance(parsed, dict) else None
+        if not isinstance(raw_facts, list):
+            logger.warning("ClaudeExtractionProvider: response missing 'facts' list")
+            return []
+
+        facts = []
+        for raw_fact in raw_facts:
+            if not isinstance(raw_fact, dict):
+                continue
+            fact_text = raw_fact.get("text")
+            if not isinstance(fact_text, str) or not fact_text.strip():
+                continue
+            entities = raw_fact.get("entities")
+            if not isinstance(entities, list):
+                entities = []
+            entities = [e for e in entities if isinstance(e, str)]
+            importance = _clamp01(
+                raw_fact.get("importance"), Defaults.EXTRACTION_DEFAULT_IMPORTANCE
+            )
+            confidence = _clamp01(
+                raw_fact.get("confidence"), Defaults.EXTRACTION_DEFAULT_CONFIDENCE
+            )
+            facts.append(
+                ExtractedFact(
+                    text=fact_text.strip(),
+                    entities=entities,
+                    importance=importance,
+                    confidence=confidence,
+                )
+            )
+        return facts

--- a/src/popoto/extraction/claude.py
+++ b/src/popoto/extraction/claude.py
@@ -26,6 +26,11 @@ try:
 
     _anthropic_available = True
 except ImportError:
+    # Keep the name bound (to None) even when the optional dependency is
+    # absent, so callers/tests can always `monkeypatch.setattr(claude_mod,
+    # "anthropic_module", ...)` regardless of whether `anthropic` is
+    # installed in the current environment.
+    anthropic_module = None
     _anthropic_available = False
 
 logger = logging.getLogger("POPOTO.extraction")

--- a/src/popoto/extraction/claude.py
+++ b/src/popoto/extraction/claude.py
@@ -47,6 +47,9 @@ logger = logging.getLogger("POPOTO.extraction")
 EXTRACTION_MODEL = "claude-opus-4-8"
 """Pinned model for Claude-based extraction. Not user-configurable."""
 
+EXTRACTION_MAX_TOKENS = 4096
+"""Pinned max_tokens for Claude-based extraction. Not user-configurable."""
+
 EXTRACTION_PROMPT = """You are a memory-extraction engine for an AI agent. Given a \
 block of text (typically an LLM's response during a conversation), extract the \
 discrete, independently-useful facts it contains.
@@ -156,7 +159,7 @@ class ClaudeExtractionProvider(AbstractExtractionProvider):
         try:
             response = self._client.messages.create(
                 model=EXTRACTION_MODEL,
-                max_tokens=4096,
+                max_tokens=EXTRACTION_MAX_TOKENS,
                 system=EXTRACTION_PROMPT,
                 messages=[{"role": "user", "content": text}],
                 output_config={

--- a/src/popoto/fields/constants.py
+++ b/src/popoto/fields/constants.py
@@ -176,6 +176,7 @@ class Defaults:
     EXTRACTION_DEFAULT_IMPORTANCE = 0.5  # aligns with SubconsciousMemory.extract_memories()'s current flat importance default
     EXTRACTION_DEFAULT_CONFIDENCE = 0.7  # signal applied when a provider asserts a fact but returns no explicit confidence
     EXTRACTION_ENTITY_PAIR_LINK_WEIGHT = 0.1  # matches CO_OCCURRENCE_INITIAL_WEIGHT; must stay <= CO_OCCURRENCE_WEIGHT_CAP (1.0) or CoOccurrenceField.link() raises
+    EXTRACTION_MAX_ENTITIES_PER_FACT = 12  # cap on deduped entities paired per fact; combinations grow O(n^2), so a malformed/adversarial extraction with many entities can't blow up co-occurrence writes
 
 
 class TemporalPeriod:

--- a/src/popoto/fields/constants.py
+++ b/src/popoto/fields/constants.py
@@ -169,6 +169,14 @@ class Defaults:
     )
     LIFECYCLE_FORGET_IDLE_SECONDS = 86400.0  # 24 h idle → eligible for forget
 
+    # -- Extraction (extraction/) ---------------------------------------------
+    # Experimental tuning constants for the pluggable LLM-extraction path
+    # (popoto.extraction). Not yet swept -- initial values set by design,
+    # per issue #461 / docs/plans/llm_memory_extraction_path.md.
+    EXTRACTION_DEFAULT_IMPORTANCE = 0.5  # aligns with SubconsciousMemory.extract_memories()'s current flat importance default
+    EXTRACTION_DEFAULT_CONFIDENCE = 0.7  # signal applied when a provider asserts a fact but returns no explicit confidence
+    EXTRACTION_ENTITY_PAIR_LINK_WEIGHT = 0.1  # matches CO_OCCURRENCE_INITIAL_WEIGHT; must stay <= CO_OCCURRENCE_WEIGHT_CAP (1.0) or CoOccurrenceField.link() raises
+
 
 class TemporalPeriod:
     """Named constants for common temporal cycle periods in seconds.

--- a/src/popoto/recipes/subconscious_memory.py
+++ b/src/popoto/recipes/subconscious_memory.py
@@ -54,10 +54,13 @@ Example:
     sm.report_outcomes(assembly_result)
 """
 
+import itertools
 import logging
-import re
 
 from .context_assembler import AssemblyResult, ContextAssembler
+from ..extraction import HeuristicExtractionProvider
+from ..fields.confidence_field import ConfidenceField
+from ..fields.constants import Defaults
 from ..fields.observation import ObservationProtocol
 
 logger = logging.getLogger("POPOTO.SubconsciousMemory")
@@ -103,6 +106,21 @@ class SubconsciousMemory:
             importance score. Default "importance".
         agent_id_field: Name of the KeyField for agent partitioning.
             Default "agent_id".
+        extraction_provider: An ``AbstractExtractionProvider`` instance
+            (see ``popoto.extraction``) used to turn LLM response text
+            into ``ExtractedFact`` records in ``extract_memories()``.
+            Default ``None``, which resolves to
+            ``HeuristicExtractionProvider(min_length=extraction_min_length)``
+            -- the historical sentence-splitting behavior, preserved
+            byte-identical when no new kwargs are passed. Pass a
+            ``ClaudeExtractionProvider`` (``popoto.extraction.claude``)
+            for LLM-based extraction with entities/importance/confidence.
+        confidence_field: Name of a ``ConfidenceField`` on model_class to
+            seed from each extracted fact's ``confidence`` opinion, or
+            ``None`` (default) to skip confidence seeding entirely.
+        co_occurrence_field: Name of a ``CoOccurrenceField`` on
+            model_class to link co-mentioned entities in, or ``None``
+            (default) to skip association seeding entirely.
     """
 
     def __init__(
@@ -117,6 +135,9 @@ class SubconsciousMemory:
         content_field="content",
         importance_field="importance",
         agent_id_field="agent_id",
+        extraction_provider=None,
+        confidence_field=None,
+        co_occurrence_field=None,
     ):
         self.model_class = model_class
         self.agent_id = agent_id
@@ -128,6 +149,12 @@ class SubconsciousMemory:
         self.content_field = content_field
         self.importance_field = importance_field
         self.agent_id_field = agent_id_field
+
+        self._extractor = extraction_provider or HeuristicExtractionProvider(
+            min_length=extraction_min_length
+        )
+        self.confidence_field = confidence_field
+        self.co_occurrence_field = co_occurrence_field
 
         self._assembler = ContextAssembler(
             model_class=model_class,
@@ -192,17 +219,38 @@ class SubconsciousMemory:
     def extract_memories(self, response_text, importance=0.5):
         """Post-turn: extract facts from LLM response and save as Memory records.
 
-        Uses a simple heuristic: split response into sentences, filter by
-        minimum length, and save each as a separate Memory record.
+        Delegates to ``self._extractor`` (an ``AbstractExtractionProvider``,
+        see ``popoto.extraction``) to turn ``response_text`` into
+        ``ExtractedFact`` records, then saves each as a Memory record. By
+        default ``self._extractor`` is a ``HeuristicExtractionProvider``,
+        which splits the response into sentences and filters by minimum
+        length -- this reproduces the original sentence-splitting behavior
+        of this method byte-for-byte when no new constructor kwargs are
+        passed. Pass ``extraction_provider=ClaudeExtractionProvider(...)``
+        (see ``popoto.extraction.claude``) for LLM-based extraction with
+        entities, importance, and confidence opinions.
 
-        For LLM-based extraction (more accurate but requires an API call),
-        override this method or pass extracted facts directly to your
-        model_class.save().
+        Importance-on-write nuance: each ``ExtractedFact.importance`` is
+        used verbatim when the provider has an opinion (not ``None``);
+        otherwise the ``importance`` argument passed to this call is used
+        as the fallback. The heuristic provider never has an opinion, so
+        its output always uses the caller-supplied ``importance``.
+
+        If ``co_occurrence_field`` is configured and a fact names two or
+        more distinct entities, every unordered pair is linked in that
+        field's co-occurrence graph (see ``_seed_associations``). If
+        ``confidence_field`` is configured and a fact has a confidence
+        opinion, that field is seeded via ``_seed_confidence`` -- note
+        ``ConfidenceField.update_confidence()`` blends the signal with the
+        field's fixed ``initial_confidence`` rather than storing it
+        verbatim; see ``_seed_confidence`` for the exact formula.
 
         Args:
             response_text: The LLM's response text.
-            importance: Default importance score for extracted memories.
-                Float between 0.0 and 1.0. Default 0.5.
+            importance: Fallback importance score used for any extracted
+                fact that has no importance opinion of its own (i.e.
+                ``ExtractedFact.importance is None``). Float between 0.0
+                and 1.0. Default 0.5.
 
         Returns:
             List of saved model instances. Empty list if response_text
@@ -211,28 +259,119 @@ class SubconsciousMemory:
         if not response_text or not response_text.strip():
             return []
 
-        sentences = self._split_sentences(response_text)
+        facts = self._extractor.extract(response_text)
         saved = []
 
-        for sentence in sentences:
-            sentence = sentence.strip()
-            if len(sentence) < self.extraction_min_length:
-                continue
-
+        for fact in facts:
+            eff_importance = (
+                fact.importance if fact.importance is not None else importance
+            )
+            kwargs = {
+                self.agent_id_field: self.agent_id,
+                self.content_field: fact.text,
+                self.importance_field: eff_importance,
+            }
             try:
-                kwargs = {
-                    self.agent_id_field: self.agent_id,
-                    self.content_field: sentence,
-                    self.importance_field: importance,
-                }
                 instance = self.model_class(**kwargs)
-                result = instance.save()
-                if result is not False:
+                if instance.save() is not False:
                     saved.append(instance)
+                    self._seed_associations(instance, fact)
+                    self._seed_confidence(instance, fact)
             except Exception as e:
                 logger.warning("Failed to save extracted memory: %s", e)
 
         return saved
+
+    def _seed_associations(self, instance, fact):
+        """Link co-mentioned entities in ``self.co_occurrence_field``.
+
+        No-op unless ``self.co_occurrence_field`` is set, the named field
+        exists on ``self.model_class``, and ``fact.entities`` contains at
+        least two distinct (case-sensitive, whitespace-trimmed) names.
+
+        Entity name strings -- not the saved ``instance``'s PK -- are used
+        as the graph nodes: co-mention within one fact is treated as an
+        association between entities, which is the natural unit for a
+        write-time extraction graph (there is no record PK for an
+        abstract entity). This is a deliberate departure from the field's
+        usual record-PK-as-node convention; entity-name nodes and record
+        PK nodes coexist in the same keyspace under
+        ``$CoOcF:{ClassName}:{field}:``.
+
+        Entities are deduplicated (order-stable) before pairing, since
+        ``CoOccurrenceField.link()`` rejects self-pairs. Each pair is
+        linked independently with its own try/except so one failing pair
+        (e.g. a residual self-pair, or a transient Redis error) never
+        drops the remaining valid pairs or the already-saved memory
+        record.
+
+        Args:
+            instance: The already-saved model instance for this fact.
+            fact: The ``ExtractedFact`` that produced ``instance``.
+        """
+        if not self.co_occurrence_field:
+            return
+        if self.model_class._meta.fields.get(self.co_occurrence_field) is None:
+            return
+
+        seen = set()
+        norm_entities = []
+        for e in fact.entities:
+            e = (e or "").strip()
+            if e and e not in seen:
+                seen.add(e)
+                norm_entities.append(e)
+
+        if len(norm_entities) < 2:
+            return
+
+        field = getattr(self.model_class, self.co_occurrence_field)
+        for a, b in itertools.combinations(norm_entities, 2):
+            try:
+                field.link(
+                    self.model_class,
+                    a,
+                    b,
+                    initial_weight=Defaults.EXTRACTION_ENTITY_PAIR_LINK_WEIGHT,
+                )
+            except Exception as exc:
+                logger.warning("entity link %r<->%r failed: %s", a, b, exc)
+
+    def _seed_confidence(self, instance, fact):
+        """Seed ``self.confidence_field`` from ``fact.confidence``.
+
+        No-op unless ``self.confidence_field`` is set, the named field
+        exists on ``self.model_class``, and ``fact.confidence is not
+        None``.
+
+        Note: ``ConfidenceField`` has no per-instance "set initial value"
+        API. The companion hash is seeded in ``on_save`` with the field's
+        fixed ``initial_confidence`` (pseudo-count 1); this method's call
+        to ``update_confidence()`` is the *first evidence update* against
+        that prior, not a hard override. Concretely, seeding with signal
+        ``s`` yields a stored confidence of ``(initial_confidence + s) /
+        2`` -- not ``s`` verbatim. Callers should not expect
+        ``fact.confidence`` to equal the stored value after this call.
+
+        Args:
+            instance: The already-saved model instance for this fact.
+            fact: The ``ExtractedFact`` that produced ``instance``.
+        """
+        if not self.confidence_field:
+            return
+        if self.model_class._meta.fields.get(self.confidence_field) is None:
+            return
+        if fact.confidence is None:
+            return
+
+        try:
+            ConfidenceField.update_confidence(
+                instance, self.confidence_field, signal=fact.confidence
+            )
+        except Exception as exc:
+            logger.warning(
+                "confidence seed for %r failed: %s", self.confidence_field, exc
+            )
 
     def report_outcomes(self, assembly_result, outcome="acted"):
         """Outcome hook: report how injected memories were used.
@@ -268,9 +407,13 @@ class SubconsciousMemory:
     def _split_sentences(text):
         """Split text into sentences using a simple regex heuristic.
 
-        Splits on sentence-ending punctuation (.!?) followed by whitespace
-        or end-of-string. Preserves abbreviations like "e.g." and "Dr."
-        reasonably well for typical LLM output.
+        Delegates to ``HeuristicExtractionProvider._split_sentences`` --
+        kept here (rather than removed) for backward compatibility with
+        callers/tests that reference this staticmethod directly.
+        ``extract_memories()`` no longer calls this method itself; it
+        delegates to ``self._extractor`` instead (see
+        ``popoto.extraction.HeuristicExtractionProvider``, which contains
+        the canonical implementation).
 
         Args:
             text: Input text to split.
@@ -278,6 +421,4 @@ class SubconsciousMemory:
         Returns:
             List of sentence strings.
         """
-        # Split on .!? followed by space or end of string
-        parts = re.split(r"(?<=[.!?])\s+", text.strip())
-        return [p for p in parts if p]
+        return HeuristicExtractionProvider._split_sentences(text)

--- a/src/popoto/recipes/subconscious_memory.py
+++ b/src/popoto/recipes/subconscious_memory.py
@@ -305,6 +305,13 @@ class SubconsciousMemory:
         drops the remaining valid pairs or the already-saved memory
         record.
 
+        The deduped entity list is truncated to
+        ``Defaults.EXTRACTION_MAX_ENTITIES_PER_FACT`` before pairing:
+        combination count grows O(n^2), so an extraction result with an
+        unusually large entity set (malformed provider output, or an
+        adversarial input) can't blow up into a burst of co-occurrence
+        writes for a single fact.
+
         Args:
             instance: The already-saved model instance for this fact.
             fact: The ``ExtractedFact`` that produced ``instance``.
@@ -324,6 +331,9 @@ class SubconsciousMemory:
 
         if len(norm_entities) < 2:
             return
+
+        if len(norm_entities) > Defaults.EXTRACTION_MAX_ENTITIES_PER_FACT:
+            norm_entities = norm_entities[: Defaults.EXTRACTION_MAX_ENTITIES_PER_FACT]
 
         field = getattr(self.model_class, self.co_occurrence_field)
         for a, b in itertools.combinations(norm_entities, 2):

--- a/tests/benchmarks/test_defaults_sync.py
+++ b/tests/benchmarks/test_defaults_sync.py
@@ -83,6 +83,7 @@ class TestDefaultsSync:
             "EXTRACTION_DEFAULT_IMPORTANCE",
             "EXTRACTION_DEFAULT_CONFIDENCE",
             "EXTRACTION_ENTITY_PAIR_LINK_WEIGHT",
+            "EXTRACTION_MAX_ENTITIES_PER_FACT",
         }
 
         expected_in_module = defaults_attrs - field_kwargs_and_class_attrs

--- a/tests/benchmarks/test_defaults_sync.py
+++ b/tests/benchmarks/test_defaults_sync.py
@@ -77,6 +77,12 @@ class TestDefaultsSync:
             "LIFECYCLE_PROMOTION_MIN_AGE_SECONDS",
             "LIFECYCLE_FORGET_IMPORTANCE_FLOOR",
             "LIFECYCLE_FORGET_IDLE_SECONDS",
+            # Extraction (extraction/, #461) — read directly from Defaults
+            # (popoto.extraction.claude, popoto.recipes.subconscious_memory);
+            # no module-level alias exists, so not in MODULE_CONSTANTS.
+            "EXTRACTION_DEFAULT_IMPORTANCE",
+            "EXTRACTION_DEFAULT_CONFIDENCE",
+            "EXTRACTION_ENTITY_PAIR_LINK_WEIGHT",
         }
 
         expected_in_module = defaults_attrs - field_kwargs_and_class_attrs

--- a/tests/recipes/test_subconscious_extraction.py
+++ b/tests/recipes/test_subconscious_extraction.py
@@ -1,0 +1,450 @@
+"""Tests for SubconsciousMemory's pluggable extraction-provider wiring
+(issue #461): confidence seeding, co-occurrence seeding, per-fact importance,
+and per-seam failure isolation.
+
+All tests hit real Redis (DB 15, auto-isolated via popoto.pytest_plugin).
+Extraction providers are FAKE (``AbstractExtractionProvider`` subclasses
+constructed in-test) -- no network, no API key, mirroring the FakeClient
+injection style used in tests/benchmarks/test_judged.py.
+
+See also:
+- tests/test_extraction.py for provider-level unit tests
+- tests/test_subconscious_memory_integration.py for the pre-existing
+  behavioral-gap integration suite (unaffected by this change)
+"""
+
+import logging
+
+import pytest
+
+from popoto import (
+    AutoKeyField,
+    ConfidenceField,
+    CoOccurrenceField,
+    FloatField,
+    KeyField,
+    Model,
+    StringField,
+)
+from popoto.extraction import AbstractExtractionProvider, ExtractedFact
+from popoto.recipes.subconscious_memory import SubconsciousMemory
+from popoto.redis_db import POPOTO_REDIS_DB
+
+
+# ---------------------------------------------------------------------------
+# Test Models
+# ---------------------------------------------------------------------------
+
+
+class ExtMemory(Model):
+    """Minimal model -- content + importance only, no ConfidenceField/
+    CoOccurrenceField. Used for the default-behavior equivalence tests."""
+
+    memory_id = AutoKeyField()
+    agent_id = KeyField()
+    content = StringField(default="")
+    importance = FloatField(default=1.0)
+
+
+class ExtMemoryFull(Model):
+    """Full model -- has both a ConfidenceField and a CoOccurrenceField, for
+    the seam-specific seeding tests."""
+
+    memory_id = AutoKeyField()
+    agent_id = KeyField()
+    content = StringField(default="")
+    importance = FloatField(default=1.0)
+    confidence = ConfidenceField(initial_confidence=0.5)
+    associations = CoOccurrenceField(symmetric=True, max_edges=50)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _clean_keys(*patterns):
+    for pattern in patterns:
+        keys = POPOTO_REDIS_DB.keys(pattern)
+        if keys:
+            POPOTO_REDIS_DB.delete(*keys)
+
+
+def _clean_all():
+    _clean_keys(
+        "*ExtMemoryFull*",
+        "$EF:*ExtMemoryFull*",
+        "$FS:*ExtMemoryFull*",
+        "$CoOcF:*ExtMemoryFull*",
+        "$ConfidencF:*ExtMemoryFull*",
+        "$SortedF:*ExtMemoryFull*",
+        "*ExtMemory:*",
+        "$EF:*ExtMemory:*",
+        "$FS:*ExtMemory:*",
+    )
+
+
+@pytest.fixture(autouse=True)
+def clean_redis():
+    _clean_all()
+    yield
+    _clean_all()
+
+
+class FakeProvider(AbstractExtractionProvider):
+    """A fake AbstractExtractionProvider that returns a canned list of
+    ExtractedFact records, recording every extract() call."""
+
+    def __init__(self, facts):
+        self._facts = facts
+        self.calls = []
+
+    def extract(self, text):
+        self.calls.append(text)
+        return list(self._facts)
+
+
+# ===========================================================================
+# Default-behavior equivalence (no new kwargs passed)
+# ===========================================================================
+
+
+class TestDefaultBehaviorEquivalence:
+    """extract_memories() with no extraction_provider/confidence_field/
+    co_occurrence_field kwargs must write IDENTICAL records to pre-change
+    behavior: same content, flat importance from the caller arg, no
+    CoOccurrenceField links, no ConfidenceField update triggered."""
+
+    def test_content_and_flat_importance(self):
+        sm = SubconsciousMemory(
+            model_class=ExtMemory,
+            agent_id="default-agent",
+            score_weights={"relevance": 0.6},
+        )
+
+        saved = sm.extract_memories(
+            "First sentence goes here for real. Second sentence follows too.",
+            importance=0.42,
+        )
+
+        assert len(saved) == 2
+        contents = sorted(r.content for r in saved)
+        assert contents == [
+            "First sentence goes here for real.",
+            "Second sentence follows too.",
+        ]
+        for r in saved:
+            assert r.importance == 0.42
+            assert r.agent_id == "default-agent"
+
+    def test_no_confidence_field_present_no_crash(self):
+        """Model has no ConfidenceField at all -- extract_memories must not
+        error even though the recipe supports confidence seeding."""
+        sm = SubconsciousMemory(
+            model_class=ExtMemory,
+            agent_id="default-agent-2",
+            score_weights={"relevance": 0.6},
+        )
+        saved = sm.extract_memories("A single sentence with no opinions.", importance=0.5)
+        assert len(saved) == 1
+
+    def test_no_co_occurrence_field_present_no_crash(self):
+        sm = SubconsciousMemory(
+            model_class=ExtMemory,
+            agent_id="default-agent-3",
+            score_weights={"relevance": 0.6},
+        )
+        saved = sm.extract_memories("Another plain sentence right here.", importance=0.5)
+        assert len(saved) == 1
+
+    def test_empty_response_returns_empty(self):
+        sm = SubconsciousMemory(
+            model_class=ExtMemory,
+            agent_id="default-agent-4",
+            score_weights={"relevance": 0.6},
+        )
+        assert sm.extract_memories("", importance=0.5) == []
+        assert sm.extract_memories("   ", importance=0.5) == []
+
+
+# ===========================================================================
+# Co-occurrence seeding
+# ===========================================================================
+
+
+class TestCoOccurrenceSeeding:
+    def test_edge_created_with_two_plus_entities_and_field_configured(self):
+        provider = FakeProvider(
+            [
+                ExtractedFact(
+                    text="Alice and Bob met.",
+                    entities=["Alice", "Bob"],
+                )
+            ]
+        )
+        sm = SubconsciousMemory(
+            model_class=ExtMemoryFull,
+            agent_id="coocc-agent",
+            score_weights={"relevance": 0.6},
+            extraction_provider=provider,
+            co_occurrence_field="associations",
+        )
+
+        saved = sm.extract_memories("Alice and Bob met.", importance=0.5)
+        assert len(saved) == 1
+
+        field = ExtMemoryFull.associations
+        linked_from_alice = field.get_linked(ExtMemoryFull, "Alice")
+        linked_from_bob = field.get_linked(ExtMemoryFull, "Bob")
+        assert any(pk == "Bob" for pk, _weight in linked_from_alice)
+        assert any(pk == "Alice" for pk, _weight in linked_from_bob)
+
+    def test_no_edge_when_co_occurrence_field_not_configured(self):
+        provider = FakeProvider(
+            [
+                ExtractedFact(
+                    text="Carol and Dave met.",
+                    entities=["Carol", "Dave"],
+                )
+            ]
+        )
+        sm = SubconsciousMemory(
+            model_class=ExtMemoryFull,
+            agent_id="coocc-agent-2",
+            score_weights={"relevance": 0.6},
+            extraction_provider=provider,
+            # co_occurrence_field intentionally omitted
+        )
+
+        saved = sm.extract_memories("Carol and Dave met.", importance=0.5)
+        assert len(saved) == 1
+
+        field = ExtMemoryFull.associations
+        assert field.get_linked(ExtMemoryFull, "Carol") == []
+        assert field.get_linked(ExtMemoryFull, "Dave") == []
+
+    def test_no_edge_when_fewer_than_two_entities(self):
+        provider = FakeProvider(
+            [
+                ExtractedFact(text="Solo mention of Eve.", entities=["Eve"])
+            ]
+        )
+        sm = SubconsciousMemory(
+            model_class=ExtMemoryFull,
+            agent_id="coocc-agent-3",
+            score_weights={"relevance": 0.6},
+            extraction_provider=provider,
+            co_occurrence_field="associations",
+        )
+
+        saved = sm.extract_memories("Solo mention of Eve.", importance=0.5)
+        assert len(saved) == 1
+
+        field = ExtMemoryFull.associations
+        assert field.get_linked(ExtMemoryFull, "Eve") == []
+
+
+# ===========================================================================
+# Per-fact importance override
+# ===========================================================================
+
+
+class TestPerFactImportance:
+    def test_fact_importance_overrides_flat_default(self):
+        provider = FakeProvider(
+            [
+                ExtractedFact(text="High importance fact.", importance=0.95),
+                ExtractedFact(text="No opinion fact.", importance=None),
+            ]
+        )
+        sm = SubconsciousMemory(
+            model_class=ExtMemory,
+            agent_id="importance-agent",
+            score_weights={"relevance": 0.6},
+            extraction_provider=provider,
+        )
+
+        saved = sm.extract_memories("irrelevant raw text", importance=0.2)
+        assert len(saved) == 2
+
+        by_content = {r.content: r for r in saved}
+        assert by_content["High importance fact."].importance == 0.95
+        # No opinion -> falls back to the caller-supplied flat importance.
+        assert by_content["No opinion fact."].importance == 0.2
+
+
+# ===========================================================================
+# Confidence seeding
+# ===========================================================================
+
+
+class TestConfidenceSeeding:
+    def test_confidence_field_updated_when_configured_and_fact_has_opinion(self):
+        provider = FakeProvider(
+            [ExtractedFact(text="A confident fact.", confidence=0.95)]
+        )
+        sm = SubconsciousMemory(
+            model_class=ExtMemoryFull,
+            agent_id="conf-agent",
+            score_weights={"relevance": 0.6},
+            extraction_provider=provider,
+            confidence_field="confidence",
+        )
+
+        saved = sm.extract_memories("irrelevant raw text", importance=0.5)
+        assert len(saved) == 1
+        instance = saved[0]
+
+        stored = ConfidenceField.get_confidence(instance, "confidence")
+        # update_confidence() blends the signal with initial_confidence
+        # (0.5) rather than storing the signal verbatim -- so the stored
+        # value should differ from the model's untouched initial_confidence.
+        assert stored != 0.5
+
+    def test_confidence_field_untouched_when_not_configured(self):
+        provider = FakeProvider(
+            [ExtractedFact(text="An unseeded fact.", confidence=0.95)]
+        )
+        sm = SubconsciousMemory(
+            model_class=ExtMemoryFull,
+            agent_id="conf-agent-2",
+            score_weights={"relevance": 0.6},
+            extraction_provider=provider,
+            # confidence_field intentionally omitted
+        )
+
+        saved = sm.extract_memories("irrelevant raw text", importance=0.5)
+        assert len(saved) == 1
+        instance = saved[0]
+
+        stored = ConfidenceField.get_confidence(instance, "confidence")
+        assert stored == 0.5
+
+    def test_confidence_field_untouched_when_fact_has_no_opinion(self):
+        provider = FakeProvider(
+            [ExtractedFact(text="No confidence opinion.", confidence=None)]
+        )
+        sm = SubconsciousMemory(
+            model_class=ExtMemoryFull,
+            agent_id="conf-agent-3",
+            score_weights={"relevance": 0.6},
+            extraction_provider=provider,
+            confidence_field="confidence",
+        )
+
+        saved = sm.extract_memories("irrelevant raw text", importance=0.5)
+        assert len(saved) == 1
+        instance = saved[0]
+
+        stored = ConfidenceField.get_confidence(instance, "confidence")
+        assert stored == 0.5
+
+
+# ===========================================================================
+# Per-record save-failure isolation
+# ===========================================================================
+
+
+class TestSaveFailureIsolation:
+    def test_one_failing_save_does_not_abort_the_rest(self, monkeypatch, caplog):
+        provider = FakeProvider(
+            [
+                ExtractedFact(text="Good fact one."),
+                ExtractedFact(text="Poison fact."),
+                ExtractedFact(text="Good fact two."),
+            ]
+        )
+        sm = SubconsciousMemory(
+            model_class=ExtMemory,
+            agent_id="fail-agent",
+            score_weights={"relevance": 0.6},
+            extraction_provider=provider,
+        )
+
+        real_save = ExtMemory.save
+
+        def flaky_save(self, *args, **kwargs):
+            if self.content == "Poison fact.":
+                raise RuntimeError("simulated save failure")
+            return real_save(self, *args, **kwargs)
+
+        monkeypatch.setattr(ExtMemory, "save", flaky_save)
+
+        with caplog.at_level(logging.WARNING, logger="POPOTO.SubconsciousMemory"):
+            saved = sm.extract_memories("irrelevant raw text", importance=0.5)
+
+        contents = sorted(r.content for r in saved)
+        assert contents == ["Good fact one.", "Good fact two."]
+        assert any(
+            "failed to save" in r.message.lower() for r in caplog.records
+        ), f"Expected a warning log, got: {[r.message for r in caplog.records]}"
+
+
+# ===========================================================================
+# link()/update_confidence() failure does not lose the saved memory
+# ===========================================================================
+
+
+class TestSeamFailureDoesNotLoseSavedMemory:
+    def test_co_occurrence_link_failure_keeps_saved_memory(self, monkeypatch, caplog):
+        provider = FakeProvider(
+            [
+                ExtractedFact(
+                    text="Frank and Grace collaborated.",
+                    entities=["Frank", "Grace"],
+                )
+            ]
+        )
+        sm = SubconsciousMemory(
+            model_class=ExtMemoryFull,
+            agent_id="link-fail-agent",
+            score_weights={"relevance": 0.6},
+            extraction_provider=provider,
+            co_occurrence_field="associations",
+        )
+
+        def flaky_link(self, *args, **kwargs):
+            raise RuntimeError("simulated link failure")
+
+        monkeypatch.setattr(
+            type(ExtMemoryFull.associations), "link", flaky_link
+        )
+
+        with caplog.at_level(logging.WARNING, logger="POPOTO.SubconsciousMemory"):
+            saved = sm.extract_memories("irrelevant raw text", importance=0.5)
+
+        assert len(saved) == 1
+        assert saved[0].content == "Frank and Grace collaborated."
+        assert any(
+            "link" in r.message.lower() and "failed" in r.message.lower()
+            for r in caplog.records
+        ), f"Expected a link-failure warning log, got: {[r.message for r in caplog.records]}"
+
+    def test_update_confidence_failure_keeps_saved_memory(self, monkeypatch, caplog):
+        provider = FakeProvider(
+            [ExtractedFact(text="A fact whose confidence seed will fail.", confidence=0.8)]
+        )
+        sm = SubconsciousMemory(
+            model_class=ExtMemoryFull,
+            agent_id="confseed-fail-agent",
+            score_weights={"relevance": 0.6},
+            extraction_provider=provider,
+            confidence_field="confidence",
+        )
+
+        def flaky_update_confidence(cls, model_instance, field_name, signal, pipeline=None):
+            raise RuntimeError("simulated confidence update failure")
+
+        monkeypatch.setattr(
+            ConfidenceField, "update_confidence", classmethod(flaky_update_confidence)
+        )
+
+        with caplog.at_level(logging.WARNING, logger="POPOTO.SubconsciousMemory"):
+            saved = sm.extract_memories("irrelevant raw text", importance=0.5)
+
+        assert len(saved) == 1
+        assert saved[0].content == "A fact whose confidence seed will fail."
+        assert any(
+            "confidence" in r.message.lower() and "failed" in r.message.lower()
+            for r in caplog.records
+        ), f"Expected a confidence-seed-failure warning log, got: {[r.message for r in caplog.records]}"

--- a/tests/recipes/test_subconscious_extraction.py
+++ b/tests/recipes/test_subconscious_extraction.py
@@ -30,7 +30,6 @@ from popoto.extraction import AbstractExtractionProvider, ExtractedFact
 from popoto.recipes.subconscious_memory import SubconsciousMemory
 from popoto.redis_db import POPOTO_REDIS_DB
 
-
 # ---------------------------------------------------------------------------
 # Test Models
 # ---------------------------------------------------------------------------
@@ -145,7 +144,9 @@ class TestDefaultBehaviorEquivalence:
             agent_id="default-agent-2",
             score_weights={"relevance": 0.6},
         )
-        saved = sm.extract_memories("A single sentence with no opinions.", importance=0.5)
+        saved = sm.extract_memories(
+            "A single sentence with no opinions.", importance=0.5
+        )
         assert len(saved) == 1
 
     def test_no_co_occurrence_field_present_no_crash(self):
@@ -154,7 +155,9 @@ class TestDefaultBehaviorEquivalence:
             agent_id="default-agent-3",
             score_weights={"relevance": 0.6},
         )
-        saved = sm.extract_memories("Another plain sentence right here.", importance=0.5)
+        saved = sm.extract_memories(
+            "Another plain sentence right here.", importance=0.5
+        )
         assert len(saved) == 1
 
     def test_empty_response_returns_empty(self):
@@ -225,9 +228,7 @@ class TestCoOccurrenceSeeding:
 
     def test_no_edge_when_fewer_than_two_entities(self):
         provider = FakeProvider(
-            [
-                ExtractedFact(text="Solo mention of Eve.", entities=["Eve"])
-            ]
+            [ExtractedFact(text="Solo mention of Eve.", entities=["Eve"])]
         )
         sm = SubconsciousMemory(
             model_class=ExtMemoryFull,
@@ -242,6 +243,42 @@ class TestCoOccurrenceSeeding:
 
         field = ExtMemoryFull.associations
         assert field.get_linked(ExtMemoryFull, "Eve") == []
+
+    def test_duplicate_entities_deduped_no_self_loop_error(self):
+        """A fact whose entities list repeats a name (e.g. ["Alice", "Bob",
+        "Alice"]) must not raise -- CoOccurrenceField.link() rejects
+        self-pairs, so _seed_associations dedupes entities (order-stable)
+        before pairing. This pins the B2 fix: exactly one edge pair
+        (Alice, Bob) is created, with no self-pair attempted."""
+        provider = FakeProvider(
+            [
+                ExtractedFact(
+                    text="Alice mentioned Bob, then Alice again.",
+                    entities=["Alice", "Bob", "Alice"],
+                )
+            ]
+        )
+        sm = SubconsciousMemory(
+            model_class=ExtMemoryFull,
+            agent_id="coocc-agent-4",
+            score_weights={"relevance": 0.6},
+            extraction_provider=provider,
+            co_occurrence_field="associations",
+        )
+
+        # Must not raise (e.g. a ValueError from a self-pair reaching link()).
+        saved = sm.extract_memories(
+            "Alice mentioned Bob, then Alice again.", importance=0.5
+        )
+        assert len(saved) == 1
+
+        field = ExtMemoryFull.associations
+        linked_from_alice = field.get_linked(ExtMemoryFull, "Alice")
+        linked_from_bob = field.get_linked(ExtMemoryFull, "Bob")
+
+        # Exactly one edge pair: Alice<->Bob, no self-loop on Alice.
+        assert [pk for pk, _weight in linked_from_alice] == ["Bob"]
+        assert [pk for pk, _weight in linked_from_bob] == ["Alice"]
 
 
 # ===========================================================================
@@ -406,9 +443,7 @@ class TestSeamFailureDoesNotLoseSavedMemory:
         def flaky_link(self, *args, **kwargs):
             raise RuntimeError("simulated link failure")
 
-        monkeypatch.setattr(
-            type(ExtMemoryFull.associations), "link", flaky_link
-        )
+        monkeypatch.setattr(type(ExtMemoryFull.associations), "link", flaky_link)
 
         with caplog.at_level(logging.WARNING, logger="POPOTO.SubconsciousMemory"):
             saved = sm.extract_memories("irrelevant raw text", importance=0.5)
@@ -422,7 +457,11 @@ class TestSeamFailureDoesNotLoseSavedMemory:
 
     def test_update_confidence_failure_keeps_saved_memory(self, monkeypatch, caplog):
         provider = FakeProvider(
-            [ExtractedFact(text="A fact whose confidence seed will fail.", confidence=0.8)]
+            [
+                ExtractedFact(
+                    text="A fact whose confidence seed will fail.", confidence=0.8
+                )
+            ]
         )
         sm = SubconsciousMemory(
             model_class=ExtMemoryFull,
@@ -432,7 +471,9 @@ class TestSeamFailureDoesNotLoseSavedMemory:
             confidence_field="confidence",
         )
 
-        def flaky_update_confidence(cls, model_instance, field_name, signal, pipeline=None):
+        def flaky_update_confidence(
+            cls, model_instance, field_name, signal, pipeline=None
+        ):
             raise RuntimeError("simulated confidence update failure")
 
         monkeypatch.setattr(

--- a/tests/recipes/test_subconscious_extraction.py
+++ b/tests/recipes/test_subconscious_extraction.py
@@ -27,6 +27,7 @@ from popoto import (
     StringField,
 )
 from popoto.extraction import AbstractExtractionProvider, ExtractedFact
+from popoto.fields.constants import Defaults
 from popoto.recipes.subconscious_memory import SubconsciousMemory
 from popoto.redis_db import POPOTO_REDIS_DB
 
@@ -279,6 +280,39 @@ class TestCoOccurrenceSeeding:
         # Exactly one edge pair: Alice<->Bob, no self-loop on Alice.
         assert [pk for pk, _weight in linked_from_alice] == ["Bob"]
         assert [pk for pk, _weight in linked_from_bob] == ["Alice"]
+
+    def test_entity_pairing_capped_at_max_entities_per_fact(self):
+        """A fact with more entities than
+        Defaults.EXTRACTION_MAX_ENTITIES_PER_FACT must only pair the first
+        N (deduped, order-stable) entities, not the full combinatorial set.
+        This pins the O(n^2) cap: without it, a malformed/adversarial
+        extraction result with many entities could generate an unbounded
+        burst of co-occurrence writes for a single fact."""
+        cap = Defaults.EXTRACTION_MAX_ENTITIES_PER_FACT
+        entities = [f"Entity{i}" for i in range(cap + 5)]
+        provider = FakeProvider(
+            [ExtractedFact(text="Many entities mentioned.", entities=entities)]
+        )
+        sm = SubconsciousMemory(
+            model_class=ExtMemoryFull,
+            agent_id="coocc-agent-cap",
+            score_weights={"relevance": 0.6},
+            extraction_provider=provider,
+            co_occurrence_field="associations",
+        )
+
+        saved = sm.extract_memories("Many entities mentioned.", importance=0.5)
+        assert len(saved) == 1
+
+        field = ExtMemoryFull.associations
+
+        # Entities within the cap got paired (and thus linked).
+        for name in entities[:cap]:
+            assert field.get_linked(ExtMemoryFull, name) != []
+
+        # Entities beyond the cap were excluded from pairing entirely.
+        for name in entities[cap:]:
+            assert field.get_linked(ExtMemoryFull, name) == []
 
 
 # ===========================================================================

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,0 +1,470 @@
+"""Tests for popoto.extraction: ExtractedFact, providers, and the pluggable
+extraction seam used by SubconsciousMemory.
+
+Covers:
+- HeuristicExtractionProvider is a byte-identical port of the pre-change
+  ``SubconsciousMemory._split_sentences`` + min-length-filter behavior.
+- ``import popoto`` / ``import popoto.extraction`` never pull in ``anthropic``
+  (opt-in-only contract).
+- ``ClaudeExtractionProvider()`` raises an actionable ``ImportError`` when
+  ``anthropic`` is unavailable.
+- ``ClaudeExtractionProvider.extract()`` parsing/clamping/failure paths via an
+  injected FAKE client (no network, no API key) -- same seam style as
+  ``tests/benchmarks/test_judged.py``'s ``FakeClient``.
+- Model/prompt pins.
+
+Runs with **no real anthropic API calls** -- the client is always a fake
+injected via the constructor's ``self._client`` seam.
+"""
+
+import logging
+import sys
+
+import pytest
+
+from popoto.extraction import (
+    AbstractExtractionProvider,
+    DEFAULT_MIN_LENGTH,
+    ExtractedFact,
+    HeuristicExtractionProvider,
+)
+from popoto.fields.constants import Defaults
+from popoto.recipes.subconscious_memory import SubconsciousMemory
+
+
+# ---------------------------------------------------------------------------
+# HeuristicExtractionProvider: before/after equivalence pin
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicEquivalence:
+    """Pin HeuristicExtractionProvider against the pre-change
+    SubconsciousMemory._split_sentences() + min-length-filter logic."""
+
+    REPRESENTATIVE_INPUTS = [
+        "The API uses REST endpoints. Authentication is via Bearer tokens.",
+        "Is this working? Yes it is! Great news.",
+        "- item one\n- item two\n- item three",
+        "Version 3.14 was released. It includes fixes.",
+        "Visit https://example.com. Next sentence here.",
+        "",
+        "   ",
+        "Short. Ok.",
+    ]
+
+    def _expected(self, text, min_length=DEFAULT_MIN_LENGTH):
+        """Reproduce the pre-change logic directly against the pinned
+        SubconsciousMemory._split_sentences staticmethod."""
+        if not text or not text.strip():
+            return []
+        sentences = SubconsciousMemory._split_sentences(text)
+        return [s.strip() for s in sentences if len(s.strip()) >= min_length]
+
+    @pytest.mark.parametrize("text", REPRESENTATIVE_INPUTS)
+    def test_matches_pre_change_behavior(self, text):
+        provider = HeuristicExtractionProvider()
+        facts = provider.extract(text)
+        got = [f.text for f in facts]
+        assert got == self._expected(text)
+
+    def test_matches_pre_change_behavior_custom_min_length(self):
+        text = "Hi. This is a longer sentence that survives filtering."
+        provider = HeuristicExtractionProvider(min_length=5)
+        facts = provider.extract(text)
+        got = [f.text for f in facts]
+        assert got == self._expected(text, min_length=5)
+
+    def test_facts_have_no_entities_or_opinions(self):
+        """The heuristic provider never has an opinion -- entities empty,
+        importance/confidence None -- so downstream falls back to the
+        caller-supplied importance and leaves confidence untouched."""
+        provider = HeuristicExtractionProvider()
+        facts = provider.extract("A sufficiently long first sentence here. And a second one too.")
+        assert len(facts) == 2
+        for fact in facts:
+            assert fact.entities == []
+            assert fact.importance is None
+            assert fact.confidence is None
+
+    def test_empty_and_whitespace_input(self):
+        provider = HeuristicExtractionProvider()
+        assert provider.extract("") == []
+        assert provider.extract("   ") == []
+        assert provider.extract(None) == []
+
+    def test_below_min_length_filtered(self):
+        provider = HeuristicExtractionProvider(min_length=10)
+        facts = provider.extract("Hi. Ok.")
+        assert facts == []
+
+
+# ---------------------------------------------------------------------------
+# Opt-in-only import contract
+# ---------------------------------------------------------------------------
+
+
+class TestOptInImportContract:
+    def test_import_popoto_does_not_import_anthropic(self):
+        # popoto is already imported by the test collection process; this
+        # asserts the *transitive* import graph never pulled anthropic in.
+        import popoto  # noqa: F401
+
+        assert "anthropic" not in sys.modules
+
+    def test_import_popoto_extraction_does_not_import_anthropic(self):
+        import popoto.extraction  # noqa: F401
+
+        assert "anthropic" not in sys.modules
+
+    def test_claude_module_importable_without_anthropic_installed(self):
+        """popoto.extraction.claude itself is always importable (the
+        ``import anthropic`` inside it is wrapped in try/except), regardless
+        of whether the anthropic SDK happens to be installed in this env."""
+        import popoto.extraction.claude as claude_mod
+
+        assert claude_mod.ClaudeExtractionProvider is not None
+
+
+# ---------------------------------------------------------------------------
+# ClaudeExtractionProvider: ImportError when anthropic unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeProviderImportError:
+    def test_raises_actionable_import_error_when_anthropic_unavailable(
+        self, monkeypatch
+    ):
+        import popoto.extraction.claude as claude_mod
+
+        monkeypatch.setattr(claude_mod, "_anthropic_available", False)
+
+        with pytest.raises(ImportError, match=r"pip install popoto\[anthropic\]"):
+            claude_mod.ClaudeExtractionProvider()
+
+    def test_error_message_names_anthropic(self, monkeypatch):
+        import popoto.extraction.claude as claude_mod
+
+        monkeypatch.setattr(claude_mod, "_anthropic_available", False)
+
+        with pytest.raises(ImportError, match="anthropic"):
+            claude_mod.ClaudeExtractionProvider()
+
+
+# ---------------------------------------------------------------------------
+# ClaudeExtractionProvider: parsing/clamping/failure via injected fake client
+# ---------------------------------------------------------------------------
+
+
+class FakeAnthropicTextBlock:
+    def __init__(self, text):
+        self.type = "text"
+        self.text = text
+
+
+class FakeAnthropicResponse:
+    def __init__(self, text):
+        self.content = [FakeAnthropicTextBlock(text)]
+
+
+class FakeAnthropicMessages:
+    """Fake ``client.messages`` -- records calls, returns a canned
+    ``FakeAnthropicResponse`` (or raises) from ``create()``."""
+
+    def __init__(self, response_text=None, raise_exc=None):
+        self.response_text = response_text
+        self.raise_exc = raise_exc
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return FakeAnthropicResponse(self.response_text)
+
+
+class FakeAnthropicClient:
+    def __init__(self, response_text=None, raise_exc=None):
+        self.messages = FakeAnthropicMessages(
+            response_text=response_text, raise_exc=raise_exc
+        )
+
+
+def _make_provider(monkeypatch, response_text=None, raise_exc=None):
+    """Build a ClaudeExtractionProvider with a fake client injected via the
+    constructor's ``self._client`` seam -- no network, no API key.
+
+    Mirrors tests/benchmarks/test_judged.py's FakeClient-injection style:
+    bypass __init__'s real Anthropic() construction by forcing
+    _anthropic_available True (so the ImportError guard is skipped) and
+    monkeypatching the module's Anthropic class to a lightweight factory.
+    """
+    import popoto.extraction.claude as claude_mod
+
+    fake_client = FakeAnthropicClient(response_text=response_text, raise_exc=raise_exc)
+
+    class _FakeAnthropicModule:
+        @staticmethod
+        def Anthropic(api_key=None):
+            return fake_client
+
+    monkeypatch.setattr(claude_mod, "_anthropic_available", True)
+    monkeypatch.setattr(claude_mod, "anthropic_module", _FakeAnthropicModule())
+
+    provider = claude_mod.ClaudeExtractionProvider(api_key="fake-key")
+    return provider, fake_client
+
+
+class TestClaudeProviderExtraction:
+    def test_well_formed_response_produces_correct_facts(self, monkeypatch):
+        import json
+
+        response = json.dumps(
+            {
+                "facts": [
+                    {
+                        "text": "Alice met Bob in Paris.",
+                        "entities": ["Alice", "Bob", "Paris"],
+                        "importance": 0.8,
+                        "confidence": 0.9,
+                    },
+                    {
+                        "text": "The meeting was productive.",
+                        "entities": [],
+                        "importance": 0.3,
+                        "confidence": 0.6,
+                    },
+                ]
+            }
+        )
+        provider, fake_client = _make_provider(monkeypatch, response_text=response)
+
+        facts = provider.extract("Alice met Bob in Paris. The meeting was productive.")
+
+        assert len(facts) == 2
+        assert facts[0] == ExtractedFact(
+            text="Alice met Bob in Paris.",
+            entities=["Alice", "Bob", "Paris"],
+            importance=0.8,
+            confidence=0.9,
+        )
+        assert facts[1] == ExtractedFact(
+            text="The meeting was productive.",
+            entities=[],
+            importance=0.3,
+            confidence=0.6,
+        )
+        # One API call, using the pinned model/prompt/schema.
+        assert len(fake_client.messages.calls) == 1
+        call = fake_client.messages.calls[0]
+        assert call["model"] == claude_module_constant("EXTRACTION_MODEL")
+        assert call["system"] == claude_module_constant("EXTRACTION_PROMPT")
+
+    def test_missing_importance_and_confidence_default(self, monkeypatch):
+        import json
+
+        response = json.dumps(
+            {
+                "facts": [
+                    {"text": "A fact with no opinions.", "entities": []},
+                ]
+            }
+        )
+        provider, _ = _make_provider(monkeypatch, response_text=response)
+
+        facts = provider.extract("A fact with no opinions.")
+
+        assert len(facts) == 1
+        assert facts[0].importance == Defaults.EXTRACTION_DEFAULT_IMPORTANCE
+        assert facts[0].confidence == Defaults.EXTRACTION_DEFAULT_CONFIDENCE
+
+    def test_out_of_range_importance_and_confidence_clamped(self, monkeypatch):
+        import json
+
+        response = json.dumps(
+            {
+                "facts": [
+                    {
+                        "text": "Too high and too low.",
+                        "entities": [],
+                        "importance": 5.0,
+                        "confidence": -3.0,
+                    },
+                ]
+            }
+        )
+        provider, _ = _make_provider(monkeypatch, response_text=response)
+
+        facts = provider.extract("Too high and too low.")
+
+        assert len(facts) == 1
+        assert facts[0].importance == 1.0
+        assert facts[0].confidence == 0.0
+
+    def test_non_numeric_importance_defaults(self, monkeypatch):
+        import json
+
+        response = json.dumps(
+            {
+                "facts": [
+                    {
+                        "text": "Non-numeric opinions.",
+                        "entities": [],
+                        "importance": "not-a-number",
+                        "confidence": None,
+                    },
+                ]
+            }
+        )
+        provider, _ = _make_provider(monkeypatch, response_text=response)
+
+        facts = provider.extract("Non-numeric opinions.")
+
+        assert len(facts) == 1
+        assert facts[0].importance == Defaults.EXTRACTION_DEFAULT_IMPORTANCE
+        assert facts[0].confidence == Defaults.EXTRACTION_DEFAULT_CONFIDENCE
+
+    def test_malformed_json_returns_empty_and_logs_warning(self, monkeypatch, caplog):
+        provider, _ = _make_provider(monkeypatch, response_text="not json at all {{{")
+
+        with caplog.at_level(logging.WARNING, logger="POPOTO.extraction"):
+            facts = provider.extract("Some text.")
+
+        assert facts == []
+        assert any(
+            "extraction failed" in r.message.lower() for r in caplog.records
+        ), f"Expected a warning log, got: {[r.message for r in caplog.records]}"
+
+    def test_missing_facts_key_returns_empty_and_logs_warning(self, monkeypatch, caplog):
+        import json
+
+        provider, _ = _make_provider(
+            monkeypatch, response_text=json.dumps({"not_facts": []})
+        )
+
+        with caplog.at_level(logging.WARNING, logger="POPOTO.extraction"):
+            facts = provider.extract("Some text.")
+
+        assert facts == []
+        assert any(
+            "facts" in r.message.lower() for r in caplog.records
+        ), f"Expected a warning log, got: {[r.message for r in caplog.records]}"
+
+    def test_client_raises_returns_empty_and_logs_warning(self, monkeypatch, caplog):
+        provider, _ = _make_provider(
+            monkeypatch, raise_exc=RuntimeError("simulated API failure")
+        )
+
+        with caplog.at_level(logging.WARNING, logger="POPOTO.extraction"):
+            facts = provider.extract("Some text.")
+
+        assert facts == []
+        assert any(
+            "extraction failed" in r.message.lower() for r in caplog.records
+        ), f"Expected a warning log, got: {[r.message for r in caplog.records]}"
+
+    def test_empty_and_whitespace_input_short_circuits(self, monkeypatch):
+        provider, fake_client = _make_provider(monkeypatch, response_text="{}")
+
+        assert provider.extract("") == []
+        assert provider.extract("   ") == []
+        # No API call should have been made for empty/blank input.
+        assert fake_client.messages.calls == []
+
+    def test_facts_with_non_dict_entries_are_skipped(self, monkeypatch):
+        import json
+
+        response = json.dumps(
+            {
+                "facts": [
+                    "not a dict",
+                    {"text": "A valid fact.", "entities": [], "importance": 0.5, "confidence": 0.5},
+                ]
+            }
+        )
+        provider, _ = _make_provider(monkeypatch, response_text=response)
+
+        facts = provider.extract("Some text.")
+
+        assert len(facts) == 1
+        assert facts[0].text == "A valid fact."
+
+    def test_facts_with_missing_or_blank_text_are_skipped(self, monkeypatch):
+        import json
+
+        response = json.dumps(
+            {
+                "facts": [
+                    {"entities": []},
+                    {"text": "   ", "entities": []},
+                    {"text": "Real fact.", "entities": []},
+                ]
+            }
+        )
+        provider, _ = _make_provider(monkeypatch, response_text=response)
+
+        facts = provider.extract("Some text.")
+
+        assert len(facts) == 1
+        assert facts[0].text == "Real fact."
+
+
+def claude_module_constant(name):
+    import popoto.extraction.claude as claude_mod
+
+    return getattr(claude_mod, name)
+
+
+# ---------------------------------------------------------------------------
+# Model + prompt pins
+# ---------------------------------------------------------------------------
+
+
+class TestModelAndPromptPins:
+    def test_model_is_pinned(self):
+        import popoto.extraction.claude as claude_mod
+
+        assert claude_mod.EXTRACTION_MODEL == "claude-opus-4-8"
+
+    def test_prompt_constant_exists_and_is_nonempty(self):
+        import popoto.extraction.claude as claude_mod
+
+        assert isinstance(claude_mod.EXTRACTION_PROMPT, str)
+        assert len(claude_mod.EXTRACTION_PROMPT) > 0
+
+    def test_facts_schema_shape(self):
+        import popoto.extraction.claude as claude_mod
+
+        schema = claude_mod.FACTS_SCHEMA
+        assert schema["type"] == "object"
+        assert "facts" in schema["properties"]
+        fact_schema = schema["properties"]["facts"]["items"]
+        assert set(fact_schema["required"]) == {
+            "text",
+            "entities",
+            "importance",
+            "confidence",
+        }
+
+
+# ---------------------------------------------------------------------------
+# ExtractedFact / AbstractExtractionProvider sanity
+# ---------------------------------------------------------------------------
+
+
+class TestExtractedFactAndAbstractProvider:
+    def test_cannot_instantiate_abstract_provider(self):
+        with pytest.raises(TypeError):
+            AbstractExtractionProvider()
+
+    def test_extracted_fact_with_fewer_than_two_entities_does_not_crash(self):
+        # < 2 entities is a normal, valid case -- construction must not raise.
+        f0 = ExtractedFact(text="No entities.", entities=[])
+        f1 = ExtractedFact(text="One entity.", entities=["Solo"])
+        assert f0.entities == []
+        assert f1.entities == ["Solo"]
+
+    def test_extracted_fact_defaults(self):
+        f = ExtractedFact(text="Just text.")
+        assert f.entities == []
+        assert f.importance is None
+        assert f.confidence is None

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -31,7 +31,6 @@ from popoto.extraction import (
 from popoto.fields.constants import Defaults
 from popoto.recipes.subconscious_memory import SubconsciousMemory
 
-
 # ---------------------------------------------------------------------------
 # HeuristicExtractionProvider: before/after equivalence pin
 # ---------------------------------------------------------------------------
@@ -79,7 +78,9 @@ class TestHeuristicEquivalence:
         importance/confidence None -- so downstream falls back to the
         caller-supplied importance and leaves confidence untouched."""
         provider = HeuristicExtractionProvider()
-        facts = provider.extract("A sufficiently long first sentence here. And a second one too.")
+        facts = provider.extract(
+            "A sufficiently long first sentence here. And a second one too."
+        )
         assert len(facts) == 2
         for fact in facts:
             assert fact.entities == []
@@ -334,7 +335,9 @@ class TestClaudeProviderExtraction:
             "extraction failed" in r.message.lower() for r in caplog.records
         ), f"Expected a warning log, got: {[r.message for r in caplog.records]}"
 
-    def test_missing_facts_key_returns_empty_and_logs_warning(self, monkeypatch, caplog):
+    def test_missing_facts_key_returns_empty_and_logs_warning(
+        self, monkeypatch, caplog
+    ):
         import json
 
         provider, _ = _make_provider(
@@ -377,7 +380,12 @@ class TestClaudeProviderExtraction:
             {
                 "facts": [
                     "not a dict",
-                    {"text": "A valid fact.", "entities": [], "importance": 0.5, "confidence": 0.5},
+                    {
+                        "text": "A valid fact.",
+                        "entities": [],
+                        "importance": 0.5,
+                        "confidence": 0.5,
+                    },
                 ]
             }
         )


### PR DESCRIPTION
## Summary
- Adds a pluggable, opt-in LLM-extraction path for `SubconsciousMemory.extract_memories()`, mirroring the existing `popoto.embeddings` provider pattern.
- New `popoto.extraction` package: `AbstractExtractionProvider` ABC, `ExtractedFact` dataclass, `HeuristicExtractionProvider` (zero-dependency default, wraps the pre-existing sentence-split heuristic byte-for-byte), and `ClaudeExtractionProvider` (opt-in, lazy `import anthropic`, pinned `claude-opus-4-8` model + prompt, JSON-schema structured output).
- `SubconsciousMemory` gains three optional kwargs — `extraction_provider`, `confidence_field`, `co_occurrence_field` — all defaulting to today's exact behavior. When configured, extraction now seeds `CoOccurrenceField` entity-pair links (>=2 entities) and `ConfidenceField` signals, and supports importance-on-write from the extractor.
- New `anthropic = ["anthropic>=0.40.0"]` optional extra in `pyproject.toml`; `import popoto` / `import popoto.extraction` never require it.
- New `Defaults` constants (`EXTRACTION_DEFAULT_IMPORTANCE`, `EXTRACTION_DEFAULT_CONFIDENCE`, `EXTRACTION_ENTITY_PAIR_LINK_WEIGHT`), tagged experimental per project convention.

## Changes
- `src/popoto/extraction/__init__.py` (new), `src/popoto/extraction/claude.py` (new)
- `src/popoto/fields/constants.py` — 3 new extraction constants
- `src/popoto/recipes/subconscious_memory.py` — rewritten `extract_memories()`, new `_seed_associations`/`_seed_confidence` helpers, new constructor kwargs
- `pyproject.toml` — `anthropic` optional extra
- `tests/test_extraction.py` (new), `tests/recipes/test_subconscious_extraction.py` (new) — 48 tests covering heuristic equivalence pin, import-safety, `ImportError` messaging, Claude-provider parse/clamp/failure via a fake client, model/prompt pins, importance-on-write, entity-pair linking (incl. duplicate-entity dedup regression), confidence seeding, and per-record/per-seam failure isolation
- `tests/benchmarks/test_defaults_sync.py` — registered the 3 new constants in the manifest exception set
- `docs/features/llm-memory-extraction.md` (new), `docs/features/README.md`, `docs/guides/subconscious-memory-recipe.md`, `mkdocs.yml` — feature doc, recipe-doc updates, nav entry

## Evaluation
Judged-accuracy/recall evaluation of LLM extraction vs. the heuristic default is **deferred** as a tracked follow-up under epic #456 Track B. Inspected `tests/benchmarks/{judge.py,run_external.py,test_judged.py}` and the ingestion path (`ExternalScenario.setup()`): the harness's ingestion path doesn't currently call `SubconsciousMemory.extract_memories()` at all (writes raw turns directly), and the judged-answer stage is hard-pinned to OpenAI `gpt-4o-mini` with no extraction-provider axis. Wiring a real comparison would need non-trivial harness surgery plus a live `ANTHROPIC_API_KEY`, which the plan's Prerequisites/No-Gos rule out of the default suite. No benchmark numbers were fabricated or estimated.

## Testing
- [x] `pytest tests/test_extraction.py tests/recipes/test_subconscious_extraction.py -q` — 48 passed
- [x] `pytest tests/ -q` — 2181+ passed; remaining failures independently confirmed pre-existing/environmental (missing `sentence-transformers` extra, a wall-clock weekday-boundary flake in `test_prediction_ledger.py` unrelated to this change, a stream-consumer timing flake, and the documented editable-install `test_version` drift per CLAUDE.md's `ci-local.sh` notes) — none touch extraction/recipe code
- [x] `ruff check` clean, `black --check` clean
- [x] `mkdocs build --strict` passes

## Documentation
- [x] `docs/features/llm-memory-extraction.md` created
- [x] `docs/guides/subconscious-memory-recipe.md` updated with the new kwargs
- [x] `mkdocs build --strict` passes

## Definition of Done
- [x] Built: Code implemented and working
- [x] Tested: All tests passing (pre-existing/environmental failures excluded, verified independently)
- [x] Documented: Docs created/updated
- [x] Quality: Lint and format checks pass

Closes #461