### PR TITLE
SIQ benchmark — Subconscious Injection Quality harness (#459)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -582,3 +582,110 @@ the harness pre-flights every query so a fallback can never masquerade as a
 lexical number) and `rankings_identical` per case.
 
 To add a test case, see "Adding a CsrTestCase" in `tests/benchmarks/README.md`.
+
+## Subconscious Injection Quality (SIQ) Harness
+
+### Overview
+
+SIQ (issue #459) is Popoto's flagship **native** benchmark — it measures the
+one thing composite (query-blind) retrieval does that no public benchmark
+scores: *without an explicit query cueing it, did the right memory get injected
+into context at the right turn?* Every other harness on this page (the external
+LongMemEval-S/LoCoMo runs, the Tier-5 judged-answer harness, even CSR) is
+**query-driven** — an explicit question or `query_cues` dict is supplied and the
+harness scores whether the right evidence came back. SIQ is the complement.
+
+Each case is a multi-turn agent **trace**: a later turn needs a memory that was
+established several turns earlier, but the turn's own message never lexically
+restates it (coreference, implication, or need-to-know). This is exactly the
+regime where query-blind importance/decay ranking should beat query-driven
+retrieval — and where a pure retriever scores ~0 by construction. The traces are
+**committed deterministic fixtures** (CSR discipline: no runtime generation RNG,
+no wall-clock in ranking, bit-identical scores every run), and retrieval runs
+through `ContextAssembler` in `composite` mode (a plain `importance` SortedField,
+no BM25/embedding field on the model, so the pull path is genuinely query-blind).
+
+An authoring **cue-blindness lint** makes the ground truth un-gameable: using the
+*real* BM25 tokenizer (`src.popoto.fields._tokenizer.tokenize` — the same
+preprocessing BM25 indexes with), `lint_trace` rejects any trace whose
+`should_recall` turn shares even one indexed token with the target memory. The
+constraint only ever gets *harder* to satisfy, never easier.
+
+### Metrics and What They Mean
+
+| Metric | Meaning |
+|--------|---------|
+| **Injection Precision @ budget** | Of the memories injected under the `max_items`/`max_tokens` budget at an evaluation turn, the fraction that are ground-truth useful |
+| **Injection Recall @ budget** | Of that turn's `should_recall` targets, the fraction actually injected |
+| **Anticipation lead time** | Per memory: the number of consecutive turns immediately before it becomes explicitly relevant during which it was already injected (rewards proactive recall; a query retriever scores 0 here by construction) |
+| **Budget efficiency** | `useful_tokens / injected_tokens` — quality tied to the token budget the recipe already enforces |
+
+Precision, recall, and budget efficiency are evaluated **only at turns that
+carry a `should_recall` annotation** — the moments of defined information need.
+Narrative turns contribute nothing to them; proactive injection at those turns
+is credited by *anticipation lead time* instead. Edge cases resolve to
+`None` (undefined), never a `ZeroDivisionError`: precision is `None` when
+nothing was injected, recall is `None` at a non-evaluation turn, and a memory
+never injected when it mattered is a **miss** (excluded from the mean, counted
+separately) rather than a bogus lead value.
+
+### Why It's Competitor-Fair
+
+`SiqAdapter` (a `Protocol`, mirroring the Tier-5 `JudgeProtocol`) is the
+extension point: any memory system replayed turn-by-turn can be scored on
+identical footing. Two adapters ship:
+
+- **`NativeAdapter`** — Popoto's query-blind composite mode (the system under
+  test); the composite-mode invariant is asserted before scoring.
+- **`QueryOnlyStubAdapter`** — a dependency-free, deterministic *query-driven*
+  baseline (the Mem0/Zep/Hindsight stand-in). It injects only memories whose
+  content lexically overlaps the current message, so by the cue-blindness lint
+  it injects **nothing** at the recall turn — scoring ~0 recall and all-miss
+  anticipation *by construction*. That near-zero baseline is the harness's own
+  validity proof (asserted in `test_siq.py`), not a rigged result.
+
+Real Mem0/Zep/Hindsight adapters (heavyweight optional deps + live API keys) are
+a tracked follow-up; no competitor numbers are fabricated here. An optional
+LLM-judged "usefulness" cross-check reuses the Tier-5 pinned judge
+(`gpt-4o-mini`, temperature 0) and is never in the default/CI path.
+
+Baseline over the four committed fixtures (`coreference_relocation`,
+`implication_deadline`, `need_to_know_allergy`, `multi_recall_preferences`):
+
+| adapter | recall @ budget | anticipation misses | mean lead |
+|---|---|---|---|
+| `native` (query-blind) | **1.000** | 0 / 5 targets | 4.0 turns |
+| `query_stub` (query-driven) | 0.000 | 5 / 5 targets | n/a |
+
+Everything is Valkey-safe — core Redis commands only, no modules — and the
+whole default suite needs no network, no model download, and no API key.
+
+### DB Hygiene
+
+The CI-facing surface is `tests/benchmarks/test_siq.py`, which runs under the
+pytest **db15** isolation plugin like every other `test_*.py` — it plants
+per-trace, uniquely-prefixed model classes and tears them down, never touching
+db0. The optional `run_siq.py` CLI is a manual (non-pytest) report generator, so
+it reuses `run_external`'s bench-DB machinery: a dedicated bench DB (default
+**14**, `POPOTO_BENCH_DB` override, **db0 rejected**), pointed at only at
+`main()` time. Point the CLI away from any in-flight external run (which also
+uses db14), e.g. `POPOTO_BENCH_DB=13`.
+
+### Running It
+
+```bash
+# CI gate (pytest, DB-15 isolation, deterministic — no network, no API key):
+pytest tests/benchmarks/test_siq.py -q
+
+# Manual run — writes tests/benchmarks/results/siq/siq_{date}_{adapter}.{json,md}
+# and siq_latest_{adapter}.{json,md}. Use a free bench DB (db0 rejected):
+POPOTO_BENCH_DB=13 python -m tests.benchmarks.siq.run_siq --adapter native
+POPOTO_BENCH_DB=13 python -m tests.benchmarks.siq.run_siq --adapter query_stub
+
+# Summary only, no report written:
+POPOTO_BENCH_DB=13 python -m tests.benchmarks.siq.run_siq --dry-run
+```
+
+To add a trace, drop a committed JSON fixture in `tests/benchmarks/siq/fixtures/`
+(schema in `tests/benchmarks/siq/corpus.py`); `lint_trace` enforces the
+cue-blindness and anticipation-window authoring rules at load time.

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -17,6 +17,16 @@ tests/benchmarks/
     test_sweep.py            # Tests for sweep engine
     test_external.py         # Tests for external benchmark (fixture-based, no network)
     test_csr.py              # CI gate for the deterministic CSR harness
+    test_siq.py              # CI gate for the SIQ (query-blind injection) harness
+    siq/
+        __init__.py          # SIQ overview + design invariants
+        corpus.py            # SiqTrace/SiqTurn/SiqMemory schema, load, lint, plant
+        metrics.py           # precision/recall @ budget, anticipation lead, efficiency
+        adapters.py          # SiqAdapter Protocol + NativeAdapter + QueryOnlyStubAdapter
+        runner.py            # turn-by-turn replay driver
+        run_siq.py           # CLI entry point + report writer (bench DB, db0 rejected)
+        fixtures/
+            *.json           # Deterministic committed multi-turn traces (no runtime RNG)
     csr/
         __init__.py          # CSR constants (DEFAULT_TOP_K, alert thresholds)
         satisfaction.py      # Assertion engine (InTopK, RanksAbove, ...)
@@ -47,6 +57,8 @@ tests/benchmarks/
             locomo_*.{json,md}         # External benchmark reports
         csr/
             csr_*.{json,md}            # Deterministic CSR reports
