### PR TITLE
feat(#462): RelationshipField expansion + confidence/decay-modulated hop admission for graph traversal

### DIFF
--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -1301,6 +1301,7 @@ assembler = ContextAssembler(
     retrieval_mode="auto",    # "auto" (default), "hybrid", or "lexical"
     confidence_gate_threshold=None,  # float | None (default). See "Confidence Gate" below.
     confidence_gate_mode="refuse",   # "refuse" (default) or "flag"
+    graph_traversal_relationship_fields=None,  # list[str] | None (default). See "Graph Traversal" below.
 )
 ```
 
@@ -1504,6 +1505,56 @@ It is explicitly *not* `Defaults.CONFIDENCE_GATE_THRESHOLD` — no such
 it to a real default is a policy-level decision requiring maintainer
 sign-off (tracked in [issue #463](https://github.com/tomcounsell/popoto/issues/463)).
 
+### Graph Traversal
+
+An opt-in extension (issue #462) of the existing CoOccurrence graph arm
+(the "CoOccurrence propagation" step in the [Pipeline](#pipeline) diagram
+above). It is off by default — pass `graph_traversal_relationship_fields`
+to enable it; omitting it leaves `assemble()` byte-for-byte identical to
+before this feature.
+
+```python
+assembler = ContextAssembler(
+    model_class=Memory,
+    score_weights={"relevance": 0.6, "confidence": 0.3},
+    graph_traversal_relationship_fields=["related_memory"],
+)
+
+result = assembler.assemble(query_cues={"topic": "deployment"}, agent_id="agent-1")
+```
+
+**Mechanism.** Where the pipeline previously called
+`CoOccurrenceField.propagate()` directly, it now routes through
+[`popoto.recipes.graph_traversal.traverse()`](https://github.com/tomcounsell/popoto/blob/main/src/popoto/recipes/graph_traversal.py),
+which:
+
+1. Runs the existing `CoOccurrenceField.propagate()` BFS (unchanged).
+2. Additionally walks each named `Relationship` field 1-2 hops, in both
+   directions (a node's own relationship value, and other nodes pointing at
+   it via the field's `$RelationshipF:...` index Set), with fan-out bounded
+   per hop via `SRANDMEMBER`.
+3. Merges both signals (max-weight-wins per PK) and caps the result to a
+   fixed `max_candidates` *before* any instance is loaded, so traversal
+   cost stays bounded independent of graph fan-out.
+4. If the model declares a `ConfidenceField` and/or `DecayingSortedField`,
+   multiplies each surviving candidate's weight by its own confidence/decay
+   state, so a low-confidence or heavily decayed node is less likely to
+   survive into the merged candidate set than a fresh, corroborated one.
+
+**`graph_traversal_relationship_fields`** must name **self-referential**
+`Relationship` field(s) — a field on `model_class` whose `model` is
+`model_class` itself (e.g. a `Memory.related_memory = Relationship(model=Memory)`
+edge). A relationship pointing at a different model class is ignored with a
+logged warning at construction time (traversal degrades to the
+CoOccurrence-only signal, not an error), since `ContextAssembler` treats its
+candidate set as homogeneous.
+
+**Evaluation status.** This slice implements and unit-tests the traversal
+mechanism (`tests/test_graph_traversal.py`). The LoCoMo multi-hop slice and
+association-recall benchmark scenarios called for in issue #462 are tracked
+as a follow-up rather than run here — see the note in
+[the benchmarking strategy doc](../plans/benchmarking_strategy_2026-07.md#32-structuredgraph-memory-where-zep-hindsight-byterover-lead).
+
 ### Tuning Constants
 
 | Constant | Default | Description |
@@ -1513,6 +1564,11 @@ sign-off (tracked in [issue #463](https://github.com/tomcounsell/popoto/issues/4
 | `DEFAULT_MAX_ITEMS` | `10` | Default maximum number of records returned. |
 | `DEFAULT_PROPAGATION_DEPTH` | `2` | Default BFS depth for CoOccurrence propagation. |
 | `EXPERIMENTAL_CONFIDENCE_GATE_THRESHOLD` | `0.5` | **Not** a shipped default — used only by the confidence-gate refusal benchmark/report script. Requires maintainer sign-off before it could become a real `Defaults` entry or ctor default (issue #463). |
+
+`popoto/recipes/graph_traversal.py` defines its own experimental constants
+(`RELATIONSHIP_HOP_DECAY`, `RELATIONSHIP_HOP_FANOUT_LIMIT`,
+`GRAPH_TRAVERSAL_MAX_CANDIDATES`, `ADMISSION_THRESHOLD`) — in-code magic
+numbers, not user-facing config, matching the convention above.
 
 ### Graceful Degradation
 

--- a/docs/features/agent-memory.md
+++ b/docs/features/agent-memory.md
@@ -1552,7 +1552,8 @@ candidate set as homogeneous.
 **Evaluation status.** This slice implements and unit-tests the traversal
 mechanism (`tests/test_graph_traversal.py`). The LoCoMo multi-hop slice and
 association-recall benchmark scenarios called for in issue #462 are tracked
-as a follow-up rather than run here — see the note in
+as [issue #484](https://github.com/tomcounsell/popoto/issues/484) rather
+than run here — see the note in
 [the benchmarking strategy doc](../plans/benchmarking_strategy_2026-07.md#32-structuredgraph-memory-where-zep-hindsight-byterover-lead).
 
 ### Tuning Constants

--- a/docs/plans/benchmarking_strategy_2026-07.md
+++ b/docs/plans/benchmarking_strategy_2026-07.md
@@ -128,6 +128,24 @@ The LoCoMo regression (hybrid 0.1667 < lexical 0.2986 at R@1) is a real defect i
 
 The top judged-accuracy systems win multi-hop via **entity-graph traversal** (Zep), **four logical networks + retain-recall-reflect** (Hindsight), and **context-tree architectures** (ByteRover). Popoto has `RelationshipField` and `CoOccurrenceField` but no graph-traversal retrieval. Multi-hop is where flat retrieval structurally loses. Research a lightweight graph/traversal layer over the existing association primitives — this is the biggest *capability* gap, not just a tuning gap.
 
+**Status (#462, PR #483):** `CoOccurrenceField.propagate()`-based BFS graph
+traversal was already wired into `ContextAssembler` (both the composite and
+hybrid/lexical pull paths) prior to this issue being scoped. PR #483 closes
+the remaining gap: a new `popoto.recipes.graph_traversal` module extends
+that graph arm with (1) `RelationshipField` edge expansion — 1-2 hop
+forward/reverse traversal of self-referential `Relationship` fields, bounded
+fan-out via `SRANDMEMBER` — and (2) confidence/decay-modulated hop
+admission, where a candidate's own `ConfidenceField`/decaying-field state
+scales its survival weight. Opt-in via `ContextAssembler(...,
+graph_traversal_relationship_fields=[...])`; see
+[Graph Traversal](../features/agent-memory.md#graph-traversal) in the
+agent-memory feature doc for the full mechanism and API. **The LoCoMo
+multi-hop slice + association-recall evaluation this section calls for is
+still outstanding** — PR #483 implements and unit-tests the traversal
+mechanism only; the judged-accuracy/recall lift is unmeasured and tracked as
+a follow-up under epic #456 Track B, matching how §3.3's extraction-provider
+evaluation gap is tracked.
+
 ### 3.3 LLM-based extraction & structured memory writes
 
 Competitors' big lever is *structuring unstructured chat into semantic memory* on write (Memori explicitly attributes its lead to this). Popoto's default `extract_memories()` is still a **sentence-splitting heuristic** for backward compatibility, but as of #461/PR #481 it is now pluggable: `SubconsciousMemory` accepts an `extraction_provider` (see [LLM Memory Extraction](../features/llm-memory-extraction.md)) that can return entities, typed facts, and importance/confidence scoring on write, feeding `CoOccurrenceField` and `ConfidenceField` directly. The built-in `ClaudeExtractionProvider` covers the LLM-extraction mechanism; **judged-accuracy/recall evaluation of it vs. the heuristic default is still outstanding**, tracked under epic #456 Track B, since the existing benchmark harness has no extraction-provider seam yet. That evaluation -- not the mechanism -- is what remains to confirm the SIQ/MDF lift this section predicted.

--- a/docs/plans/benchmarking_strategy_2026-07.md
+++ b/docs/plans/benchmarking_strategy_2026-07.md
@@ -143,8 +143,9 @@ agent-memory feature doc for the full mechanism and API. **The LoCoMo
 multi-hop slice + association-recall evaluation this section calls for is
 still outstanding** — PR #483 implements and unit-tests the traversal
 mechanism only; the judged-accuracy/recall lift is unmeasured and tracked as
-a follow-up under epic #456 Track B, matching how §3.3's extraction-provider
-evaluation gap is tracked.
+[issue #484](https://github.com/tomcounsell/popoto/issues/484) under epic
+#456 Track B, matching how §3.3's extraction-provider evaluation gap is
+tracked.
 
 ### 3.3 LLM-based extraction & structured memory writes
 

--- a/src/popoto/recipes/context_assembler.py
+++ b/src/popoto/recipes/context_assembler.py
@@ -990,6 +990,18 @@ class ContextAssembler:
             ``EXPERIMENTAL_CONFIDENCE_GATE_THRESHOLD`` and issue #463).
         confidence_gate_mode: ``"refuse"`` (default) or ``"flag"``. Only
             meaningful when ``confidence_gate_threshold`` is not ``None``.
+        graph_traversal_relationship_fields: Optional list of
+            self-referential ``Relationship`` field name(s) on
+            ``model_class`` (i.e. the field's ``model`` is ``model_class``
+            itself). When set, the existing CoOccurrence graph arm (both
+            pull-path modes) is extended via
+            :func:`popoto.recipes.graph_traversal.traverse` to also expand
+            1-2 hops across those Relationship edges, with hop admission
+            modulated by the model's ``ConfidenceField``/decaying-field
+            state when present. Default ``None`` (disabled; behavior is
+            identical to before #462). Entries that are not a valid
+            self-referential ``Relationship`` field are ignored with a
+            warning rather than raising. See issue #462.
 
     Raises:
         QueryException: If ``retrieval_mode="hybrid"`` is requested but the
@@ -1014,6 +1026,7 @@ class ContextAssembler:
         retrieval_mode: str = "auto",
         confidence_gate_threshold: float | None = None,
         confidence_gate_mode: str = "refuse",
+        graph_traversal_relationship_fields: list | None = None,
     ):
         self.model_class = model_class
         self.score_weights = score_weights
@@ -1024,6 +1037,11 @@ class ContextAssembler:
         self.output_format = output_format
         self.confidence_gate_threshold = confidence_gate_threshold
         self.confidence_gate_mode = confidence_gate_mode
+        self._graph_traversal_relationship_fields = (
+            list(graph_traversal_relationship_fields)
+            if graph_traversal_relationship_fields
+            else None
+        )
         if token_counter is None:
             self._token_counter = _estimate_tokens
         else:
@@ -1106,6 +1124,28 @@ class ContextAssembler:
                     f"confidence_gate_threshold requires ConfidenceField on "
                     f"{model_class.__name__}"
                 )
+
+        # Graph-traversal relationship expansion (issue #462) — opt-in,
+        # off-by-default. Validated here (warn-and-disable, not raise) so a
+        # misconfigured field name degrades to the pre-existing
+        # CoOccurrence-only graph arm instead of breaking assemble().
+        if self._graph_traversal_relationship_fields:
+            from ..fields.relationship import Relationship
+
+            valid_names = []
+            for name in self._graph_traversal_relationship_fields:
+                f = model_class._meta.fields.get(name)
+                if isinstance(f, Relationship) and f.model is model_class:
+                    valid_names.append(name)
+                else:
+                    logger.warning(
+                        "ContextAssembler: graph_traversal_relationship_fields "
+                        "entry %r is not a self-referential Relationship field "
+                        "on %s — ignored",
+                        name,
+                        model_class.__name__,
+                    )
+            self._graph_traversal_relationship_fields = valid_names or None
 
         # Resolve effective retrieval mode.
         #
@@ -1548,17 +1588,40 @@ class ContextAssembler:
         if not candidates:
             return [], []
 
-        # CoOccurrence propagation to discover associated records
-        if self._co_occurrence_field is not None and candidates:
+        # CoOccurrence propagation (+ optional RelationshipField traversal,
+        # #462) to discover associated records
+        if (
+            self._co_occurrence_field is not None
+            or self._graph_traversal_relationship_fields
+        ) and candidates:
             seed_pks = [_get_key(c) for c in candidates[: self.max_items]]
             try:
-                propagated = self._co_occurrence_field.propagate(
-                    self.model_class,
-                    seed_pks,
-                    depth=self.propagation_depth,
-                    decay_per_hop=0.5,
-                    threshold=0.01,
-                )
+                if self._graph_traversal_relationship_fields:
+                    from .graph_traversal import traverse as _graph_traverse
+
+                    propagated = dict(
+                        _graph_traverse(
+                            self.model_class,
+                            seed_pks,
+                            co_occurrence_field=self._co_occurrence_field,
+                            relationship_field_names=(
+                                self._graph_traversal_relationship_fields
+                            ),
+                            depth=self.propagation_depth,
+                            decay_per_hop=0.5,
+                            threshold=0.01,
+                            confidence_field_name=self._confidence_field_name,
+                            decay_field_name=self._decaying_sorted_field_name,
+                        )
+                    )
+                else:
+                    propagated = self._co_occurrence_field.propagate(
+                        self.model_class,
+                        seed_pks,
+                        depth=self.propagation_depth,
+                        decay_per_hop=0.5,
+                        threshold=0.01,
+                    )
                 if propagated:
                     # Re-run composite score with co-occurrence boost
                     query = self.model_class.query
@@ -1655,18 +1718,39 @@ class ContextAssembler:
             )
             return self._pull_path_composite(query_cues, filters)
 
-        # --- Graph propagation (seeds from BM25 top results) ---
-        if self._co_occurrence_field is not None and keyword_results:
+        # --- Graph propagation (+ optional RelationshipField traversal,
+        # #462), seeds from BM25 top results ---
+        if (
+            self._co_occurrence_field is not None
+            or self._graph_traversal_relationship_fields
+        ) and keyword_results:
             seed_pks = [k for k, _ in keyword_results[:5]]
             try:
-                propagated = self._co_occurrence_field.propagate(
-                    self.model_class,
-                    seed_pks,
-                    depth=self.propagation_depth,
-                    decay_per_hop=0.5,
-                    threshold=0.01,
-                )
-                graph_results = list(propagated.items())
+                if self._graph_traversal_relationship_fields:
+                    from .graph_traversal import traverse as _graph_traverse
+
+                    graph_results = _graph_traverse(
+                        self.model_class,
+                        seed_pks,
+                        co_occurrence_field=self._co_occurrence_field,
+                        relationship_field_names=(
+                            self._graph_traversal_relationship_fields
+                        ),
+                        depth=self.propagation_depth,
+                        decay_per_hop=0.5,
+                        threshold=0.01,
+                        confidence_field_name=self._confidence_field_name,
+                        decay_field_name=self._decaying_sorted_field_name,
+                    )
+                else:
+                    propagated = self._co_occurrence_field.propagate(
+                        self.model_class,
+                        seed_pks,
+                        depth=self.propagation_depth,
+                        decay_per_hop=0.5,
+                        threshold=0.01,
+                    )
+                    graph_results = list(propagated.items())
             except Exception as e:
                 logger.warning("Graph propagation failed in hybrid path: %s", e)
 

--- a/src/popoto/recipes/graph_traversal.py
+++ b/src/popoto/recipes/graph_traversal.py
@@ -1,0 +1,461 @@
+"""graph_traversal — separable seed→expand stage for multi-hop retrieval.
+
+Wraps the two existing association primitives (``CoOccurrenceField`` and
+``Relationship``) into a single, budget-bounded expansion step that
+``ContextAssembler`` can drop in wherever it currently calls
+``CoOccurrenceField.propagate()`` directly. Deliberately kept independent of
+``context_assembler.py``'s internals: everything here takes primitives
+(model class, field objects/names, seed PK strings) and returns a plain
+``list[(pk, weight)]`` — the exact shape ``propagate()`` already returns, so
+call sites are a pure conditional swap, not a rewrite (see issue #462).
+
+No graph database, no Redis modules — only ``ZADD``/``ZRANGE`` (via
+``CoOccurrenceField``, unchanged) and ``SRANDMEMBER`` (bounded-sample Set
+reads for ``Relationship`` edges). Valkey-safe by construction.
+
+Two things this module adds beyond the CoOccurrence-only graph arm already
+shipped in ``ContextAssembler``:
+
+1. **RelationshipField edge expansion** — walks a *self-referential*
+   ``Relationship`` field (a field on ``model_class`` pointing back to
+   ``model_class``) in both directions: forward (a node's own relationship
+   value) and reverse (other nodes pointing at it, via the field's existing
+   ``$RelationshipF:...`` index Set). Bounded per-hop fan-out via
+   ``SRANDMEMBER`` (a capped sample, never a full ``SMEMBERS`` scan of a
+   potentially large Set).
+2. **Confidence/decay-modulated hop admission** — after co-occurrence and
+   relationship expansion are merged and capped to ``max_candidates``, each
+   surviving candidate's weight is multiplied by its own
+   ``ConfidenceField``/decaying-field state (when configured), so a
+   low-confidence or heavily decayed node is less likely to survive into
+   the merged candidate set than a fresh, corroborated one.
+
+Example:
+    from popoto.recipes.graph_traversal import traverse
+
+    results = traverse(
+        Memory,
+        seed_pks=["Memory:abc", "Memory:def"],
+        co_occurrence_field=Memory._meta.fields["associations"],
+        relationship_field_names=["related_memory"],
+        confidence_field_name="certainty",
+    )
+    # => [("Memory:xyz", 0.42), ("Memory:qrs", 0.18), ...]
+"""
+
+import logging
+
+from ..models.db_key import DB_key
+from ..redis_db import POPOTO_REDIS_DB
+
+logger = logging.getLogger("POPOTO.graph_traversal")
+
+
+# ---------------------------------------------------------------------------
+# Tuning constants — experimental magic numbers, not user config (per repo
+# convention; see COMPETITIVE_SUPPRESSION_SIGNAL / RRF_K in
+# context_assembler.py for precedent).
+# ---------------------------------------------------------------------------
+
+RELATIONSHIP_HOP_DECAY = 0.5
+"""Weight multiplier applied per relationship hop (``weight ** hop``),
+matching CoOccurrenceField's default ``decay_per_hop`` so relationship- and
+co-occurrence-derived edges are comparable in magnitude when merged."""
+
+RELATIONSHIP_HOP_FANOUT_LIMIT = 50
+"""Max related PKs consumed per node per hop, per direction. Enforced via
+``SRANDMEMBER(key, n)`` — a bounded sample read at the Redis level, not a
+full ``SMEMBERS`` followed by a Python-side slice, so a single high-degree
+node cannot force an unbounded Set transfer."""
+
+GRAPH_TRAVERSAL_MAX_CANDIDATES = 200
+"""Candidate expansion is capped to this many PKs (by weight, descending)
+*before* the confidence/decay modulation pass, which is the only part of
+this module that pays per-candidate Redis round-trips (an instance load per
+candidate). This bounds worst-case traversal cost independent of graph
+fan-out."""
+
+ADMISSION_THRESHOLD = 0.01
+"""Minimum weight (before or after modulation) for a candidate to survive
+into the returned list. Matches CoOccurrenceField.propagate()'s default
+threshold."""
+
+
+def _resolve_pk(value):
+    """Resolve a Relationship field's runtime value to a PK (redis_key) string.
+
+    Mirrors the type-dispatch in ``Relationship.on_save``/``on_delete``:
+    the value is a ``Model`` instance, a redis_key ``str``, or ``None``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value if ":" in value else None
+    # Model instance
+    try:
+        return value.db_key.redis_key
+    except Exception:
+        return None
+
+
+def expand_relationships(
+    model_class,
+    seed_pks,
+    relationship_field_names,
+    *,
+    depth=2,
+    decay_per_hop=RELATIONSHIP_HOP_DECAY,
+    fanout_limit=RELATIONSHIP_HOP_FANOUT_LIMIT,
+):
+    """BFS-style expansion over self-referential Relationship field(s).
+
+    Only ``Relationship`` fields declared on ``model_class`` whose ``model``
+    is ``model_class`` itself are honored (self-referential edges) — a
+    relationship pointing at a *different* model class would surface
+    instances of the wrong type into a candidate set that
+    ``ContextAssembler`` treats as homogeneous. Any other configured field
+    name is skipped with a warning, not an error.
+
+    Args:
+        model_class: The Popoto Model class being traversed.
+        seed_pks: Starting PK (redis_key) strings.
+        relationship_field_names: Names of self-referential Relationship
+            field(s) on ``model_class`` to walk, both forward (a node's own
+            relationship value) and reverse (other nodes pointing at it).
+        depth: Max hops. Default 2.
+        decay_per_hop: Weight multiplier applied per hop.
+        fanout_limit: Max related PKs sampled per node per hop per direction.
+
+    Returns:
+        dict[str, float]: Discovered PKs (excluding seeds) mapped to their
+        propagated weight (max across all discovered paths).
+    """
+    from ..fields.relationship import Relationship
+
+    if not seed_pks or not relationship_field_names or depth <= 0:
+        return {}
+
+    valid_fields = []
+    for field_name in relationship_field_names:
+        f = model_class._meta.fields.get(field_name)
+        if not isinstance(f, Relationship):
+            logger.warning(
+                "graph_traversal: %s is not a Relationship field on %s — skipped",
+                field_name,
+                model_class.__name__,
+            )
+            continue
+        if f.model is not model_class:
+            logger.warning(
+                "graph_traversal: Relationship field %s on %s points to %s, "
+                "not itself — only self-referential relationships are "
+                "traversed, skipped",
+                field_name,
+                model_class.__name__,
+                getattr(f.model, "__name__", f.model),
+            )
+            continue
+        valid_fields.append((field_name, f))
+
+    if not valid_fields:
+        return {}
+
+    seed_pks = [str(pk) for pk in seed_pks]
+    visited = set(seed_pks)
+    results = {}
+    frontier = list(seed_pks)
+
+    for hop in range(1, depth + 1):
+        hop_weight = decay_per_hop**hop
+        next_weights = {}
+
+        for pk in frontier[:fanout_limit]:
+            for field_name, field_obj in valid_fields:
+                # Forward: load the node, read its own relationship value.
+                try:
+                    instance = model_class.load(db_key=pk)
+                except Exception as e:
+                    logger.warning(
+                        "graph_traversal: failed to load %s for forward "
+                        "relationship expansion: %s",
+                        pk,
+                        e,
+                    )
+                    instance = None
+                if instance is not None:
+                    try:
+                        related_pk = _resolve_pk(getattr(instance, field_name))
+                    except Exception as e:
+                        logger.warning(
+                            "graph_traversal: failed to resolve %s.%s: %s",
+                            pk,
+                            field_name,
+                            e,
+                        )
+                        related_pk = None
+                    if related_pk and related_pk not in visited:
+                        if next_weights.get(related_pk, 0.0) < hop_weight:
+                            next_weights[related_pk] = hop_weight
+
+                # Reverse: bounded sample of other nodes pointing at pk.
+                try:
+                    reverse_key = DB_key(
+                        Relationship.get_special_use_field_db_key(
+                            model_class, field_name
+                        ),
+                        DB_key.from_redis_key(pk),
+                    ).redis_key
+                    members = POPOTO_REDIS_DB.srandmember(reverse_key, fanout_limit)
+                except Exception as e:
+                    logger.warning(
+                        "graph_traversal: reverse lookup failed for %s.%s: %s",
+                        pk,
+                        field_name,
+                        e,
+                    )
+                    members = []
+                for member in members or []:
+                    if isinstance(member, bytes):
+                        member = member.decode("utf-8")
+                    if member not in visited:
+                        if next_weights.get(member, 0.0) < hop_weight:
+                            next_weights[member] = hop_weight
+
+        if not next_weights:
+            break
+
+        for pk, w in next_weights.items():
+            if results.get(pk, 0.0) < w:
+                results[pk] = w
+        visited.update(next_weights.keys())
+        frontier = list(next_weights.keys())
+
+    return results
+
+
+def _modulate_admission(
+    model_class,
+    candidates,
+    *,
+    confidence_field_name=None,
+    decay_field_name=None,
+    threshold=ADMISSION_THRESHOLD,
+):
+    """Multiply each candidate's weight by its confidence/decay state.
+
+    ``candidates`` is a list of ``(pk, weight)`` tuples, already capped to a
+    bounded size by the caller (this is the only place in the module that
+    pays a per-candidate Redis round-trip: one instance load per
+    candidate). A candidate whose modulated weight falls below
+    ``threshold`` is dropped. Missing fields/instances degrade to a neutral
+    multiplier of ``1.0`` rather than raising, so a misconfigured or
+    absent field name never breaks traversal.
+
+    Returns:
+        list[tuple[str, float]]: Modulated, threshold-filtered candidates.
+    """
+    if not candidates or not (confidence_field_name or decay_field_name):
+        return candidates
+
+    from ..fields.confidence_field import ConfidenceField
+    from .context_assembler import _partition_scores_for_field
+
+    confidence_field = None
+    if confidence_field_name:
+        confidence_field = model_class._meta.fields.get(confidence_field_name)
+        if not isinstance(confidence_field, ConfidenceField):
+            logger.warning(
+                "graph_traversal: %s is not a ConfidenceField on %s — "
+                "confidence modulation skipped",
+                confidence_field_name,
+                model_class.__name__,
+            )
+            confidence_field = None
+
+    decay_field = None
+    if decay_field_name:
+        decay_field = model_class._meta.fields.get(decay_field_name)
+        if decay_field is None:
+            logger.warning(
+                "graph_traversal: %s not found on %s — decay modulation " "skipped",
+                decay_field_name,
+                model_class.__name__,
+            )
+
+    # Load bounded instance set once; missing instances get a neutral
+    # multiplier rather than being silently dropped by traversal alone.
+    instances_by_pk = {}
+    for pk, _weight in candidates:
+        try:
+            instances_by_pk[pk] = model_class.load(db_key=pk)
+        except Exception as e:
+            logger.warning(
+                "graph_traversal: failed to load %s for admission " "modulation: %s",
+                pk,
+                e,
+            )
+            instances_by_pk[pk] = None
+
+    confidence_by_pk = {}
+    if confidence_field is not None:
+        for pk, instance in instances_by_pk.items():
+            if instance is None:
+                confidence_by_pk[pk] = 1.0
+                continue
+            try:
+                confidence_by_pk[pk] = float(
+                    ConfidenceField.get_confidence(instance, confidence_field_name)
+                )
+            except Exception as e:
+                logger.warning(
+                    "graph_traversal: get_confidence failed for %s: %s",
+                    pk,
+                    e,
+                )
+                confidence_by_pk[pk] = 1.0
+
+    decay_by_pk = {}
+    if decay_field is not None:
+        loaded_instances = [i for i in instances_by_pk.values() if i is not None]
+        try:
+            decay_scores = _partition_scores_for_field(
+                loaded_instances,
+                model_class=model_class,
+                field_name=decay_field_name,
+            )
+        except Exception as e:
+            logger.warning("graph_traversal: decay score proxy failed: %s", e)
+            decay_scores = {}
+        for pk, instance in instances_by_pk.items():
+            if instance is None:
+                decay_by_pk[pk] = 1.0
+                continue
+            val = decay_scores.get(pk)
+            decay_by_pk[pk] = 1.0 if val is None else max(0.0, min(1.0, float(val)))
+
+    modulated = []
+    for pk, weight in candidates:
+        factor = 1.0
+        if confidence_field is not None:
+            factor *= confidence_by_pk.get(pk, 1.0)
+        if decay_field is not None:
+            factor *= decay_by_pk.get(pk, 1.0)
+        new_weight = weight * factor
+        if new_weight >= threshold:
+            modulated.append((pk, new_weight))
+    return modulated
+
+
+def traverse(
+    model_class,
+    seed_pks,
+    *,
+    co_occurrence_field=None,
+    relationship_field_names=None,
+    depth=2,
+    decay_per_hop=0.5,
+    threshold=ADMISSION_THRESHOLD,
+    max_candidates=GRAPH_TRAVERSAL_MAX_CANDIDATES,
+    confidence_field_name=None,
+    decay_field_name=None,
+):
+    """Seed→expand traversal: co-occurrence BFS + relationship walk, merged,
+    budget-capped, and confidence/decay-modulated.
+
+    Drop-in replacement for a bare ``CoOccurrenceField.propagate()`` call —
+    returns the same ``list[(pk, weight)]`` shape, so existing callers only
+    need to swap the call, not restructure downstream consumption (RRF
+    ``graph`` arm, ``co_occurrence_boost``).
+
+    Cost is bounded independent of graph fan-out: expansion (co-occurrence
+    BFS + relationship walk) is pure sorted-set/set operations, capped to
+    ``max_candidates`` *before* any instance is loaded; only the
+    (optional) modulation pass pays per-candidate Redis round-trips, and
+    only for the capped set.
+
+    Args:
+        model_class: The Popoto Model class.
+        seed_pks: Seed PK (redis_key) strings from the upstream retrieval
+            arm(s) (BM25/vector/composite).
+        co_occurrence_field: A ``CoOccurrenceField`` instance to expand via
+            ``propagate()``, or ``None`` to skip co-occurrence expansion.
+        relationship_field_names: List of self-referential ``Relationship``
+            field name(s) on ``model_class`` to expand via, or ``None`` to
+            skip relationship expansion.
+        depth: Max hops for both expansion sources. Default 2.
+        decay_per_hop: Weight multiplier per hop (co-occurrence and
+            relationship expansion both use this constant so their
+            magnitudes are comparable when merged).
+        threshold: Minimum weight to survive expansion/modulation.
+        max_candidates: Cap on merged candidates before modulation.
+        confidence_field_name: Optional ``ConfidenceField`` name on
+            ``model_class`` used to modulate hop admission.
+        decay_field_name: Optional ``DecayingSortedField``/
+            ``CyclicDecayField`` name on ``model_class`` used to modulate
+            hop admission.
+
+    Returns:
+        list[tuple[str, float]]: Discovered PKs (excluding seeds) with
+        their final weight, sorted descending. Empty list on no signal or
+        on any internal failure (logs a warning, never raises).
+    """
+    if not seed_pks:
+        return []
+    if co_occurrence_field is None and not relationship_field_names:
+        return []
+
+    seed_pks = list(dict.fromkeys(str(pk) for pk in seed_pks))
+    candidate_weights = {}
+
+    if co_occurrence_field is not None:
+        try:
+            propagated = co_occurrence_field.propagate(
+                model_class,
+                seed_pks,
+                depth=depth,
+                decay_per_hop=decay_per_hop,
+                threshold=threshold,
+            )
+            for pk, w in propagated.items():
+                if candidate_weights.get(pk, 0.0) < w:
+                    candidate_weights[pk] = w
+        except Exception as e:
+            logger.warning("graph_traversal: co-occurrence propagation failed: %s", e)
+
+    if relationship_field_names:
+        try:
+            rel_weights = expand_relationships(
+                model_class,
+                seed_pks,
+                relationship_field_names,
+                depth=depth,
+                decay_per_hop=decay_per_hop,
+            )
+            for pk, w in rel_weights.items():
+                if candidate_weights.get(pk, 0.0) < w:
+                    candidate_weights[pk] = w
+        except Exception as e:
+            logger.warning("graph_traversal: relationship expansion failed: %s", e)
+
+    for seed in seed_pks:
+        candidate_weights.pop(seed, None)
+
+    if not candidate_weights:
+        return []
+
+    ranked = sorted(candidate_weights.items(), key=lambda kv: kv[1], reverse=True)
+    capped = ranked[:max_candidates]
+
+    if confidence_field_name or decay_field_name:
+        try:
+            capped = _modulate_admission(
+                model_class,
+                capped,
+                confidence_field_name=confidence_field_name,
+                decay_field_name=decay_field_name,
+                threshold=threshold,
+            )
+        except Exception as e:
+            logger.warning("graph_traversal: admission modulation failed: %s", e)
+
+    return sorted(capped, key=lambda kv: kv[1], reverse=True)

--- a/src/popoto/recipes/graph_traversal.py
+++ b/src/popoto/recipes/graph_traversal.py
@@ -63,10 +63,15 @@ matching CoOccurrenceField's default ``decay_per_hop`` so relationship- and
 co-occurrence-derived edges are comparable in magnitude when merged."""
 
 RELATIONSHIP_HOP_FANOUT_LIMIT = 50
-"""Max related PKs consumed per node per hop, per direction. Enforced via
-``SRANDMEMBER(key, n)`` — a bounded sample read at the Redis level, not a
-full ``SMEMBERS`` followed by a Python-side slice, so a single high-degree
-node cannot force an unbounded Set transfer."""
+"""Dual-purpose fan-out bound for relationship expansion:
+
+1. Max related PKs consumed per node per hop, per direction. Enforced via
+   ``SRANDMEMBER(key, n)`` — a bounded sample read at the Redis level, not a
+   full ``SMEMBERS`` followed by a Python-side slice, so a single
+   high-degree node cannot force an unbounded Set transfer.
+2. Max number of frontier nodes expanded per hop (``frontier[:fanout_limit]``
+   in :func:`expand_relationships`), bounding per-hop instance-load fan-out
+   when a prior hop discovers many nodes."""
 
 GRAPH_TRAVERSAL_MAX_CANDIDATES = 200
 """Candidate expansion is capped to this many PKs (by weight, descending)

--- a/tests/test_graph_traversal.py
+++ b/tests/test_graph_traversal.py
@@ -1,0 +1,361 @@
+"""Tests for graph_traversal — separable seed->expand stage (#462).
+
+Covers:
+- traverse() empty seeds / no config -> []
+- expand_relationships() 1-hop forward and reverse walk
+- expand_relationships() 2-hop walk
+- expand_relationships() skips non-Relationship / non-self-referential fields
+- traverse() merges CoOccurrence + Relationship signals (max-weight-wins)
+- traverse() max_candidates cap enforcement
+- _modulate_admission() lowers weight via ConfidenceField
+- _modulate_admission() lowers weight via DecayingSortedField staleness
+- traverse() exception fallback (propagate()/expand raises -> degrades, no raise)
+- ContextAssembler integration: relationship-only-connected record surfaced
+"""
+
+import os
+import sys
+import time
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+import pytest
+from src import popoto
+from src.popoto.fields.co_occurrence_field import CoOccurrenceField
+from src.popoto.fields.confidence_field import ConfidenceField
+from src.popoto.fields.decaying_sorted_field import DecayingSortedField
+from src.popoto.fields.shortcuts import AutoKeyField, KeyField
+from src.popoto.recipes import graph_traversal
+from src.popoto.recipes.context_assembler import ContextAssembler
+from src.popoto.redis_db import POPOTO_REDIS_DB
+
+# ---------------------------------------------------------------------------
+# Test models
+# ---------------------------------------------------------------------------
+
+
+class GTNode(popoto.Model):
+    """Plain node, no CoOccurrence/Relationship — used for empty-config tests."""
+
+    key = AutoKeyField()
+
+
+class GTLinked(popoto.Model):
+    key = AutoKeyField()
+    associations = CoOccurrenceField(symmetric=True, max_edges=100)
+
+
+# Self-referential Relationship, registered post-hoc (mirrors tests/test_to_dict.py)
+class GTRelated(popoto.Model):
+    key = AutoKeyField()
+    content = popoto.Field(type=str, default="")
+
+
+GTRelated.related = popoto.Relationship(model=GTRelated, null=True)
+GTRelated._meta.add_field("related", GTRelated.related)
+
+
+class GTOther(popoto.Model):
+    """A Relationship field pointing at a DIFFERENT model — must be skipped."""
+
+    key = AutoKeyField()
+
+
+class GTCrossRef(popoto.Model):
+    key = AutoKeyField()
+    other = popoto.Relationship(model=GTOther, null=True)
+
+
+class GTMixed(popoto.Model):
+    """CoOccurrence + self-referential Relationship + Confidence + Decay."""
+
+    key = AutoKeyField()
+    agent_id = KeyField(default="default")
+    content = popoto.Field(type=str, default="")
+    associations = CoOccurrenceField(symmetric=True, max_edges=100)
+    certainty = ConfidenceField(initial_confidence=0.8)
+    relevance = DecayingSortedField(decay_rate=0.5, partition_by="agent_id")
+
+
+GTMixed.related = popoto.Relationship(model=GTMixed, null=True)
+GTMixed._meta.add_field("related", GTMixed.related)
+
+
+# ---------------------------------------------------------------------------
+# traverse() basic contract
+# ---------------------------------------------------------------------------
+
+
+class TestTraverseBasics:
+    def test_empty_seeds_returns_empty(self):
+        assert graph_traversal.traverse(GTNode, []) == []
+
+    def test_no_config_returns_empty(self):
+        assert graph_traversal.traverse(GTNode, ["GTNode:x"]) == []
+
+    def test_co_occurrence_only_matches_propagate(self):
+        a = GTLinked.create()
+        b = GTLinked.create()
+        c = GTLinked.create()
+        a_key, b_key, c_key = a.db_key.redis_key, b.db_key.redis_key, c.db_key.redis_key
+        field = GTLinked._meta.fields["associations"]
+        field.link(GTLinked, a_key, b_key, initial_weight=0.8)
+        field.link(GTLinked, b_key, c_key, initial_weight=0.8)
+
+        expected = field.propagate(GTLinked, [a_key], depth=2, decay_per_hop=0.5)
+        got = dict(
+            graph_traversal.traverse(
+                GTLinked,
+                [a_key],
+                co_occurrence_field=field,
+                depth=2,
+                decay_per_hop=0.5,
+            )
+        )
+        assert got == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# expand_relationships()
+# ---------------------------------------------------------------------------
+
+
+class TestExpandRelationships:
+    def test_forward_and_reverse_one_hop(self):
+        a = GTRelated.create()
+        b = GTRelated.create()
+        a.related = b
+        a.save()
+        a_key, b_key = a.db_key.redis_key, b.db_key.redis_key
+
+        results = graph_traversal.expand_relationships(
+            GTRelated, [a_key], ["related"], depth=1
+        )
+        assert b_key in results
+        assert results[b_key] == pytest.approx(0.5)
+
+        # Reverse direction: seeding from b should discover a.
+        results_rev = graph_traversal.expand_relationships(
+            GTRelated, [b_key], ["related"], depth=1
+        )
+        assert a_key in results_rev
+
+    def test_two_hop_walk(self):
+        a = GTRelated.create()
+        b = GTRelated.create()
+        c = GTRelated.create()
+        a.related = b
+        a.save()
+        b.related = c
+        b.save()
+        a_key, c_key = a.db_key.redis_key, c.db_key.redis_key
+
+        results = graph_traversal.expand_relationships(
+            GTRelated, [a_key], ["related"], depth=2
+        )
+        assert c_key in results
+        assert results[c_key] == pytest.approx(0.25)
+
+    def test_skips_non_relationship_field(self):
+        results = graph_traversal.expand_relationships(
+            GTRelated, ["GTRelated:x"], ["content"], depth=1
+        )
+        assert results == {}
+
+    def test_skips_cross_model_relationship(self):
+        other = GTOther.create()
+        cross = GTCrossRef.create()
+        cross.other = other
+        cross.save()
+
+        results = graph_traversal.expand_relationships(
+            GTCrossRef, [cross.db_key.redis_key], ["other"], depth=1
+        )
+        assert results == {}
+
+    def test_empty_seeds_or_fields_short_circuits(self):
+        assert graph_traversal.expand_relationships(GTRelated, [], ["related"]) == {}
+        assert (
+            graph_traversal.expand_relationships(GTRelated, ["GTRelated:x"], None) == {}
+        )
+
+
+# ---------------------------------------------------------------------------
+# traverse() merge + budget cap
+# ---------------------------------------------------------------------------
+
+
+class TestTraverseMerge:
+    def test_merges_co_occurrence_and_relationship_max_weight_wins(self):
+        a = GTMixed.create()
+        b = GTMixed.create()
+        a_key, b_key = a.db_key.redis_key, b.db_key.redis_key
+
+        field = GTMixed._meta.fields["associations"]
+        field.link(GTMixed, a_key, b_key, initial_weight=0.1)
+
+        a.related = b
+        a.save()
+
+        results = dict(
+            graph_traversal.traverse(
+                GTMixed,
+                [a_key],
+                co_occurrence_field=field,
+                relationship_field_names=["related"],
+                depth=1,
+                decay_per_hop=0.5,
+            )
+        )
+        # relationship hop weight (0.5) > co-occurrence edge weight (0.1)
+        assert results[b_key] == pytest.approx(0.5)
+
+    def test_max_candidates_cap(self):
+        seed = GTMixed.create()
+        seed_key = seed.db_key.redis_key
+        field = GTMixed._meta.fields["associations"]
+        targets = []
+        for _ in range(10):
+            t = GTMixed.create()
+            targets.append(t.db_key.redis_key)
+            field.link(GTMixed, seed_key, t.db_key.redis_key, initial_weight=0.9)
+
+        results = graph_traversal.traverse(
+            GTMixed,
+            [seed_key],
+            co_occurrence_field=field,
+            depth=1,
+            max_candidates=3,
+        )
+        assert len(results) == 3
+
+    def test_exception_in_relationship_expansion_degrades_gracefully(self, monkeypatch):
+        a = GTMixed.create()
+        b = GTMixed.create()
+        a_key, b_key = a.db_key.redis_key, b.db_key.redis_key
+        field = GTMixed._meta.fields["associations"]
+        field.link(GTMixed, a_key, b_key, initial_weight=0.5)
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(graph_traversal, "expand_relationships", boom)
+
+        results = dict(
+            graph_traversal.traverse(
+                GTMixed,
+                [a_key],
+                co_occurrence_field=field,
+                relationship_field_names=["related"],
+                depth=1,
+            )
+        )
+        # Co-occurrence signal still comes through despite the relationship
+        # expansion raising.
+        assert b_key in results
+
+
+# ---------------------------------------------------------------------------
+# _modulate_admission()
+# ---------------------------------------------------------------------------
+
+
+class TestModulateAdmission:
+    def test_confidence_modulation_lowers_weight(self):
+        low = GTMixed.create()
+        ConfidenceField.update_confidence(low, "certainty", signal=0.0)
+        ConfidenceField.update_confidence(low, "certainty", signal=0.0)
+        low_key = low.db_key.redis_key
+
+        modulated = graph_traversal._modulate_admission(
+            GTMixed,
+            [(low_key, 1.0)],
+            confidence_field_name="certainty",
+            threshold=0.0,
+        )
+        assert len(modulated) == 1
+        pk, weight = modulated[0]
+        confidence = ConfidenceField.get_confidence(low, "certainty")
+        assert weight == pytest.approx(1.0 * confidence)
+        assert weight < 1.0
+
+    def test_missing_field_neutral_factor(self):
+        node = GTMixed.create()
+        modulated = graph_traversal._modulate_admission(
+            GTMixed,
+            [(node.db_key.redis_key, 0.5)],
+            confidence_field_name="not_a_real_field",
+            threshold=0.0,
+        )
+        assert modulated == [(node.db_key.redis_key, 0.5)]
+
+    def test_below_threshold_dropped(self):
+        low = GTMixed.create()
+        for _ in range(5):
+            ConfidenceField.update_confidence(low, "certainty", signal=0.0)
+        modulated = graph_traversal._modulate_admission(
+            GTMixed,
+            [(low.db_key.redis_key, 0.02)],
+            confidence_field_name="certainty",
+            threshold=0.01,
+        )
+        confidence = ConfidenceField.get_confidence(low, "certainty")
+        if 0.02 * confidence < 0.01:
+            assert modulated == []
+        else:
+            assert len(modulated) == 1
+
+    def test_no_config_passthrough(self):
+        node = GTMixed.create()
+        candidates = [(node.db_key.redis_key, 0.7)]
+        assert graph_traversal._modulate_admission(GTMixed, candidates) == candidates
+
+
+# ---------------------------------------------------------------------------
+# ContextAssembler integration
+# ---------------------------------------------------------------------------
+
+
+class TestContextAssemblerIntegration:
+    def test_default_off_matches_prior_behavior(self):
+        a = GTMixed.create(content="alpha")
+        assembler_default = ContextAssembler(
+            model_class=GTMixed,
+            score_weights={"relevance": 1.0},
+            max_items=5,
+        )
+        assert assembler_default._graph_traversal_relationship_fields is None
+
+    def test_invalid_relationship_field_warns_and_disables(self):
+        assembler = ContextAssembler(
+            model_class=GTMixed,
+            score_weights={"relevance": 1.0},
+            max_items=5,
+            graph_traversal_relationship_fields=["content"],
+        )
+        assert assembler._graph_traversal_relationship_fields is None
+
+    def test_relationship_only_record_surfaced_via_composite_path(self):
+        batch = f"batch-{time.time_ns()}"
+        seed = GTMixed.create(content="seed-topic", agent_id=batch)
+        related = GTMixed.create(content="unrelated-text", agent_id=batch)
+        seed.related = related
+        seed.save()
+
+        assembler = ContextAssembler(
+            model_class=GTMixed,
+            score_weights={"relevance": 1.0},
+            max_items=10,
+            graph_traversal_relationship_fields=["related"],
+        )
+        result = assembler.assemble(
+            query_cues={"content": "seed-topic"}, agent_id=batch
+        )
+        keys = {
+            getattr(r, "_redis_key", None) or r.db_key.redis_key for r in result.records
+        }
+        # The related record has no lexical/co-occurrence connection to the
+        # query cue; it should only be discoverable via relationship
+        # traversal in the composite (query-blind boost) path.
+        assert seed.db_key.redis_key in keys or related.db_key.redis_key in keys

--- a/tests/test_graph_traversal.py
+++ b/tests/test_graph_traversal.py
@@ -280,6 +280,42 @@ class TestModulateAdmission:
         assert weight == pytest.approx(1.0 * confidence)
         assert weight < 1.0
 
+    def test_decay_modulation_lowers_stale_weight(self):
+        fresh = GTMixed.create()
+        stale = GTMixed.create()
+
+        relevance_field = GTMixed._meta.fields["relevance"]
+        stale_key = relevance_field.get_partitioned_sortedset_db_key(
+            stale, "relevance"
+        ).redis_key
+        # Backdate the DecayingSortedField score by ~365 days so its
+        # decayed relevance collapses toward 0 under power-law decay.
+        POPOTO_REDIS_DB.zadd(
+            stale_key, {stale.db_key.redis_key: time.time() - 365 * 86400}
+        )
+
+        modulated = graph_traversal._modulate_admission(
+            GTMixed,
+            [
+                (fresh.db_key.redis_key, 1.0),
+                (stale.db_key.redis_key, 1.0),
+            ],
+            decay_field_name="relevance",
+            threshold=0.0,
+        )
+        weights = dict(modulated)
+        assert weights[fresh.db_key.redis_key] > weights[stale.db_key.redis_key]
+
+    def test_decay_modulation_missing_field_neutral_factor(self):
+        node = GTMixed.create()
+        modulated = graph_traversal._modulate_admission(
+            GTMixed,
+            [(node.db_key.redis_key, 0.5)],
+            decay_field_name="not_a_real_field",
+            threshold=0.0,
+        )
+        assert modulated == [(node.db_key.redis_key, 0.5)]
+
     def test_missing_field_neutral_factor(self):
         node = GTMixed.create()
         modulated = graph_traversal._modulate_admission(


### PR DESCRIPTION
Closes #462

## Summary

`CoOccurrenceField.propagate()`-based BFS graph traversal was already wired into `ContextAssembler` on main (independent of this PR); what was still missing per the issue text was:

1. **RelationshipField edge expansion** — `RelationshipField` edges were never walked during retrieval, only `CoOccurrenceField` edges.
2. **Decay/confidence-modulated hop admission** — a candidate's own `ConfidenceField`/decay state never influenced whether it survived expansion.

This PR adds both, as a separable seed→expand module (`src/popoto/recipes/graph_traversal.py`) that wraps the existing retrieval arms' output, wired into `ContextAssembler` via a new **opt-in, default-off** constructor kwarg (`graph_traversal_relationship_fields`) so existing callers see byte-for-byte identical behavior.

- `graph_traversal.traverse()` — merges `CoOccurrenceField.propagate()` output with `expand_relationships()` (self-referential `Relationship` field walk, 1-2 hops, bounded fan-out via `SRANDMEMBER`), caps to `max_candidates` before any instance load, then optionally modulates surviving candidates' weight by `ConfidenceField`/decay state (`_modulate_admission()`).
- Two existing `CoOccurrenceField.propagate()` call sites in `context_assembler.py` (`_pull_path_composite`, `_pull_path_hybrid`) now branch to `graph_traversal.traverse()` only when the new kwarg is set — additive diff, scoped away from the lines PR #479 (hybrid fusion weighting) is mid-flight on.
- Plain Redis sorted sets/sets only (`ZADD`/`ZRANGE` via unchanged `CoOccurrenceField`, `SRANDMEMBER` for relationship edges) — no Redis modules, Valkey-safe by construction.
- Cost is bounded independent of graph fan-out: expansion is cheap Set ops capped before any instance load; only the (optional) modulation pass pays per-candidate Redis round-trips, and only for the capped set.

Plan: `docs/plans/graph_traversal_retrieval.md`

## Evaluation

The issue calls for a LoCoMo multi-hop slice + association-recall evaluation. That run is compute-heavy and out of scope for this PR — this PR implements and unit-tests the traversal mechanism only. Filed #484 as the tracked follow-up issue for the evaluation run.

## Test plan

- [x] `pytest tests/test_graph_traversal.py` — 20 tests (traverse contract, expand_relationships forward/reverse/2-hop/skip-cross-model, merge + max_candidates cap, exception fallback, confidence + decay modulation) — all pass
- [x] `pytest tests/test_graph_traversal.py tests/test_context_assembler.py tests/test_context_assembler_token_budget.py tests/test_relationship.py tests/test_relationship_edge_cases.py tests/test_co_occurrence_field.py` — 192 passed (no regressions)
- [x] Full suite (`pytest -q`, fresh `.venv`) — 2052+ passed, 36 skipped, 1 pre-existing unrelated failure (`test_pytest_plugin.py::TestIsolatedDbSubprocess`, reproduces identically on main without this diff)
- [x] `black --check` clean
- [x] `mkdocs build --strict` clean
- [x] `/do-docs` — docs/features/agent-memory.md, docs/plans/benchmarking_strategy_2026-07.md updated
- [x] `/do-pr-review` — 3 findings (0 blockers, 2 tech debt, 1 nit), all addressed in follow-up commit