+        siq/
+            siq_*_{adapter}.{json,md}  # SIQ reports (native / query_stub adapters)
 ```
 
 ## Quick Start
@@ -65,6 +77,14 @@ POPOTO_BENCH_DB=13 python -m tests.benchmarks.run_external --dataset locomo
 # Deterministic CSR harness (no network, no model download):
 pytest tests/benchmarks/test_csr.py -q          # CI gate
 python -m tests.benchmarks.csr.run_csr          # write report artifact
+
+# SIQ — Subconscious Injection Quality (query-blind injection; #459):
+pytest tests/benchmarks/test_siq.py -q          # CI gate (db15 plugin, no network)
+POPOTO_BENCH_DB=13 python -m tests.benchmarks.siq.run_siq --adapter native
+POPOTO_BENCH_DB=13 python -m tests.benchmarks.siq.run_siq --adapter query_stub
+# NOTE: the CLI plants to a dedicated bench DB (default 14; db0 rejected). Point
+# it away from any in-flight external run (which also uses db14). The CI-facing
+# surface is test_siq.py, which runs under the pytest db15 isolation plugin.
 
 # External benchmark smoke test (fixture-based, no download):
 python -m tests.benchmarks.run_external \

--- a/tests/benchmarks/results/siq/siq_20260721_native.json
+++ b/tests/benchmarks/results/siq/siq_20260721_native.json
@@ -1,0 +1,71 @@
+{
+  "adapter": "native",
+  "n_traces": 4,
+  "aggregate": {
+    "precision_at_budget": 0.6666666666666666,
+    "recall_at_budget": 1.0,
+    "budget_efficiency": 0.706015037593985,
+    "mean_anticipation_lead": 4.0,
+    "total_anticipation_misses": 0,
+    "total_recall_targets": 5
+  },
+  "per_trace": [
+    {
+      "n_turns": 5,
+      "precision_at_budget": 1.0,
+      "recall_at_budget": 1.0,
+      "budget_efficiency": 1.0,
+      "anticipation_lead_times": {
+        "mem_relocation": 4
+      },
+      "mean_anticipation_lead": 4.0,
+      "anticipation_misses": 0,
+      "n_recall_targets": 1,
+      "trace_id": "coreference_relocation",
+      "adapter": "native"
+    },
+    {
+      "n_turns": 5,
+      "precision_at_budget": 0.5,
+      "recall_at_budget": 1.0,
+      "budget_efficiency": 0.5526315789473685,
+      "anticipation_lead_times": {
+        "mem_locked_demo": 4
+      },
+      "mean_anticipation_lead": 4.0,
+      "anticipation_misses": 0,
+      "n_recall_targets": 1,
+      "trace_id": "implication_deadline",
+      "adapter": "native"
+    },
+    {
+      "n_turns": 6,
+      "precision_at_budget": 0.6666666666666666,
+      "recall_at_budget": 1.0,
+      "budget_efficiency": 0.7,
+      "anticipation_lead_times": {
+        "mem_budget": 3,
+        "mem_vegetarian": 5
+      },
+      "mean_anticipation_lead": 4.0,
+      "anticipation_misses": 0,
+      "n_recall_targets": 2,
+      "trace_id": "multi_recall_preferences",
+      "adapter": "native"
+    },
+    {
+      "n_turns": 5,
+      "precision_at_budget": 0.5,
+      "recall_at_budget": 1.0,
+      "budget_efficiency": 0.5714285714285714,
+      "anticipation_lead_times": {
+        "mem_allergy": 4
+      },
+      "mean_anticipation_lead": 4.0,
+      "anticipation_misses": 0,
+      "n_recall_targets": 1,
+      "trace_id": "need_to_know_allergy",
+      "adapter": "native"
+    }
+  ]
+}

--- a/tests/benchmarks/results/siq/siq_20260721_native.md
+++ b/tests/benchmarks/results/siq/siq_20260721_native.md
@@ -1,0 +1,22 @@
+# SIQ Benchmark — adapter: `native`
+
+Subconscious Injection Quality (issue #459). Deterministic committed fixtures; no runtime RNG. See `docs/benchmarks.md`.
+
+## Aggregate
+
+| metric | value |
+|---|---|
+| precision @ budget | 0.667 |
+| recall @ budget | 1.000 |
+| budget efficiency | 0.706 |
+| mean anticipation lead (turns) | 4.000 |
+| anticipation misses | 0 / 5 targets |
+
+## Per trace
+
+| trace | recall | precision | efficiency | mean lead | misses |
+|---|---|---|---|---|---|
+| coreference_relocation | 1.000 | 1.000 | 1.000 | 4.000 | 0/1 |
+| implication_deadline | 1.000 | 0.500 | 0.553 | 4.000 | 0/1 |
+| multi_recall_preferences | 1.000 | 0.667 | 0.700 | 4.000 | 0/2 |
+| need_to_know_allergy | 1.000 | 0.500 | 0.571 | 4.000 | 0/1 |

--- a/tests/benchmarks/results/siq/siq_20260721_query_stub.json
+++ b/tests/benchmarks/results/siq/siq_20260721_query_stub.json
@@ -1,0 +1,71 @@
+{
+  "adapter": "query_stub",
+  "n_traces": 4,
+  "aggregate": {
+    "precision_at_budget": null,
+    "recall_at_budget": 0.0,
+    "budget_efficiency": null,
+    "mean_anticipation_lead": null,
+    "total_anticipation_misses": 5,
+    "total_recall_targets": 5
+  },
+  "per_trace": [
+    {
+      "n_turns": 5,
+      "precision_at_budget": null,
+      "recall_at_budget": 0.0,
+      "budget_efficiency": null,
+      "anticipation_lead_times": {
+        "mem_relocation": null
+      },
+      "mean_anticipation_lead": null,
+      "anticipation_misses": 1,
+      "n_recall_targets": 1,
+      "trace_id": "coreference_relocation",
+      "adapter": "query_stub"
+    },
+    {
+      "n_turns": 5,
+      "precision_at_budget": null,
+      "recall_at_budget": 0.0,
+      "budget_efficiency": null,
+      "anticipation_lead_times": {
+        "mem_locked_demo": null
+      },
+      "mean_anticipation_lead": null,
+      "anticipation_misses": 1,
+      "n_recall_targets": 1,
+      "trace_id": "implication_deadline",
+      "adapter": "query_stub"
+    },
+    {
+      "n_turns": 6,
+      "precision_at_budget": null,
+      "recall_at_budget": 0.0,
+      "budget_efficiency": null,
+      "anticipation_lead_times": {
+        "mem_budget": null,
+        "mem_vegetarian": null
+      },
+      "mean_anticipation_lead": null,
+      "anticipation_misses": 2,
+      "n_recall_targets": 2,
+      "trace_id": "multi_recall_preferences",
+      "adapter": "query_stub"
+    },
+    {
+      "n_turns": 5,
+      "precision_at_budget": null,
+      "recall_at_budget": 0.0,
+      "budget_efficiency": null,
+      "anticipation_lead_times": {
+        "mem_allergy": null
+      },
+      "mean_anticipation_lead": null,
+      "anticipation_misses": 1,
+      "n_recall_targets": 1,
+      "trace_id": "need_to_know_allergy",
+      "adapter": "query_stub"
+    }
+  ]
+}

--- a/tests/benchmarks/results/siq/siq_20260721_query_stub.md
+++ b/tests/benchmarks/results/siq/siq_20260721_query_stub.md
@@ -1,0 +1,22 @@
+# SIQ Benchmark — adapter: `query_stub`
+
+Subconscious Injection Quality (issue #459). Deterministic committed fixtures; no runtime RNG. See `docs/benchmarks.md`.
+
+## Aggregate
+
+| metric | value |
+|---|---|
+| precision @ budget | n/a |
+| recall @ budget | 0.000 |
+| budget efficiency | n/a |
+| mean anticipation lead (turns) | n/a |
+| anticipation misses | 5 / 5 targets |
+
+## Per trace
+
+| trace | recall | precision | efficiency | mean lead | misses |
+|---|---|---|---|---|---|
+| coreference_relocation | 0.000 | n/a | n/a | n/a | 1/1 |
+| implication_deadline | 0.000 | n/a | n/a | n/a | 1/1 |
+| multi_recall_preferences | 0.000 | n/a | n/a | n/a | 2/2 |
+| need_to_know_allergy | 0.000 | n/a | n/a | n/a | 1/1 |

--- a/tests/benchmarks/results/siq/siq_latest_native.json
+++ b/tests/benchmarks/results/siq/siq_latest_native.json
@@ -1,0 +1,71 @@
+{
+  "adapter": "native",
+  "n_traces": 4,
+  "aggregate": {
+    "precision_at_budget": 0.6666666666666666,
+    "recall_at_budget": 1.0,
+    "budget_efficiency": 0.706015037593985,
+    "mean_anticipation_lead": 4.0,
+    "total_anticipation_misses": 0,
+    "total_recall_targets": 5
+  },
+  "per_trace": [
+    {
+      "n_turns": 5,
+      "precision_at_budget": 1.0,
+      "recall_at_budget": 1.0,
+      "budget_efficiency": 1.0,
+      "anticipation_lead_times": {
+        "mem_relocation": 4
+      },
+      "mean_anticipation_lead": 4.0,
+      "anticipation_misses": 0,
+      "n_recall_targets": 1,
+      "trace_id": "coreference_relocation",
+      "adapter": "native"
+    },
+    {
+      "n_turns": 5,
+      "precision_at_budget": 0.5,
+      "recall_at_budget": 1.0,
+      "budget_efficiency": 0.5526315789473685,
+      "anticipation_lead_times": {
+        "mem_locked_demo": 4
+      },
+      "mean_anticipation_lead": 4.0,
+      "anticipation_misses": 0,
+      "n_recall_targets": 1,
+      "trace_id": "implication_deadline",
+      "adapter": "native"
+    },
+    {
+      "n_turns": 6,
+      "precision_at_budget": 0.6666666666666666,
+      "recall_at_budget": 1.0,
+      "budget_efficiency": 0.7,
+      "anticipation_lead_times": {
+        "mem_budget": 3,
+        "mem_vegetarian": 5
+      },
+      "mean_anticipation_lead": 4.0,
+      "anticipation_misses": 0,
+      "n_recall_targets": 2,
+      "trace_id": "multi_recall_preferences",
+      "adapter": "native"
+    },
+    {
+      "n_turns": 5,
+      "precision_at_budget": 0.5,
+      "recall_at_budget": 1.0,
+      "budget_efficiency": 0.5714285714285714,
+      "anticipation_lead_times": {
+        "mem_allergy": 4
+      },
+      "mean_anticipation_lead": 4.0,
+      "anticipation_misses": 0,
+      "n_recall_targets": 1,
+      "trace_id": "need_to_know_allergy",
+      "adapter": "native"
+    }
+  ]
+}

--- a/tests/benchmarks/results/siq/siq_latest_native.md
+++ b/tests/benchmarks/results/siq/siq_latest_native.md
@@ -1,0 +1,22 @@
+# SIQ Benchmark — adapter: `native`
+
+Subconscious Injection Quality (issue #459). Deterministic committed fixtures; no runtime RNG. See `docs/benchmarks.md`.
+
+## Aggregate
+
+| metric | value |
+|---|---|
+| precision @ budget | 0.667 |
+| recall @ budget | 1.000 |
+| budget efficiency | 0.706 |
+| mean anticipation lead (turns) | 4.000 |
+| anticipation misses | 0 / 5 targets |
+
+## Per trace
+
+| trace | recall | precision | efficiency | mean lead | misses |
+|---|---|---|---|---|---|
+| coreference_relocation | 1.000 | 1.000 | 1.000 | 4.000 | 0/1 |
+| implication_deadline | 1.000 | 0.500 | 0.553 | 4.000 | 0/1 |
+| multi_recall_preferences | 1.000 | 0.667 | 0.700 | 4.000 | 0/2 |
+| need_to_know_allergy | 1.000 | 0.500 | 0.571 | 4.000 | 0/1 |

--- a/tests/benchmarks/results/siq/siq_latest_query_stub.json
+++ b/tests/benchmarks/results/siq/siq_latest_query_stub.json
@@ -1,0 +1,71 @@
+{
+  "adapter": "query_stub",
+  "n_traces": 4,
+  "aggregate": {
+    "precision_at_budget": null,
+    "recall_at_budget": 0.0,
+    "budget_efficiency": null,
+    "mean_anticipation_lead": null,
+    "total_anticipation_misses": 5,
+    "total_recall_targets": 5
+  },
+  "per_trace": [
+    {
+      "n_turns": 5,
+      "precision_at_budget": null,
+      "recall_at_budget": 0.0,
+      "budget_efficiency": null,
+      "anticipation_lead_times": {
+        "mem_relocation": null
+      },
+      "mean_anticipation_lead": null,
+      "anticipation_misses": 1,
+      "n_recall_targets": 1,
+      "trace_id": "coreference_relocation",
+      "adapter": "query_stub"
+    },
+    {
+      "n_turns": 5,
+      "precision_at_budget": null,
+      "recall_at_budget": 0.0,
+      "budget_efficiency": null,
+      "anticipation_lead_times": {
+        "mem_locked_demo": null
+      },
+      "mean_anticipation_lead": null,
+      "anticipation_misses": 1,
+      "n_recall_targets": 1,
+      "trace_id": "implication_deadline",
+      "adapter": "query_stub"
+    },
+    {
+      "n_turns": 6,
+      "precision_at_budget": null,
+      "recall_at_budget": 0.0,
+      "budget_efficiency": null,
+      "anticipation_lead_times": {
+        "mem_budget": null,
+        "mem_vegetarian": null
+      },
+      "mean_anticipation_lead": null,
+      "anticipation_misses": 2,
+      "n_recall_targets": 2,
+      "trace_id": "multi_recall_preferences",
+      "adapter": "query_stub"
+    },
+    {
+      "n_turns": 5,
+      "precision_at_budget": null,
+      "recall_at_budget": 0.0,
+      "budget_efficiency": null,
+      "anticipation_lead_times": {
+        "mem_allergy": null
+      },
+      "mean_anticipation_lead": null,
+      "anticipation_misses": 1,
+      "n_recall_targets": 1,
+      "trace_id": "need_to_know_allergy",
+      "adapter": "query_stub"
+    }
+  ]
+}

--- a/tests/benchmarks/results/siq/siq_latest_query_stub.md
+++ b/tests/benchmarks/results/siq/siq_latest_query_stub.md
@@ -1,0 +1,22 @@
+# SIQ Benchmark — adapter: `query_stub`
+
+Subconscious Injection Quality (issue #459). Deterministic committed fixtures; no runtime RNG. See `docs/benchmarks.md`.
+
+## Aggregate
+
+| metric | value |
+|---|---|
+| precision @ budget | n/a |
+| recall @ budget | 0.000 |
+| budget efficiency | n/a |
+| mean anticipation lead (turns) | n/a |
+| anticipation misses | 5 / 5 targets |
+
+## Per trace
+
+| trace | recall | precision | efficiency | mean lead | misses |
+|---|---|---|---|---|---|
+| coreference_relocation | 0.000 | n/a | n/a | n/a | 1/1 |
+| implication_deadline | 0.000 | n/a | n/a | n/a | 1/1 |
+| multi_recall_preferences | 0.000 | n/a | n/a | n/a | 2/2 |
+| need_to_know_allergy | 0.000 | n/a | n/a | n/a | 1/1 |

--- a/tests/benchmarks/siq/__init__.py
+++ b/tests/benchmarks/siq/__init__.py
@@ -1,0 +1,33 @@
+"""SIQ — Subconscious Injection Quality benchmark (issue #459).
+
+The flagship *native* Popoto benchmark. It measures the thing composite
+(query-blind) retrieval actually does and no public benchmark measures:
+*without an explicit query cueing it,* did the right memory get injected into
+context at the right turn?
+
+Every other benchmark in this repo (Tier 1-4 scenarios, the LongMemEval-S /
+LoCoMo external harness, the Tier-5 judged-answer harness) is *query-driven*:
+an explicit question or ``query_cues`` dict is supplied and the harness scores
+whether the right evidence came back. SIQ is the complement — it replays
+multi-turn agent traces where a later turn needs a memory established earlier
+but the turn's own message never lexically cues it (coreference, implication,
+or need-to-know that's simply never restated). A ``lint_trace`` authoring guard
+proves the cue is *mechanically* absent (BM25-tokenizer-disjoint), so the
+benchmark can't be gamed by picking easy targets.
+
+Design invariants (issue #459 + ``docs/plans/siq_benchmark.md``):
+
+- **Deterministic, committed fixtures.** Traces live as JSON under
+  ``fixtures/`` — no runtime generation, no RNG in scoring, no wall-clock in
+  ranking (planted ``importance`` drives the query-blind composite order).
+- **pytest DB-15 native.** The CI-facing suite is ``tests/benchmarks/test_siq.py``
+  and runs under the standard db15 isolation plugin. The optional CLI
+  (``run_siq.py``) reuses ``external_base._bench_db`` (default 14, rejects 0)
+  for the same isolation reason — SIQ never touches db0.
+- **Competitor-fair.** ``SiqAdapter`` (``adapters.py``) is the extension point
+  mirroring the Tier-5 ``JudgeProtocol`` pattern. This module ships the native
+  Popoto adapter plus a dependency-free query-driven baseline
+  (``QueryOnlyStubAdapter``) that scores ~0 on these traces *by construction* —
+  the harness's own validity proof. Real Mem0/Zep/Hindsight adapters are a
+  tracked follow-up (not fabricated here).
+"""

--- a/tests/benchmarks/siq/adapters.py
+++ b/tests/benchmarks/siq/adapters.py
@@ -1,0 +1,168 @@
+"""SIQ adapters — the competitor-fair extension point (issue #459).
+
+An :class:`SiqAdapter` is a memory system replayed turn-by-turn against a
+:class:`~tests.benchmarks.siq.corpus.SiqTrace`. The runner calls
+:meth:`ingest_turn` for every turn in order (the adapter writes any established
+memory into its own store), then :meth:`injected_for_turn` to ask *what the
+adapter would place in context at this turn* — the injected set the SIQ metrics
+score. Token accounting and metric computation live in the runner/metrics, so
+every adapter is scored on identical footing.
+
+This mirrors the Tier-5 ``JudgeProtocol`` pattern (``tests/benchmarks/judge.py``):
+a ``Protocol`` plus a reference implementation, no hard third-party dependency.
+
+Two adapters ship here:
+
+- :class:`NativeAdapter` — Popoto's query-blind composite mode via
+  ``ContextAssembler(retrieval_mode="composite")``. This is the system under
+  test. It injects by importance/decay ranking with **no** lexical cue from the
+  current turn's message, so it can surface a memory before the user restates it.
+- :class:`QueryOnlyStubAdapter` — a dependency-free, deterministic *query-driven*
+  baseline standing in for the Mem0/Zep/Hindsight family. It injects only
+  memories whose content lexically overlaps the current turn's message. By the
+  cue-blindness authoring lint, at a ``should_recall`` turn the message shares
+  no token with the target memory, so this adapter injects nothing there — it
+  scores ~0 recall / all-miss anticipation *by construction*. That near-zero
+  baseline is the harness's own validity proof and is asserted in ``test_siq.py``.
+
+Real Mem0/Zep/Hindsight adapters (heavyweight optional deps + live API keys)
+are a tracked follow-up, not implemented here — no competitor numbers are
+fabricated.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Protocol
+
+from src.popoto.fields._tokenizer import tokenize
+from src.popoto.recipes.context_assembler import ContextAssembler
+
+from .corpus import (
+    SiqTrace,
+    SiqTurn,
+    cleanup,
+    new_trace_namespace,
+    plant_memory,
+)
+
+#: Composite score weights for the native adapter — a single query-blind signal
+#: over the model's ``importance`` SortedField. Deterministic (no wall-clock),
+#: matching the CSR composite-control convention.
+NATIVE_SCORE_WEIGHTS = {"importance": 1.0}
+
+#: Content-free cue used only to enter the composite pull path (``assemble``
+#: skips the pull path when ``query_cues`` is falsy). Its value never affects
+#: composite ranking — that is the query-blind property SIQ measures.
+_BLIND_CUE = {"topic": "_"}
+
+
+class SiqAdapter(Protocol):
+    """Turn-by-turn memory-system interface the SIQ runner drives."""
+
+    name: str
+
+    def ingest_turn(self, turn: SiqTurn) -> None:
+        """Observe one turn; write its established memory (if any) to store."""
+        ...
+
+    def injected_for_turn(self, turn: SiqTurn) -> List[str]:
+        """Return the rank-ordered, budget-capped memory ids to inject now."""
+        ...
+
+    def teardown(self) -> None:
+        """Release any resources (Redis keys, clients)."""
+        ...
+
+
+class NativeAdapter:
+    """Popoto query-blind composite mode (the system under test).
+
+    Builds a per-trace key-isolated Model + a ``ContextAssembler`` in
+    ``composite`` mode. ``injected_for_turn`` calls ``assemble`` with a
+    content-free cue, so the injected set is ranked purely by importance over
+    whatever has been planted so far — never by the current message.
+    """
+
+    name = "native"
+
+    def __init__(self, trace: SiqTrace) -> None:
+        self._trace = trace
+        self._model_class, self._agent_id, self._prefix = new_trace_namespace()
+        self._assembler = ContextAssembler(
+            self._model_class,
+            score_weights=NATIVE_SCORE_WEIGHTS,
+            max_items=trace.max_items,
+            max_tokens=trace.max_tokens,
+            retrieval_mode="composite",
+        )
+        # Guard the query-blind invariant: if the model ever grew a BM25Field /
+        # EmbeddingField this would flip to lexical/hybrid and silently stop
+        # measuring subconscious injection. Fail loud instead.
+        assert self._assembler._effective_mode == "composite", (
+            "NativeAdapter must run composite (query-blind) mode; got "
+            f"{self._assembler._effective_mode!r}"
+        )
+        self._reverse_map: Dict[str, str] = {}  # redis_key -> memory id
+
+    def ingest_turn(self, turn: SiqTurn) -> None:
+        if turn.establishes is not None:
+            record = plant_memory(self._model_class, self._agent_id, turn.establishes)
+            self._reverse_map[record.db_key.redis_key] = turn.establishes.id
+
+    def injected_for_turn(self, turn: SiqTurn) -> List[str]:
+        result = self._assembler.assemble(
+            query_cues=_BLIND_CUE, agent_id=self._agent_id
+        )
+        injected: List[str] = []
+        for record in result.records:
+            mem_id = self._reverse_map.get(record.db_key.redis_key)
+            if mem_id is not None:
+                injected.append(mem_id)
+        return injected
+
+    def teardown(self) -> None:
+        cleanup(self._model_class, self._agent_id)
+
+
+class QueryOnlyStubAdapter:
+    """Deterministic query-driven baseline (Mem0/Zep/Hindsight stand-in).
+
+    Holds established memories in-process and injects only those whose content
+    shares an indexed token with the current turn's message, ranked by
+    importance (desc), tie-broken by id, capped at ``max_items``. No Redis, no
+    network, no RNG — fully deterministic and dependency-free.
+    """
+
+    name = "query_stub"
+
+    def __init__(self, trace: SiqTrace) -> None:
+        self._trace = trace
+        self._max_items = trace.max_items
+        self._store: Dict[str, tuple] = {}  # id -> (importance, content_tokens)
+
+    def ingest_turn(self, turn: SiqTurn) -> None:
+        if turn.establishes is not None:
+            m = turn.establishes
+            self._store[m.id] = (m.importance, frozenset(tokenize(m.content)))
+
+    def injected_for_turn(self, turn: SiqTurn) -> List[str]:
+        msg_tokens = set(tokenize(turn.message))
+        hits = [
+            (imp, mem_id)
+            for mem_id, (imp, content_tokens) in self._store.items()
+            if msg_tokens & content_tokens
+        ]
+        # importance desc, then id asc for a stable deterministic order.
+        hits.sort(key=lambda x: (-x[0], x[1]))
+        return [mem_id for _, mem_id in hits[: self._max_items]]
+
+    def teardown(self) -> None:  # no external resources
+        return None
+
+
+#: Adapter registry for the CLI (``run_siq.py --adapter``). Real competitor
+#: adapters register here in the tracked follow-up.
+ADAPTERS = {
+    "native": NativeAdapter,
+    "query_stub": QueryOnlyStubAdapter,
+}

--- a/tests/benchmarks/siq/corpus.py
+++ b/tests/benchmarks/siq/corpus.py
@@ -1,0 +1,328 @@
+"""Trace schema, loader, authoring lint, and corpus planting for SIQ (#459).
+
+A :class:`SiqTrace` is an ordered list of :class:`SiqTurn`. Some turns
+*establish* a memory (a :class:`SiqMemory`); some turns declare a
+``should_recall`` set — the ids of memories that are ground-truth-useful at
+that turn, decided by the fixture author from the narrative (never computed).
+
+The authoring discipline mirrors ``tests/benchmarks/csr/corpus.py``: the
+mechanical, un-gameable half of ground truth is enforced at load time by
+:func:`lint_trace` using the *real* BM25 tokenizer
+(``src.popoto.fields._tokenizer.tokenize`` — the single source of truth BM25
+uses). The core rule is **cue-blindness**: at a turn that declares a memory in
+``should_recall``, the turn's own ``message`` must share **no** indexed token
+with that memory's content. That is the mechanical proof that a query-driven
+retriever has nothing to match on — which is exactly the regime SIQ measures.
+
+Planting mirrors the proven per-case key-isolation pattern: each trace gets a
+uniquely-named Popoto Model class (``type()`` so the metaclass captures the
+unique ``db_class_key`` from the start), so records / sorted-index / any
+secondary keys can never contaminate another trace, and :func:`cleanup` scans
+and deletes by the unique class name (+ agent prefix backstop).
+
+The model declares **no** ``BM25Field`` / ``EmbeddingField`` / ``CyclicDecayField``
+/ ``ExistenceFilter`` — so ``ContextAssembler(retrieval_mode="composite")`` is
+the only retrieval mode in play, the push path stays inert, and ranking is
+query-blind and deterministic (a plain ``importance`` SortedField, no
+wall-clock decay).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from src import popoto
+from src.popoto.fields._tokenizer import tokenize
+from src.popoto.redis_db import POPOTO_REDIS_DB
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class SiqAuthoringError(ValueError):
+    """A trace fixture violates an authoring rule (raised at load/plant)."""
+
+
+@dataclass(frozen=True)
+class SiqMemory:
+    """One memory a turn establishes.
+
+    ``importance`` is the query-blind composite ranking signal (a plain
+    SortedField value, deterministic — no wall-clock decay). Higher importance
+    ranks earlier under the budget.
+    """
+
+    id: str
+    content: str
+    importance: float = 0.5
+
+
+@dataclass(frozen=True)
+class SiqTurn:
+    """One turn of a trace.
+
+    ``establishes`` is the memory this turn writes into store (``None`` if the
+    turn establishes nothing). ``should_recall`` is the set of memory ids that
+    are ground-truth-useful at this turn (empty for most turns).
+    """
+
+    index: int
+    speaker: str
+    message: str
+    establishes: Optional[SiqMemory] = None
+    should_recall: frozenset = frozenset()
+
+
+@dataclass(frozen=True)
+class SiqTrace:
+    """A full multi-turn trace fixture.
+
+    ``max_items`` / ``max_tokens`` are the injection budget handed to the
+    assembler (``max_tokens=None`` → item-count budget only).
+    """
+
+    trace_id: str
+    description: str
+    turns: Tuple[SiqTurn, ...]
+    max_items: int = 5
+    max_tokens: Optional[int] = None
+
+    def memories(self) -> Dict[str, SiqMemory]:
+        """Map memory id -> SiqMemory for every memory the trace establishes."""
+        out: Dict[str, SiqMemory] = {}
+        for turn in self.turns:
+            if turn.establishes is not None:
+                out[turn.establishes.id] = turn.establishes
+        return out
+
+    def establish_turn(self) -> Dict[str, int]:
+        """Map memory id -> the turn index that establishes it."""
+        out: Dict[str, int] = {}
+        for turn in self.turns:
+            if turn.establishes is not None:
+                out[turn.establishes.id] = turn.index
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def _parse_trace(raw: dict) -> SiqTrace:
+    """Build a :class:`SiqTrace` from a decoded fixture dict (no linting)."""
+    turns: List[SiqTurn] = []
+    for i, t in enumerate(raw.get("turns", [])):
+        establishes = None
+        if t.get("establishes") is not None:
+            m = t["establishes"]
+            establishes = SiqMemory(
+                id=str(m["id"]),
+                content=str(m["content"]),
+                importance=float(m.get("importance", 0.5)),
+            )
+        turns.append(
+            SiqTurn(
+                index=i,
+                speaker=str(t.get("speaker", "user")),
+                message=str(t.get("message", "")),
+                establishes=establishes,
+                should_recall=frozenset(str(x) for x in t.get("should_recall", [])),
+            )
+        )
+    return SiqTrace(
+        trace_id=str(raw["trace_id"]),
+        description=str(raw.get("description", "")),
+        turns=tuple(turns),
+        max_items=int(raw.get("max_items", 5)),
+        max_tokens=(None if raw.get("max_tokens") is None else int(raw["max_tokens"])),
+    )
+
+
+def load_trace(path) -> SiqTrace:
+    """Load and lint a single trace fixture from ``path``.
+
+    Raises:
+        SiqAuthoringError: If the fixture violates an authoring rule.
+    """
+    raw = json.loads(Path(path).read_text())
+    trace = _parse_trace(raw)
+    lint_trace(trace)
+    return trace
+
+
+def load_all_traces(directory=FIXTURES_DIR) -> List[SiqTrace]:
+    """Load and lint every ``*.json`` trace in ``directory`` (sorted by name).
+
+    Also enforces globally-unique ``trace_id`` across the suite.
+    """
+    traces = [load_trace(p) for p in sorted(Path(directory).glob("*.json"))]
+    seen = set()
+    for tr in traces:
+        if tr.trace_id in seen:
+            raise SiqAuthoringError(f"duplicate trace_id {tr.trace_id!r}")
+        seen.add(tr.trace_id)
+    return traces
+
+
+# ---------------------------------------------------------------------------
+# Authoring lint (the un-gameable, mechanical half of ground truth)
+# ---------------------------------------------------------------------------
+
+
+def lint_trace(trace: SiqTrace) -> None:
+    """Pure fixture-load lint. Raises :class:`SiqAuthoringError` on violation.
+
+    Rules (all token checks use the real BM25 tokenizer):
+
+    1. Trace has at least one turn.
+    2. Memory ids are unique; each turn's ``establishes`` id is unique across
+       the trace.
+    3. Every ``should_recall`` id was ``establishes``-ed at a **strictly
+       earlier** turn (a turn cannot recall a memory it just wrote or a memory
+       that never exists).
+    4. **Cue-blindness** — at every turn ``T`` that lists memory ``m`` in
+       ``should_recall``, ``T.message`` shares **no** indexed token with
+       ``m.content``. This is the mechanical proof the current message does not
+       lexically cue the target memory.
+    5. **Anticipation window** — at least one ``should_recall`` in the trace
+       occurs ``>= 2`` turns after the memory's establishing turn, so the trace
+       can actually exercise anticipation lead time.
+    """
+    if not trace.turns:
+        raise SiqAuthoringError(f"trace {trace.trace_id!r}: no turns")
+
+    establish_turn = trace.establish_turn()
+    memories = trace.memories()
+
+    # Rule 2: unique establishes ids.
+    seen_ids: List[str] = [
+        t.establishes.id for t in trace.turns if t.establishes is not None
+    ]
+    dups = {i for i in seen_ids if seen_ids.count(i) > 1}
+    if dups:
+        raise SiqAuthoringError(
+            f"trace {trace.trace_id!r}: duplicate established memory ids "
+            f"{sorted(dups)}"
+        )
+
+    max_gap = -1
+    for turn in trace.turns:
+        for mem_id in sorted(turn.should_recall):
+            # Rule 3: established strictly earlier.
+            if mem_id not in establish_turn:
+                raise SiqAuthoringError(
+                    f"trace {trace.trace_id!r} turn {turn.index}: should_recall "
+                    f"{mem_id!r} was never established"
+                )
+            e_turn = establish_turn[mem_id]
+            if e_turn >= turn.index:
+                raise SiqAuthoringError(
+                    f"trace {trace.trace_id!r} turn {turn.index}: should_recall "
+                    f"{mem_id!r} is established at turn {e_turn} (must be a "
+                    f"strictly earlier turn)"
+                )
+            # Rule 4: cue-blindness.
+            msg_tokens = set(tokenize(turn.message))
+            content_tokens = set(tokenize(memories[mem_id].content))
+            shared = msg_tokens & content_tokens
+            if shared:
+                raise SiqAuthoringError(
+                    f"trace {trace.trace_id!r} turn {turn.index}: message shares "
+                    f"indexed token(s) {sorted(shared)} with should_recall memory "
+                    f"{mem_id!r} — the turn lexically cues the memory, so this is "
+                    f"a query-driven case, not a subconscious one"
+                )
+            max_gap = max(max_gap, turn.index - e_turn)
+
+    # Rule 5: anticipation window.
+    if max_gap < 2:
+        raise SiqAuthoringError(
+            f"trace {trace.trace_id!r}: no should_recall occurs >= 2 turns after "
+            f"its establishing turn — trace cannot exercise anticipation lead time"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Corpus planting (per-trace key-isolated Model class)
+# ---------------------------------------------------------------------------
+
+
+def build_trace_model_class(safe_prefix: str):
+    """Build a fresh per-trace Popoto Model class for Redis key isolation.
+
+    Composite-only by construction: a plain ``importance`` SortedField is the
+    query-blind ranking signal (deterministic — no wall-clock decay), and there
+    is **no** BM25Field / EmbeddingField / CyclicDecayField / ExistenceFilter,
+    so ``ContextAssembler(retrieval_mode="composite")`` is the only path and the
+    push path stays inert.
+
+    Built with ``type()`` so the metaclass captures the unique
+    ``db_class_key`` from class creation (a post-hoc ``__name__`` rename would
+    leave the SortedField index shared across traces — cross-trace
+    contamination).
+    """
+    return type(
+        f"SiqMem{safe_prefix}",
+        (popoto.Model,),
+        {
+            "__module__": __name__,
+            "__qualname__": f"SiqMem{safe_prefix}",
+            "memory_key": popoto.AutoKeyField(),
+            "agent_id": popoto.KeyField(),
+            "content": popoto.StringField(default=""),
+            "importance": popoto.SortedField(type=float, default=0.5),
+        },
+    )
+
+
+def plant_memory(model_class, agent_id: str, memory: SiqMemory):
+    """Plant a single memory into the current Redis DB.
+
+    Returns the saved record.
+
+    Raises:
+        SiqAuthoringError: If ``save()`` reports failure.
+    """
+    record = model_class(
+        agent_id=agent_id,
+        content=memory.content,
+        importance=memory.importance,
+    )
+    if record.save() is False:
+        raise SiqAuthoringError(f"save() returned False planting memory {memory.id!r}")
+    return record
+
+
+def new_trace_namespace() -> Tuple[object, str, str]:
+    """Allocate a fresh (model_class, agent_id, safe_prefix) for one replay.
+
+    The prefix is random per replay so repeated runs and parallel pytest
+    workers never collide on Redis keys (matches ``external_base``).
+    """
+    safe_prefix = uuid.uuid4().hex[:8]
+    model_class = build_trace_model_class(safe_prefix)
+    agent_id = f"siq{safe_prefix}"
+    return model_class, agent_id, safe_prefix
+
+
+def cleanup(model_class, agent_id: str) -> None:
+    """Delete every Redis key created for one planted trace.
+
+    Scans ``*{ClassName}*`` (the unique per-trace class name appears in record
+    keys and the ``:_importance`` sorted index) then the agent prefix as a
+    backstop — mirrors ``external_base.teardown`` / ``csr.corpus.cleanup``.
+    Uses non-blocking ``SCAN`` (Valkey-safe, no modules).
+    """
+    class_name = model_class.__name__
+    for pattern in (f"*{class_name}*", f"*{agent_id}*"):
+        cursor = 0
+        while True:
+            cursor, keys = POPOTO_REDIS_DB.scan(cursor, match=pattern, count=200)
+            if keys:
+                POPOTO_REDIS_DB.delete(*keys)
+            if cursor == 0:
+                break

--- a/tests/benchmarks/siq/fixtures/coreference_relocation.json
+++ b/tests/benchmarks/siq/fixtures/coreference_relocation.json
@@ -1,0 +1,34 @@
+{
+  "trace_id": "coreference_relocation",
+  "description": "User establishes a relocation to Austin early, then later asks about 'good spots there' via coreference ('there') without ever restating the city or the move. The subconscious injector should still have the relocation memory in context.",
+  "max_items": 5,
+  "max_tokens": null,
+  "turns": [
+    {
+      "speaker": "user",
+      "message": "Heads up, I am relocating to Austin next month to begin a new engineering position.",
+      "establishes": {
+        "id": "mem_relocation",
+        "content": "User is relocating to Austin next month to begin a new engineering position.",
+        "importance": 0.9
+      }
+    },
+    {
+      "speaker": "assistant",
+      "message": "Congratulations, that sounds like a big and exciting step."
+    },
+    {
+      "speaker": "user",
+      "message": "My paperwork finally cleared yesterday afternoon."
+    },
+    {
+      "speaker": "assistant",
+      "message": "Glad it all worked itself out without extra hassle."
+    },
+    {
+      "speaker": "user",
+      "message": "Which quiet residential spots would you recommend around here?",
+      "should_recall": ["mem_relocation"]
+    }
+  ]
+}

--- a/tests/benchmarks/siq/fixtures/implication_deadline.json
+++ b/tests/benchmarks/siq/fixtures/implication_deadline.json
@@ -1,0 +1,39 @@
+{
+  "trace_id": "implication_deadline",
+  "description": "User states a hard constraint (board demo locked for Friday) early, then several turns later asks to 'push the timeline two weeks' — the implication that Friday is immovable is never restated. The relevant constraint must already be in context.",
+  "max_items": 5,
+  "max_tokens": null,
+  "turns": [
+    {
+      "speaker": "user",
+      "message": "Remember the board demonstration is locked for Friday and absolutely cannot move.",
+      "establishes": {
+        "id": "mem_locked_demo",
+        "content": "The board demonstration is locked for Friday and cannot move under any circumstances.",
+        "importance": 0.95
+      }
+    },
+    {
+      "speaker": "assistant",
+      "message": "Understood, noting that firmly on my side."
+    },
+    {
+      "speaker": "user",
+      "message": "The onboarding copy still needs another editing pass.",
+      "establishes": {
+        "id": "mem_copy_edit",
+        "content": "The onboarding copy still needs another editing pass before it ships.",
+        "importance": 0.4
+      }
+    },
+    {
+      "speaker": "assistant",
+      "message": "Okay, I will slot revisions where they fit."
+    },
+    {
+      "speaker": "user",
+      "message": "Honestly, can we just slide everything back a fortnight?",
+      "should_recall": ["mem_locked_demo"]
+    }
+  ]
+}

--- a/tests/benchmarks/siq/fixtures/multi_recall_preferences.json
+++ b/tests/benchmarks/siq/fixtures/multi_recall_preferences.json
@@ -1,0 +1,48 @@
+{
+  "trace_id": "multi_recall_preferences",
+  "description": "Two constraints (vegetarian, tight budget) plus one low-importance distractor hobby are established across early turns. A later planning request cues none of them lexically but needs both constraints — exercises multi-memory recall and sub-1.0 precision (the distractor is also injected under budget).",
+  "max_items": 5,
+  "max_tokens": null,
+  "turns": [
+    {
+      "speaker": "user",
+      "message": "For meals, note that I am strictly vegetarian and never eat meat or fish.",
+      "establishes": {
+        "id": "mem_vegetarian",
+        "content": "User is strictly vegetarian and never eats meat or fish.",
+        "importance": 0.85
+      }
+    },
+    {
+      "speaker": "assistant",
+      "message": "Noted clearly, I will honor that."
+    },
+    {
+      "speaker": "user",
+      "message": "Please keep the overall trip budget beneath one thousand dollars.",
+      "establishes": {
+        "id": "mem_budget",
+        "content": "Keep the overall trip budget beneath one thousand dollars.",
+        "importance": 0.8
+      }
+    },
+    {
+      "speaker": "user",
+      "message": "On free days I really enjoy long weekend hikes.",
+      "establishes": {
+        "id": "mem_hobby",
+        "content": "On free days user really enjoys long weekend hikes.",
+        "importance": 0.4
+      }
+    },
+    {
+      "speaker": "assistant",
+      "message": "Sounds wonderful, thanks for sharing."
+    },
+    {
+      "speaker": "user",
+      "message": "Could you organize the group outing please?",
+      "should_recall": ["mem_vegetarian", "mem_budget"]
+    }
+  ]
+}

--- a/tests/benchmarks/siq/fixtures/need_to_know_allergy.json
+++ b/tests/benchmarks/siq/fixtures/need_to_know_allergy.json
@@ -1,0 +1,39 @@
+{
+  "trace_id": "need_to_know_allergy",
+  "description": "User mentions a severe peanut allergy once, early. Turns later they ask for a dinner recipe recommendation without repeating the allergy. The need-to-know memory must surface subconsciously even though the request never cues it.",
+  "max_items": 5,
+  "max_tokens": null,
+  "turns": [
+    {
+      "speaker": "user",
+      "message": "Just so you know, I have a severe peanut allergy that gets dangerous fast.",
+      "establishes": {
+        "id": "mem_allergy",
+        "content": "User has a severe peanut allergy that becomes dangerous quickly.",
+        "importance": 0.92
+      }
+    },
+    {
+      "speaker": "assistant",
+      "message": "Thanks for telling me, I will keep that front of mind."
+    },
+    {
+      "speaker": "user",
+      "message": "Work has been relentless this quarter honestly.",
+      "establishes": {
+        "id": "mem_busy",
+        "content": "User has been extremely busy at work this quarter.",
+        "importance": 0.3
+      }
+    },
+    {
+      "speaker": "assistant",
+      "message": "That is a lot to carry; hope it eases soon."
+    },
+    {
+      "speaker": "user",
+      "message": "Could you suggest an easy weeknight dinner recipe I could cook tonight?",
+      "should_recall": ["mem_allergy"]
+    }
+  ]
+}

--- a/tests/benchmarks/siq/metrics.py
+++ b/tests/benchmarks/siq/metrics.py
@@ -1,0 +1,201 @@
+"""SIQ scoring — pure, deterministic metric functions over replay results.
+
+Every function here is a pure function of :class:`TurnResult` lists plus the
+trace ground truth. No Redis, no RNG, no wall-clock — given the same
+``TurnResult`` sequence the numbers are bit-for-bit reproducible, so
+``test_siq.py`` asserts exact expected constants (no tolerance bands).
+
+Metric definitions (locked in ``docs/plans/siq_benchmark.md`` "Critique
+Response"):
+
+Precision, recall, and budget efficiency are evaluated **only at turns that
+carry a ``should_recall`` annotation** — the moments of defined information
+need. Narrative turns (empty ``should_recall``) contribute nothing to these
+three; scoring a proactive injection at every narrative turn as "imprecise"
+would make the aggregate meaningless and punish the very anticipation the
+benchmark exists to reward. Early injection at narrative turns is instead
+credited by *anticipation lead time*, which is the metric designed for it.
+
+- **Injection precision @ budget** (per evaluation turn): ``|injected ∩
+  should_recall| / |injected|``. Undefined (``None``) at non-evaluation turns
+  and when nothing was injected — never ``0/0``.
+- **Injection recall @ budget** (per evaluation turn): ``|injected ∩
+  should_recall| / |should_recall|``. Undefined (``None``) at non-evaluation
+  turns.
+- **Anticipation lead time** (per memory): given ``R`` = the first turn a memory
+  is a ``should_recall`` target, and requiring it to be injected *at* ``R``, the
+  count of consecutive turns immediately before ``R`` at which it was also
+  injected. A memory not injected at ``R`` is a **miss** (excluded from the
+  mean, counted separately) — never a negative or ``+inf`` value. This rewards
+  *proactive, continuous* presence: a pure query-driven retriever, which only
+  injects on a lexical match, is absent at ``R`` by the cue-blindness lint and
+  therefore always misses.
+- **Budget efficiency** (per evaluation turn): ``useful_tokens /
+  injected_tokens`` where ``useful_tokens`` is the token mass of injected
+  records whose id is in that turn's ``should_recall``. Undefined (``None``) at
+  non-evaluation turns and when nothing was injected.
+
+Token counting is a deterministic character-length heuristic (``len // 4``,
+floor 1) — no model, no network — so budget numbers are reproducible from the
+committed fixture text alone.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+def siq_token_count(text: str) -> int:
+    """Deterministic token estimate: ``max(1, len(text) // 4)``.
+
+    A whitespace/character heuristic with no model dependency, so the same
+    fixture text always yields the same count. Floor of 1 so a non-empty
+    record never counts as zero tokens.
+    """
+    if not text:
+        return 0
+    return max(1, len(text) // 4)
+
+
+@dataclass(frozen=True)
+class TurnResult:
+    """The outcome of replaying one trace turn against one adapter.
+
+    ``injected_ids`` is the rank-ordered list of memory ids the adapter placed
+    in context for this turn (already budget-capped by the adapter).
+    ``injected_tokens`` maps each injected id to its token count.
+    """
+
+    index: int
+    should_recall: frozenset
+    injected_ids: tuple
+    injected_tokens: Dict[str, int] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Per-turn precision / recall
+# ---------------------------------------------------------------------------
+
+
+def turn_precision(result: TurnResult) -> Optional[float]:
+    """Injection precision @ budget at an evaluation turn.
+
+    ``None`` at non-evaluation turns (no ``should_recall``) and when nothing
+    was injected.
+    """
+    if not result.should_recall:
+        return None
+    injected = set(result.injected_ids)
+    if not injected:
+        return None
+    useful = injected & set(result.should_recall)
+    return len(useful) / len(injected)
+
+
+def turn_recall(result: TurnResult) -> Optional[float]:
+    """Injection recall @ budget at an evaluation turn (``None`` otherwise)."""
+    if not result.should_recall:
+        return None
+    injected = set(result.injected_ids)
+    useful = injected & set(result.should_recall)
+    return len(useful) / len(result.should_recall)
+
+
+def turn_budget_efficiency(result: TurnResult) -> Optional[float]:
+    """Useful-token / injected-token ratio at an evaluation turn.
+
+    ``None`` at non-evaluation turns and when nothing was injected.
+    """
+    if not result.should_recall:
+        return None
+    injected = list(result.injected_ids)
+    if not injected:
+        return None
+    injected_tokens = sum(result.injected_tokens.get(i, 0) for i in injected)
+    if injected_tokens == 0:
+        return None
+    useful_ids = set(injected) & set(result.should_recall)
+    useful_tokens = sum(result.injected_tokens.get(i, 0) for i in useful_ids)
+    return useful_tokens / injected_tokens
+
+
+# ---------------------------------------------------------------------------
+# Anticipation lead time (per memory)
+# ---------------------------------------------------------------------------
+
+
+def anticipation_lead_times(
+    results: List[TurnResult],
+) -> Dict[str, Optional[int]]:
+    """Per-memory anticipation lead time over a full trace replay.
+
+    For each memory that is a ``should_recall`` target at some turn, let ``R``
+    be its earliest such turn. If the memory is injected at ``R``, the lead time
+    is the number of consecutive turns immediately before ``R`` at which it was
+    also injected. If it is not injected at ``R`` the memory maps to ``None`` (a
+    miss).
+
+    Returns:
+        dict ``mem_id -> lead (int) | None`` for every memory that is a
+        ``should_recall`` target somewhere in the trace.
+    """
+    injected_at: Dict[int, set] = {r.index: set(r.injected_ids) for r in results}
+
+    first_recall_turn: Dict[str, int] = {}
+    for r in sorted(results, key=lambda x: x.index):
+        for mem_id in r.should_recall:
+            if mem_id not in first_recall_turn:
+                first_recall_turn[mem_id] = r.index
+
+    out: Dict[str, Optional[int]] = {}
+    for mem_id, R in first_recall_turn.items():
+        if mem_id not in injected_at.get(R, set()):
+            out[mem_id] = None  # miss — not injected when it mattered
+            continue
+        lead = 0
+        t = R - 1
+        while t in injected_at and mem_id in injected_at[t]:
+            lead += 1
+            t -= 1
+        out[mem_id] = lead
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Trace-level aggregation
+# ---------------------------------------------------------------------------
+
+
+def _mean(values: List[float]) -> Optional[float]:
+    defined = [v for v in values if v is not None]
+    if not defined:
+        return None
+    return sum(defined) / len(defined)
+
+
+def score_trace(results: List[TurnResult]) -> dict:
+    """Aggregate all SIQ metrics over one trace replay.
+
+    Returns a JSON-serializable dict with mean precision/recall/efficiency over
+    the turns where each is defined, the per-memory lead times, mean lead time
+    over non-miss memories, and the miss count.
+    """
+    precisions = [turn_precision(r) for r in results]
+    recalls = [turn_recall(r) for r in results]
+    efficiencies = [turn_budget_efficiency(r) for r in results]
+    leads = anticipation_lead_times(results)
+
+    hit_leads = [v for v in leads.values() if v is not None]
+    misses = sum(1 for v in leads.values() if v is None)
+
+    return {
+        "n_turns": len(results),
+        "precision_at_budget": _mean(precisions),
+        "recall_at_budget": _mean(recalls),
+        "budget_efficiency": _mean(efficiencies),
+        "anticipation_lead_times": {k: leads[k] for k in sorted(leads)},
+        "mean_anticipation_lead": (_mean(hit_leads) if hit_leads else None),
+        "anticipation_misses": misses,
+        "n_recall_targets": len(leads),
+    }

--- a/tests/benchmarks/siq/run_siq.py
+++ b/tests/benchmarks/siq/run_siq.py
@@ -1,0 +1,165 @@
+"""CLI entry point for the SIQ benchmark (issue #459).
+
+Runs every committed trace against a chosen adapter, prints a per-trace + mean
+table, and (unless ``--dry-run``) writes JSON + Markdown artifacts under
+``tests/benchmarks/results/siq/`` following the Tier-5 naming convention
+(``siq_{YYYYMMDD}_{adapter}.{json,md}`` + ``siq_latest_{adapter}.*`` pointers).
+
+DB hygiene: this is a **manual CLI, not a pytest test**, so the db15 isolation
+plugin does not apply. It therefore reuses ``run_external``'s DB machinery — a
+dedicated bench DB (default 14, ``POPOTO_BENCH_DB`` override, **db0 rejected**)
+and an in-place connection swap done only at ``main()`` time — so it never
+touches db0 and never runs at import time. The **required, CI-facing** SIQ
+surface is ``tests/benchmarks/test_siq.py`` (db15 plugin); this CLI is for
+ad-hoc/publishable report generation. To avoid colliding with a running
+external-benchmark chain on db14, point it at a free DB, e.g.
+``POPOTO_BENCH_DB=13 python -m tests.benchmarks.siq.run_siq``.
+
+Usage:
+    python -m tests.benchmarks.siq.run_siq                 # native adapter
+    python -m tests.benchmarks.siq.run_siq --adapter query_stub
+    python -m tests.benchmarks.siq.run_siq --dry-run       # no artifacts
+    POPOTO_BENCH_DB=13 python -m tests.benchmarks.siq.run_siq
+
+Real Mem0/Zep/Hindsight adapters are a tracked follow-up; only ``native`` and
+``query_stub`` are registered today (no fabricated competitor numbers).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import sys
+from pathlib import Path
+
+from tests.benchmarks.run_external import (
+    _point_connection_at_db,
+    _resolve_bench_db,
+)
+
+from .adapters import ADAPTERS
+from .corpus import FIXTURES_DIR, load_all_traces
+from .metrics import _mean
+from .runner import run_trace
+
+RESULTS_DIR = Path(__file__).resolve().parents[1] / "results" / "siq"
+
+
+def run_suite(adapter_name: str) -> dict:
+    """Run every committed trace against ``adapter_name``; return a report dict."""
+    factory = ADAPTERS[adapter_name]
+    traces = load_all_traces(FIXTURES_DIR)
+    per_trace = [run_trace(t, factory) for t in traces]
+
+    def _agg(key):
+        return _mean([r[key] for r in per_trace])
+
+    return {
+        "adapter": adapter_name,
+        "n_traces": len(per_trace),
+        "aggregate": {
+            "precision_at_budget": _agg("precision_at_budget"),
+            "recall_at_budget": _agg("recall_at_budget"),
+            "budget_efficiency": _agg("budget_efficiency"),
+            "mean_anticipation_lead": _agg("mean_anticipation_lead"),
+            "total_anticipation_misses": sum(
+                r["anticipation_misses"] for r in per_trace
+            ),
+            "total_recall_targets": sum(r["n_recall_targets"] for r in per_trace),
+        },
+        "per_trace": per_trace,
+    }
+
+
+def build_markdown(report: dict) -> str:
+    agg = report["aggregate"]
+    lines = [
+        f"# SIQ Benchmark — adapter: `{report['adapter']}`",
+        "",
+        "Subconscious Injection Quality (issue #459). Deterministic committed "
+        "fixtures; no runtime RNG. See `docs/benchmarks.md`.",
+        "",
+        "## Aggregate",
+        "",
+        "| metric | value |",
+        "|---|---|",
+        f"| precision @ budget | {_fmt(agg['precision_at_budget'])} |",
+        f"| recall @ budget | {_fmt(agg['recall_at_budget'])} |",
+        f"| budget efficiency | {_fmt(agg['budget_efficiency'])} |",
+        f"| mean anticipation lead (turns) | {_fmt(agg['mean_anticipation_lead'])} |",
+        f"| anticipation misses | {agg['total_anticipation_misses']}"
+        f" / {agg['total_recall_targets']} targets |",
+        "",
+        "## Per trace",
+        "",
+        "| trace | recall | precision | efficiency | mean lead | misses |",
+        "|---|---|---|---|---|---|",
+    ]
+    for r in report["per_trace"]:
+        lines.append(
+            f"| {r['trace_id']} | {_fmt(r['recall_at_budget'])} | "
+            f"{_fmt(r['precision_at_budget'])} | {_fmt(r['budget_efficiency'])} | "
+            f"{_fmt(r['mean_anticipation_lead'])} | "
+            f"{r['anticipation_misses']}/{r['n_recall_targets']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _fmt(v) -> str:
+    if v is None:
+        return "n/a"
+    if isinstance(v, float):
+        return f"{v:.3f}"
+    return str(v)
+
+
+def save_reports(report: dict, results_dir: Path = RESULTS_DIR) -> Path:
+    results_dir.mkdir(parents=True, exist_ok=True)
+    date = _dt.datetime.now().strftime("%Y%m%d")
+    adapter = report["adapter"]
+    json_path = results_dir / f"siq_{date}_{adapter}.json"
+    md_path = results_dir / f"siq_{date}_{adapter}.md"
+    json_path.write_text(json.dumps(report, indent=2, default=str))
+    md_path.write_text(build_markdown(report))
+    # latest pointers (plain copies — mirrors run_external's convention)
+    (results_dir / f"siq_latest_{adapter}.json").write_text(
+        json.dumps(report, indent=2, default=str)
+    )
+    (results_dir / f"siq_latest_{adapter}.md").write_text(build_markdown(report))
+    return json_path
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Run the SIQ benchmark.")
+    parser.add_argument(
+        "--adapter",
+        choices=sorted(ADAPTERS),
+        default="native",
+        help="Which memory system to replay (default: native).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the report but do not write artifacts.",
+    )
+    args = parser.parse_args(argv)
+
+    # DB hygiene: point the connection at the dedicated bench DB (default 14,
+    # db0 rejected) BEFORE any planting. Never runs at import time.
+    bench_db = _resolve_bench_db()
+    _point_connection_at_db(bench_db)
+    print(f"SIQ: bench DB = {bench_db} (db0 rejected; db15 is pytest-only)")
+
+    report = run_suite(args.adapter)
+    print(build_markdown(report))
+
+    if not args.dry_run:
+        path = save_reports(report)
+        print(f"\nArtifacts written: {path.parent}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/benchmarks/siq/runner.py
+++ b/tests/benchmarks/siq/runner.py
@@ -1,0 +1,68 @@
+"""SIQ replay driver — turn-by-turn ingest + inject + score (issue #459).
+
+``replay(trace, adapter)`` walks a :class:`~tests.benchmarks.siq.corpus.SiqTrace`
+in turn order. For each turn it first lets the adapter ingest the turn (writing
+any established memory), then asks the adapter what it would inject *now*, and
+records a :class:`~tests.benchmarks.siq.metrics.TurnResult`. Token accounting is
+computed uniformly here (from the trace's own memory content) so every adapter
+is scored identically regardless of how it stores memories.
+
+Incremental planting is intrinsic to the replay: a memory only exists in the
+adapter's store from the turn that establishes it onward, so the injected set
+genuinely evolves turn to turn — which is what makes anticipation lead time
+meaningful (a memory can be proactively injected across the turns between its
+establishment and the turn it becomes relevant).
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from .corpus import SiqTrace
+from .metrics import TurnResult, score_trace, siq_token_count
+
+
+def replay(trace: SiqTrace, adapter) -> List[TurnResult]:
+    """Replay ``trace`` against ``adapter``; return per-turn results.
+
+    The adapter is responsible for its own setup (done in ``__init__``) and
+    teardown (caller invokes ``adapter.teardown()``); ``replay`` does not own
+    the adapter lifecycle so the same adapter policy can be inspected after the
+    run if desired.
+    """
+    memories = trace.memories()
+    # Precompute deterministic token counts once per memory.
+    token_counts = {
+        mem_id: siq_token_count(mem.content) for mem_id, mem in memories.items()
+    }
+
+    results: List[TurnResult] = []
+    for turn in trace.turns:
+        adapter.ingest_turn(turn)
+        injected = adapter.injected_for_turn(turn)
+        results.append(
+            TurnResult(
+                index=turn.index,
+                should_recall=turn.should_recall,
+                injected_ids=tuple(injected),
+                injected_tokens={i: token_counts.get(i, 0) for i in injected},
+            )
+        )
+    return results
+
+
+def run_trace(trace: SiqTrace, adapter_factory) -> dict:
+    """Build an adapter via ``adapter_factory(trace)``, replay, score, teardown.
+
+    Returns the aggregated score dict (see :func:`metrics.score_trace`) plus the
+    ``trace_id`` and ``adapter`` name. Teardown always runs, even on error.
+    """
+    adapter = adapter_factory(trace)
+    try:
+        results = replay(trace, adapter)
+        scored = score_trace(results)
+    finally:
+        adapter.teardown()
+    scored["trace_id"] = trace.trace_id
+    scored["adapter"] = getattr(adapter, "name", adapter_factory.__name__)
+    return scored

--- a/tests/benchmarks/test_siq.py
+++ b/tests/benchmarks/test_siq.py
@@ -1,0 +1,361 @@
+"""CI-facing tests for the SIQ benchmark (issue #459).
+
+Fixture-based and deterministic. Runs under the standard pytest db15 isolation
+plugin (``conftest.py``) — the harness plants per-trace, uniquely-prefixed model
+classes into db15 and tears them down, never touching db0 or the db14 external
+bench. No network, no API key, no RNG: every metric value below is asserted as
+an exact expected constant.
+
+Coverage:
+
+- **Lint** — every committed fixture passes ``lint_trace``; malformed inline
+  fixtures raise ``SiqAuthoringError`` (cue-blindness, anticipation window,
+  established-earlier rules).
+- **Native replay** — the query-blind composite adapter achieves full recall
+  with multi-turn anticipation lead on every fixture; exact per-trace values.
+- **Discriminant** — the ``QueryOnlyStubAdapter`` (query-driven baseline) scores
+  zero recall and all-miss anticipation on the same fixtures *by construction*.
+  This is the harness's own validity proof.
+- **Metric edge cases** — empty ``should_recall`` and never-injected memories
+  resolve to ``None``/miss, never a ``ZeroDivisionError`` or a bogus value.
+- **Mode invariant** — the native adapter runs composite (query-blind) mode.
+- **Determinism** — replaying the same trace twice yields identical scores.
+- **Judge pin** — the reused Tier-5 judge identity is still pinned (SIQ's
+  optional usefulness cross-check inherits the same pinned model + prompt).
+"""
+
+import pytest
+
+from tests.benchmarks.siq.adapters import (
+    NATIVE_SCORE_WEIGHTS,
+    NativeAdapter,
+    QueryOnlyStubAdapter,
+)
+from tests.benchmarks.siq.corpus import (
+    FIXTURES_DIR,
+    SiqAuthoringError,
+    SiqMemory,
+    SiqTrace,
+    SiqTurn,
+    lint_trace,
+    load_all_traces,
+)
+from tests.benchmarks.siq.metrics import (
+    TurnResult,
+    anticipation_lead_times,
+    score_trace,
+    siq_token_count,
+    turn_budget_efficiency,
+    turn_precision,
+    turn_recall,
+)
+from tests.benchmarks.siq.runner import replay, run_trace
+
+FIXTURE_IDS = [
+    "coreference_relocation",
+    "implication_deadline",
+    "multi_recall_preferences",
+    "need_to_know_allergy",
+]
+
+
+def _traces_by_id():
+    return {t.trace_id: t for t in load_all_traces(FIXTURES_DIR)}
+
+
+# ---------------------------------------------------------------------------
+# Fixture inventory + lint
+# ---------------------------------------------------------------------------
+
+
+def test_all_fixtures_present_and_lint_clean():
+    traces = load_all_traces(FIXTURES_DIR)
+    assert sorted(t.trace_id for t in traces) == sorted(FIXTURE_IDS)
+    # load_all_traces lints each and enforces unique trace_id; reaching here is
+    # the pass. Re-lint explicitly for clarity.
+    for t in traces:
+        lint_trace(t)
+
+
+def _mem(mid, content, imp=0.5):
+    return SiqMemory(id=mid, content=content, importance=imp)
+
+
+def test_lint_rejects_cue_that_lexically_matches_target():
+    """Cue-blindness: a should_recall message sharing a token with the memory."""
+    trace = SiqTrace(
+        trace_id="bad_cue",
+        description="",
+        turns=(
+            SiqTurn(0, "user", "planted content", _mem("m", "peanut allergy severe")),
+            SiqTurn(1, "user", "filler line here"),
+            SiqTurn(
+                2,
+                "user",
+                "tell me about the peanut dish",
+                should_recall=frozenset({"m"}),
+            ),
+        ),
+    )
+    with pytest.raises(SiqAuthoringError, match="lexically cues"):
+        lint_trace(trace)
+
+
+def test_lint_rejects_recall_before_establish():
+    trace = SiqTrace(
+        trace_id="bad_order",
+        description="",
+        turns=(
+            SiqTurn(0, "user", "nothing yet", should_recall=frozenset({"m"})),
+            SiqTurn(1, "user", "planted", _mem("m", "zzz qqq")),
+        ),
+    )
+    with pytest.raises(SiqAuthoringError, match="strictly earlier"):
+        lint_trace(trace)
+
+
+def test_lint_rejects_recall_of_unknown_memory():
+    trace = SiqTrace(
+        trace_id="unknown_mem",
+        description="",
+        turns=(
+            SiqTurn(0, "user", "planted", _mem("real", "zzz qqq")),
+            SiqTurn(1, "user", "filler line here"),
+            SiqTurn(
+                2, "user", "unrelated words only", should_recall=frozenset({"ghost"})
+            ),
+        ),
+    )
+    with pytest.raises(SiqAuthoringError, match="never established"):
+        lint_trace(trace)
+
+
+def test_lint_rejects_no_anticipation_window():
+    """A recall exactly one turn after establishment can't exercise lead time."""
+    trace = SiqTrace(
+        trace_id="no_window",
+        description="",
+        turns=(
+            SiqTurn(0, "user", "planted", _mem("m", "zzz qqq")),
+            SiqTurn(1, "user", "unrelated words only", should_recall=frozenset({"m"})),
+        ),
+    )
+    with pytest.raises(SiqAuthoringError, match="anticipation"):
+        lint_trace(trace)
+
+
+# ---------------------------------------------------------------------------
+# Native (query-blind composite) replay — exact deterministic values
+# ---------------------------------------------------------------------------
+
+# Expected per-trace native scores. Precision/recall are exact rationals;
+# budget_efficiency is asserted via approx to a literal derived from the
+# deterministic token counter over the committed fixture content.
+NATIVE_EXPECTED = {
+    "coreference_relocation": {
+        "precision": 1.0,
+        "recall": 1.0,
+        "efficiency": 1.0,
+        "leads": {"mem_relocation": 4},
+        "misses": 0,
+    },
+    "implication_deadline": {
+        "precision": 0.5,
+        "recall": 1.0,
+        "efficiency": pytest.approx(21 / 38),
+        "leads": {"mem_locked_demo": 4},
+        "misses": 0,
+    },
+    "multi_recall_preferences": {
+        "precision": pytest.approx(2 / 3),
+        "recall": 1.0,
+        "efficiency": pytest.approx(0.7),
+        "leads": {"mem_vegetarian": 5, "mem_budget": 3},
+        "misses": 0,
+    },
+    "need_to_know_allergy": {
+        "precision": 0.5,
+        "recall": 1.0,
+        "efficiency": pytest.approx(4 / 7),
+        "leads": {"mem_allergy": 4},
+        "misses": 0,
+    },
+}
+
+
+@pytest.mark.parametrize("trace_id", FIXTURE_IDS)
+def test_native_replay_scores(trace_id):
+    trace = _traces_by_id()[trace_id]
+    scored = run_trace(trace, NativeAdapter)
+    exp = NATIVE_EXPECTED[trace_id]
+    assert scored["precision_at_budget"] == exp["precision"]
+    assert scored["recall_at_budget"] == exp["recall"]
+    assert scored["budget_efficiency"] == exp["efficiency"]
+    assert scored["anticipation_lead_times"] == exp["leads"]
+    assert scored["anticipation_misses"] == exp["misses"]
+    # Native anticipates every target: mean lead is strictly positive.
+    assert scored["mean_anticipation_lead"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Discriminant: the query-driven baseline scores ~0 by construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("trace_id", FIXTURE_IDS)
+def test_query_stub_is_blind_to_uncued_memories(trace_id):
+    """The whole point: a query-driven retriever fails these traces.
+
+    Because the cue-blindness lint guarantees the recall-turn message shares no
+    token with the target memory, the stub never injects the target at the turn
+    it matters — recall 0.0, every anticipation a miss.
+    """
+    trace = _traces_by_id()[trace_id]
+    stub = run_trace(trace, QueryOnlyStubAdapter)
+    native = run_trace(trace, NativeAdapter)
+
+    assert stub["recall_at_budget"] == 0.0
+    assert stub["anticipation_misses"] == stub["n_recall_targets"]
+    assert stub["mean_anticipation_lead"] is None
+    # The discriminating gap: native recalls, the query retriever does not.
+    assert native["recall_at_budget"] == 1.0
+    assert native["recall_at_budget"] > stub["recall_at_budget"]
+
+
+# ---------------------------------------------------------------------------
+# Metric-function unit tests (pure, no Redis)
+# ---------------------------------------------------------------------------
+
+
+def test_precision_recall_none_at_non_evaluation_turn():
+    r = TurnResult(
+        index=0,
+        should_recall=frozenset(),
+        injected_ids=("a", "b"),
+        injected_tokens={"a": 3, "b": 3},
+    )
+    assert turn_precision(r) is None
+    assert turn_recall(r) is None
+    assert turn_budget_efficiency(r) is None
+
+
+def test_precision_none_when_nothing_injected_but_recall_zero():
+    r = TurnResult(
+        index=0, should_recall=frozenset({"a"}), injected_ids=(), injected_tokens={}
+    )
+    assert turn_precision(r) is None  # nothing to judge precision on
+    assert turn_recall(r) == 0.0  # failed to recall
+    assert turn_budget_efficiency(r) is None
+
+
+def test_partial_precision_and_efficiency():
+    r = TurnResult(
+        index=0,
+        should_recall=frozenset({"a"}),
+        injected_ids=("a", "b"),
+        injected_tokens={"a": 4, "b": 12},
+    )
+    assert turn_precision(r) == 0.5
+    assert turn_recall(r) == 1.0
+    assert turn_budget_efficiency(r) == pytest.approx(4 / 16)
+
+
+def test_anticipation_miss_when_never_injected_at_relevant_turn():
+    results = [
+        TurnResult(0, frozenset(), ("m",), {"m": 3}),
+        TurnResult(1, frozenset(), (), {}),  # dropped before it mattered
+        TurnResult(2, frozenset({"m"}), (), {}),  # relevant, not injected -> miss
+    ]
+    leads = anticipation_lead_times(results)
+    assert leads == {"m": None}
+    scored = score_trace(results)
+    assert scored["anticipation_misses"] == 1
+    assert scored["mean_anticipation_lead"] is None
+
+
+def test_anticipation_counts_consecutive_lead_only():
+    # Injected at turns 0,1 (gap at 2), then 3,4; relevant at 4 -> lead counts
+    # back through 3 only (turn 2 breaks the run).
+    results = [
+        TurnResult(0, frozenset(), ("m",), {"m": 3}),
+        TurnResult(1, frozenset(), ("m",), {"m": 3}),
+        TurnResult(2, frozenset(), (), {}),
+        TurnResult(3, frozenset(), ("m",), {"m": 3}),
+        TurnResult(4, frozenset({"m"}), ("m",), {"m": 3}),
+    ]
+    assert anticipation_lead_times(results) == {"m": 1}
+
+
+def test_token_counter_deterministic_floor():
+    assert siq_token_count("") == 0
+    assert siq_token_count("x") == 1  # floor of 1 for non-empty
+    assert siq_token_count("a" * 40) == 10
+
+
+# ---------------------------------------------------------------------------
+# Mode invariant + determinism
+# ---------------------------------------------------------------------------
+
+
+def test_native_adapter_is_composite_mode():
+    trace = _traces_by_id()["coreference_relocation"]
+    adapter = NativeAdapter(trace)
+    try:
+        assert adapter._assembler._effective_mode == "composite"
+        assert NATIVE_SCORE_WEIGHTS == {"importance": 1.0}
+    finally:
+        adapter.teardown()
+
+
+def test_native_replay_is_deterministic():
+    trace = _traces_by_id()["multi_recall_preferences"]
+    first = run_trace(trace, NativeAdapter)
+    second = run_trace(trace, NativeAdapter)
+    # trace_id/adapter are identical; the metric block must match bit-for-bit.
+    for key in (
+        "precision_at_budget",
+        "recall_at_budget",
+        "budget_efficiency",
+        "anticipation_lead_times",
+        "mean_anticipation_lead",
+        "anticipation_misses",
+    ):
+        assert first[key] == second[key]
+
+
+def test_replay_lifecycle_plants_and_tears_down():
+    """A full replay leaves no residue for its own model class."""
+    from src.popoto.redis_db import POPOTO_REDIS_DB
+
+    trace = _traces_by_id()["need_to_know_allergy"]
+    adapter = NativeAdapter(trace)
+    class_name = adapter._model_class.__name__
+
+    def _scan_all():
+        found, cursor = [], 0
+        while True:
+            cursor, k = POPOTO_REDIS_DB.scan(cursor, match=f"*{class_name}*", count=200)
+            found.extend(k)
+            if cursor == 0:
+                break
+        return found
+
+    replay(trace, adapter)
+    assert _scan_all(), "expected planted keys before teardown"
+    adapter.teardown()
+    assert _scan_all() == []
+
+
+# ---------------------------------------------------------------------------
+# Judge pin (SIQ's optional usefulness cross-check reuses the Tier-5 judge)
+# ---------------------------------------------------------------------------
+
+
+def test_optional_judge_identity_is_pinned():
+    from tests.benchmarks import judge
+
+    assert judge.JUDGE_MODEL == "gpt-4o-mini"
+    assert judge.JUDGE_TEMPERATURE == 0
+    # is_judge_available gates any live call so the default suite never needs a
+    # key or the openai package.
+    assert callable(judge.is_judge_available)


### PR DESCRIPTION
## What

Adds **SIQ (Subconscious Injection Quality)** — the flagship *native* benchmark from the benchmarking strategy (`docs/plans/benchmarking_strategy_2026-07.md` §2.1). It measures the one thing composite/query-blind retrieval does that no public benchmark scores: *without an explicit query cueing it, did the right memory get injected into context at the right turn?*

Plan: `docs/plans/siq_benchmark.md`. Closes #459.

## What it measures

Multi-turn agent traces where a later turn needs a memory established earlier, but the turn's own message never lexically restates it (coreference / implication / need-to-know). Retrieval runs through `ContextAssembler` in `composite` mode (query-blind). Metrics:

- **Injection Precision/Recall @ budget** — of memories injected under `max_items`/`max_tokens`, how many are ground-truth useful (evaluated at `should_recall` turns).
- **Anticipation lead time** — consecutive turns of proactive presence before a memory becomes explicitly relevant (a query retriever scores 0 by construction).
- **Budget efficiency** — useful-tokens / injected-tokens.

## Deterministic + competitor-fair

- **4 committed fixtures** (`coreference_relocation`, `implication_deadline`, `need_to_know_allergy`, `multi_recall_preferences`) — no runtime RNG, no wall-clock in ranking, bit-identical scores every run.
- **Cue-blindness lint** — `lint_trace` uses the real BM25 tokenizer to *prove* the recall-turn message shares no indexed token with the target memory (un-gameable ground truth).
- **`SiqAdapter` Protocol** — `NativeAdapter` (Popoto composite) + dependency-free `QueryOnlyStubAdapter` (query-driven baseline scoring ~0 recall / all-miss **by construction** — the harness's own validity proof). Real Mem0/Zep/Hindsight adapters are a tracked follow-up; **no competitor numbers fabricated**.

Baseline over the 4 fixtures: `native` recall **1.000** / 0-of-5 misses / mean lead **4.0** turns vs `query_stub` recall **0.000** / 5-of-5 misses / n/a.

## DB hygiene

CI-facing `tests/benchmarks/test_siq.py` runs under the pytest **db15** isolation plugin (never db0). The optional `run_siq.py` CLI reuses `run_external`'s bench-DB machinery (default 14, **db0 rejected**), pointed at only at `main()` time — point it away from any in-flight external run on db14 (`POPOTO_BENCH_DB=13`). Valkey-safe throughout (core Redis commands only).

## Tests

`pytest tests/benchmarks/test_siq.py` — 23 tests (lint rules, exact native scores, discriminant baseline, metric edge cases, composite-mode invariant, determinism, teardown residue, pinned-judge identity). `mkdocs build --strict` passes.

## Docs

`docs/benchmarks.md` gains a "Subconscious Injection Quality (SIQ) Harness" section (publishable); `tests/benchmarks/README.md` updated.