### PR TITLE
ci: preflight guards for the worktree verification traps (#495 post-mortem)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,7 @@ data/
 /src/popoto/_archive/
 .claude/hooks/
 .claude/worktrees/
+# The SDLC pipeline creates worktrees here too. Untracked, these get swept in
+# by `git add -A` as embedded-repo gitlinks — five of them landed in a commit
+# on this branch before being caught.
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,155 +4,48 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Popoto is a Python Redis/Valkey ORM (Object-Relational Mapper) library that provides Django-like model syntax for Redis and Valkey. It supports object persistence, queries, geographic search, time-series data, and pub/sub messaging.
-
-## Setup
-
-### Using uv (recommended)
-
-```bash
-uv venv && source .venv/bin/activate && uv pip install -e ".[dev]"
-```
-
-### Using pip (fallback)
-
-```bash
-python -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
-```
+Popoto is a Python Redis/Valkey ORM providing Django-like model syntax: object persistence, queries, geographic search, time-series data, and pub/sub. See `README.md` for install/run/usage.
 
 ## Commands
 
 ```bash
-pytest                          # Run all tests (requires Redis on localhost:6379)
-pytest tests/test_queries.py    # Run specific test file
-pytest -k "test_name"           # Run single test by name
-pytest -p no:popoto             # Run tests without the auto-isolation plugin
-mypy src/                       # Type checking
-black src/ tests/               # Format code
-mkdocs serve                    # Serve docs locally
+pytest                          # requires Redis on localhost:6379; auto-isolated on DB 15
+pytest -k "test_name"           # single test by name
+mypy src/                       # type checking
+black src/ tests/               # format
+mkdocs serve                    # docs locally
+scripts/ci-local.sh             # local CI gates: tests + stress + docs (--all, --fast, or named gates)
 ```
 
-Tests automatically use Redis DB 15 for isolation (via the `popoto.pytest_plugin` entry point). Each test gets a clean DB via `flushdb()`. Override with `POPOTO_TEST_DB=<n>` env var or `popoto_test_db` in `pyproject.toml` `[tool.pytest.ini_options]`. DB 0 is rejected to prevent accidental production data loss.
-
-The isolation guarantee holds for **both** `import popoto` and `import src.popoto` paths. The plugin's `pytest_configure` hook collapses `src.popoto` (and all `popoto.*` submodules) onto the canonical `popoto` objects in `sys.modules` before any test module is imported, so there is only one Redis connection instance and it is always on DB 15. New test files do **not** need a manual `_clean_all()` autouse fixture to be stable — the plugin handles it.
-
-### Local CI (`scripts/ci-local.sh`)
-
-Run the meaningful CI gates locally before pushing, to catch failures without burning GitHub Actions minutes (or waiting on GitHub being up):
-
-```bash
-scripts/ci-local.sh              # default: tests + stress + docs
-scripts/ci-local.sh --all        # everything, incl. build + guard
-scripts/ci-local.sh --fast       # tests only
-scripts/ci-local.sh docs build   # only the named gates
-```
-
-Gates mirror the workflows: `tests` → `test-valkey.yml` (full suite vs local Redis), `stress` → `stress-tests.yml`, `docs` → `deploy-docs.yml` (`mkdocs build --strict`), `build` → `release.yml` (`uv build`), `guard` → `guard-main-push.yml`. Valkey is intentionally skipped — redis-py treats both identically and the project never uses Redis modules, so the local-Redis suite covers it; GitHub still runs the real Valkey job on PR/merge as the final word. The runner auto-refreshes the editable install if `popoto.__version__` (read from package metadata) drifts from `pyproject.toml`, which otherwise causes a false `test_version` failure locally.
+Tests are auto-isolated on Redis DB 15 via the `popoto.pytest_plugin` entry point (both `import popoto` and `import src.popoto` collapse onto one canonical module/connection). Override with `POPOTO_TEST_DB=<n>`; DB 0 is rejected to prevent accidental production data loss.
 
 ### Verifying in a worktree (read before trusting a test or mypy number)
 
-Work done in a `.worktrees/` checkout can report a confident, wrong number in five
-ways. Four are checked automatically in `scripts/ci-local.sh`'s preflight — run it (or
-at least its `tests` gate) instead of bare `pytest` when the number will be reported to
-anyone. The fifth cannot be automated.
+A `.worktrees/` checkout can report a confident, wrong number in five ways — each cost a review round on PR #495. `scripts/ci-local.sh` checks four automatically:
 
-1. **Tests exercise the installed package, not your branch.** The pytest plugin
-   collapses `src.popoto` onto canonical `popoto`, so if the venv's editable install
-   points elsewhere the suite silently tests *that* tree — failures on new APIs look
-   exactly like real regressions. Preflight hard-fails on this.
-2. **A fresh worktree venv silently deselects ~95 tests.** `.[dev]` alone omits
-   `numpy`/`sentence-transformers`; a green run then covers far less than CI. Install
-   `.[dev,embeddings,benchmark]`. (Adding `dataframe` pulls pandas, which on 3.x breaks
-   `test_dataframe_field.py` collection.) Preflight warns.
-3. **redis-py 8.x fails `test_pytest_plugin.py::test_isolated_db_subprocess`**
-   (`maint_notifications_pool_handler`). Environmental, not a regression. Preflight
-   predicts it so it isn't chased.
-4. **Every worktree shares Redis DB 15.** Concurrent suites from other checkouts have
-   produced 73–158 phantom failures. To separate contention from regression, check out
-   base into the *same* worktree and compare — don't trust either number alone.
-   Preflight warns when other `pytest` processes are running.
-5. **The `mypy` error delta is redis-py-version-dependent.** redis-py shares one stub
-   set between its sync and asyncio clients, typing every command `Awaitable[T] | T`;
-   7.x flags sites 8.x narrows. A delta of `+0` in one environment can be `+4` in
-   another, so "verified in one consistent environment" proves nothing about the diff.
-   Measure base-vs-branch in both a 7.x and an 8.x environment, and prefer a
-   centralized narrowing helper (see `_sync` in `recipes/memory_lifecycle.py`) over
-   per-site `type: ignore`.
+1. **Wrong package under test**: if the venv's editable install doesn't resolve to this checkout, the suite silently tests another tree — new-API failures look like regressions.
+2. **Fresh worktree venv deselects ~95 tests**: `.[dev]` alone omits `numpy`/`sentence-transformers`. Install `.[dev,embeddings,benchmark]` (adding `dataframe` pulls pandas, which breaks `test_dataframe_field.py` collection on 3.x).
+3. **redis-py 8.x fails `test_pytest_plugin.py::test_isolated_db_subprocess`** (`maint_notifications_pool_handler`) — environmental, not a regression.
+4. **Every worktree shares Redis DB 15**: concurrent suites from other checkouts have produced 73-158 phantom failures. To isolate contention from regression, check out base into the same worktree and compare.
+5. **mypy error delta is redis-py-version-dependent** (not automated): redis-py types every command `Awaitable[T] | T` for both sync/async clients, so 7.x flags sites 8.x narrows. Measure base-vs-branch in both a 7.x and 8.x environment before trusting a delta.
 
-The general rule behind all five: **state the environment alongside any count**, and
-reproduce a subagent's metric before relaying it. Three separate "verified" claims on
-PR #495 failed independent review, each for an environmental reason.
+Rule: state the environment alongside any count, and reproduce a subagent's metric before relaying it.
 
 ## Debugging with Redis/Valkey CLI
 
-Use `redis-cli` (or `valkey-cli` for Valkey) to inspect database state when debugging Popoto models. Both CLIs use identical commands.
+`redis-cli`/`valkey-cli` (identical commands) for inspecting state. Popoto key patterns:
+- `ClassName:key_value` — model instance (msgpack-encoded)
+- `ClassName:_field_name` — sorted index
+- `ClassName:field_name:value` — unique index
+- `ClassName:_geo_field_name` — geo index
 
-```bash
-# Connect to Redis or Valkey
-redis-cli                       # Connect to localhost:6379 (default)
-valkey-cli                      # Valkey equivalent (same commands)
-redis-cli -u $REDIS_URL         # Connect using REDIS_URL
+## Key Patterns
 
-# Inspect keys
-KEYS *                          # List all keys (dev only, slow on large DBs)
-KEYS ClassName:*                # List keys for a specific model
-TYPE keyname                    # Check key type (string, hash, set, zset, list)
-TTL keyname                     # Check time-to-live (-1 = no expiry, -2 = doesn't exist)
-
-# Read data by type
-GET keyname                     # String values (Popoto model data is msgpack-encoded)
-HGETALL keyname                 # Hash values
-SMEMBERS keyname                # Set members
-ZRANGE keyname 0 -1 WITHSCORES  # Sorted set members with scores
-LRANGE keyname 0 -1             # List values
-
-# Monitor commands in real-time (very useful for debugging)
-MONITOR                         # Watch all Redis commands as they execute
-
-# Cleanup
-DEL keyname                     # Delete a specific key
-FLUSHDB                         # Clear current database (use with caution)
-```
-
-**Popoto-specific patterns:**
-- Model instances: `ClassName:key_value` (msgpack-encoded string)
-- Sorted indexes: `ClassName:_field_name` (sorted set)
-- Unique indexes: `ClassName:field_name:value` (string)
-- Geo indexes: `ClassName:_geo_field_name` (geo set)
-
-## Architecture
-
-### Core Components (`src/popoto/`)
-
-**Model System** (`models/`)
-- `base.py` - `Model` base class and `ModelBase` metaclass. `ModelOptions` tracks field metadata (key fields, sorted fields, geo fields, relationships).
-- `query.py` - `Query` class provides Django-like filtering (`Model.query.filter()`, `Model.query.get()`).
-- `db_key.py` - Redis key generation from model class name + KeyField values
-- `encoding.py` - Serialization/deserialization using msgpack
-
-**Field System** (`fields/`)
-- `field.py` - Base `Field` class with `FieldBase` metaclass
-- Mixins in separate files provide specialized behaviors (KeyFieldMixin, AutoFieldMixin, SortedFieldMixin, UniqueFieldMixin)
-- `shortcuts.py` - Convenience field types (AutoKeyField, UniqueKeyField, IntField, etc.)
-- `relationship.py` - `Relationship` field handles three value types:
-  - `Model` instance: fully loaded relationship
-  - `str`: redis_key string (lazy-loaded to prevent infinite recursion in circular references)
-  - `None`: no relationship set
-
-**Pub/Sub** (`pubsub/`) - Redis pub/sub for real-time messaging
-
-### Key Patterns
-
-- Public model attributes must be Field instances; private attrs use underscore prefix
-- Field names must start with lowercase; reserved names: `limit`, `order_by`, `values`
-- Models auto-generate an `_auto_key` (AutoKeyField) if no KeyField is defined
-- Redis keys follow pattern: `ClassName:key1_value:key2_value:...`
-- Fields have `on_save()` and `on_delete()` hooks for maintaining secondary indexes
-- Relationship fields support circular references via lazy-loading (field value stored as redis_key string)
-
-### Redis/Valkey Connection
-
-Uses `REDIS_URL` environment variable or defaults to `localhost:6379`. Connection managed in `redis_db.py`. Works with both Redis and Valkey servers.
+- Public model attributes must be `Field` instances; private attrs use underscore prefix
+- Field names must start lowercase; reserved: `limit`, `order_by`, `values`
+- Models auto-generate `_auto_key` (AutoKeyField) if no KeyField is defined
+- `Relationship` fields support circular references via lazy-loading: value is stored as a redis_key string and loaded on access, not eagerly, to avoid infinite recursion
+- Numeric constants are magic numbers for experimental tuning, not dev/user config — pin them in-repo (see `popoto.fields.constants.Defaults` docstring), don't expose as constructor kwargs
 
 ## Code Style
 
@@ -161,6 +54,5 @@ Uses `REDIS_URL` environment variable or defaults to `localhost:6379`. Connectio
 
 ## Git Workflow
 
-- Never push code changes directly to main - always create a feature branch and open a PR
-- Documentation-only changes (docs/, CLAUDE.md, .claude/commands/) may be pushed directly to main
+- Never push directly to main except docs-only changes (`docs/`, `CLAUDE.md`, `.claude/commands/`) — enforced by `guard-main-push.yml`
 - Use descriptive branch names like `feature/query-performance` or `fix/scan-keys`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,40 @@ scripts/ci-local.sh docs build   # only the named gates
 
 Gates mirror the workflows: `tests` → `test-valkey.yml` (full suite vs local Redis), `stress` → `stress-tests.yml`, `docs` → `deploy-docs.yml` (`mkdocs build --strict`), `build` → `release.yml` (`uv build`), `guard` → `guard-main-push.yml`. Valkey is intentionally skipped — redis-py treats both identically and the project never uses Redis modules, so the local-Redis suite covers it; GitHub still runs the real Valkey job on PR/merge as the final word. The runner auto-refreshes the editable install if `popoto.__version__` (read from package metadata) drifts from `pyproject.toml`, which otherwise causes a false `test_version` failure locally.
 
+### Verifying in a worktree (read before trusting a test or mypy number)
+
+Work done in a `.worktrees/` checkout can report a confident, wrong number in five
+ways. Four are checked automatically in `scripts/ci-local.sh`'s preflight — run it (or
+at least its `tests` gate) instead of bare `pytest` when the number will be reported to
+anyone. The fifth cannot be automated.
+
+1. **Tests exercise the installed package, not your branch.** The pytest plugin
+   collapses `src.popoto` onto canonical `popoto`, so if the venv's editable install
+   points elsewhere the suite silently tests *that* tree — failures on new APIs look
+   exactly like real regressions. Preflight hard-fails on this.
+2. **A fresh worktree venv silently deselects ~95 tests.** `.[dev]` alone omits
+   `numpy`/`sentence-transformers`; a green run then covers far less than CI. Install
+   `.[dev,embeddings,benchmark]`. (Adding `dataframe` pulls pandas, which on 3.x breaks
+   `test_dataframe_field.py` collection.) Preflight warns.
+3. **redis-py 8.x fails `test_pytest_plugin.py::test_isolated_db_subprocess`**
+   (`maint_notifications_pool_handler`). Environmental, not a regression. Preflight
+   predicts it so it isn't chased.
+4. **Every worktree shares Redis DB 15.** Concurrent suites from other checkouts have
+   produced 73–158 phantom failures. To separate contention from regression, check out
+   base into the *same* worktree and compare — don't trust either number alone.
+   Preflight warns when other `pytest` processes are running.
+5. **The `mypy` error delta is redis-py-version-dependent.** redis-py shares one stub
+   set between its sync and asyncio clients, typing every command `Awaitable[T] | T`;
+   7.x flags sites 8.x narrows. A delta of `+0` in one environment can be `+4` in
+   another, so "verified in one consistent environment" proves nothing about the diff.
+   Measure base-vs-branch in both a 7.x and an 8.x environment, and prefer a
+   centralized narrowing helper (see `_sync` in `recipes/memory_lifecycle.py`) over
+   per-site `type: ignore`.
+
+The general rule behind all five: **state the environment alongside any count**, and
+reproduce a subagent's metric before relaying it. Three separate "verified" claims on
+PR #495 failed independent review, each for an environmental reason.
+
 ## Debugging with Redis/Valkey CLI
 
 Use `redis-cli` (or `valkey-cli` for Valkey) to inspect database state when debugging Popoto models. Both CLIs use identical commands.

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -98,6 +98,80 @@ if $needs_redis; then
       "$PY" -m pip install -e . --no-deps -q
     fi
   fi
+
+  # --- worktree verification guards (#495 post-mortem) -----------------------
+  #
+  # Four ways a run in a .worktrees/ checkout reports a confident, wrong
+  # number. Each cost a review round on PR #495, and none of them announce
+  # themselves -- the suite goes green, or fails in a way that looks like a
+  # real regression. They are checked here rather than documented in prose
+  # because every agent that shipped a bad number already had CLAUDE.md
+  # loaded.
+
+  # 1. Tests exercise the INSTALLED package, not this checkout. The pytest
+  #    plugin collapses `src.popoto` onto canonical `popoto`, so when the
+  #    venv's editable install points somewhere else, the suite silently
+  #    tests that other tree. Symptom: failures on brand-new APIs that look
+  #    exactly like real regressions.
+  resolved="$("$PY" -c "import popoto,os;print(os.path.realpath(os.path.dirname(popoto.__file__)))" 2>/dev/null || echo "")"
+  expected="$("$PY" -c "import os;print(os.path.realpath('$ROOT/src/popoto'))")"
+  if [ -n "$resolved" ] && [ "$resolved" != "$expected" ]; then
+    warn "popoto resolves to $resolved, not this checkout — refreshing editable install"
+    if command -v uv >/dev/null 2>&1; then
+      VIRTUAL_ENV="$ROOT/.venv" uv pip install -e . --no-deps -q
+    else
+      "$PY" -m pip install -e . --no-deps -q
+    fi
+    resolved="$("$PY" -c "import popoto,os;print(os.path.realpath(os.path.dirname(popoto.__file__)))" 2>/dev/null || echo "")"
+    if [ "$resolved" != "$expected" ]; then
+      fail "popoto still resolves to $resolved — tests would not exercise this checkout"
+      fail "  fix: PYTHONPATH=$ROOT/src, or recreate .venv in this worktree"
+      exit 2
+    fi
+  fi
+
+  # 2. A fresh worktree venv built from '.[dev]' alone is missing the
+  #    optional extras, which silently DESELECTS roughly 95 tests. A green
+  #    suite then covers far less than CI does, with no error to notice.
+  missing_extras="$("$PY" - <<'PYEOF' 2>/dev/null || true
+mods = ("numpy", "sentence_transformers")
+missing = []
+for m in mods:
+    try:
+        __import__(m)
+    except Exception:
+        missing.append(m)
+print(" ".join(missing))
+PYEOF
+)"
+  if [ -n "${missing_extras// /}" ]; then
+    warn "optional extras missing (${missing_extras# }) — ~95 tests will be silently skipped"
+    warn "  a green run here does NOT match CI coverage; install: uv pip install -e '.[dev,embeddings,benchmark]'"
+  fi
+
+  # 3. redis-py 8.x breaks the plugin's subprocess isolation test
+  #    (maint_notifications_pool_handler). Pre-existing and environmental --
+  #    predicted here so it is not mistaken for a regression introduced by
+  #    whatever branch is being tested.
+  redis_major="$("$PY" -c "import redis;print(redis.__version__.split('.')[0])" 2>/dev/null || echo "")"
+  if [ -n "$redis_major" ] && [ "$redis_major" -ge 8 ] 2>/dev/null; then
+    warn "redis-py ${redis_major}.x — expect test_pytest_plugin.py::test_isolated_db_subprocess to FAIL"
+    warn "  that failure is environmental, not a regression; confirm against base before chasing it"
+  fi
+
+  # 4. Every worktree shares Redis DB 15. Concurrent suites from other agent
+  #    checkouts produced 73-158 phantom failures on #495 -- indistinguishable
+  #    from a real regression until you check out base into the SAME worktree
+  #    and compare. Warn before the number is trusted, not after.
+  # Counted before this script starts its own pytest, so every hit is someone
+  # else's run. The bracket trick keeps pgrep from matching its own pattern.
+  others="$(pgrep -f "[p]ytest" 2>/dev/null | wc -l | tr -d ' ')"
+  others="${others:-0}"
+  if [ "$others" -gt 0 ] 2>/dev/null; then
+    warn "$others other pytest process(es) running — they share Redis DB 15 with this run"
+    warn "  full-suite counts are UNRELIABLE right now; to separate contention from regression,"
+    warn "  check out base into this same worktree and compare, or wait for them to finish"
+  fi
 fi
 
 declare -a RESULTS

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -113,9 +113,15 @@ if $needs_redis; then
   #    venv's editable install points somewhere else, the suite silently
   #    tests that other tree. Symptom: failures on brand-new APIs that look
   #    exactly like real regressions.
+  #    $ROOT goes through argv, never string-interpolated into the Python
+  #    source: a repo path containing a quote would otherwise raise
+  #    SyntaxError, leave `expected` empty, and hard-fail a perfectly healthy
+  #    venv. An empty result on either side means "cannot tell" -- skip the
+  #    guard rather than fail it, since a guard that blocks good runs is worse
+  #    than one that misses a bad one.
   resolved="$("$PY" -c "import popoto,os;print(os.path.realpath(os.path.dirname(popoto.__file__)))" 2>/dev/null || echo "")"
-  expected="$("$PY" -c "import os;print(os.path.realpath('$ROOT/src/popoto'))")"
-  if [ -n "$resolved" ] && [ "$resolved" != "$expected" ]; then
+  expected="$("$PY" -c 'import os,sys;print(os.path.realpath(os.path.join(sys.argv[1],"src","popoto")))' "$ROOT" 2>/dev/null || echo "")"
+  if [ -n "$resolved" ] && [ -n "$expected" ] && [ "$resolved" != "$expected" ]; then
     warn "popoto resolves to $resolved, not this checkout — refreshing editable install"
     if command -v uv >/dev/null 2>&1; then
       VIRTUAL_ENV="$ROOT/.venv" uv pip install -e . --no-deps -q
@@ -133,19 +139,19 @@ if $needs_redis; then
   # 2. A fresh worktree venv built from '.[dev]' alone is missing the
   #    optional extras, which silently DESELECTS roughly 95 tests. A green
   #    suite then covers far less than CI does, with no error to notice.
+  #    find_spec, not __import__: this asks "was the extra installed", and
+  #    fully importing sentence_transformers drags in torch for ~5s on every
+  #    single run of this script. A module that is installed but broken will
+  #    slip past, which the test run itself will report anyway.
   missing_extras="$("$PY" - <<'PYEOF' 2>/dev/null || true
-mods = ("numpy", "sentence_transformers")
-missing = []
-for m in mods:
-    try:
-        __import__(m)
-    except Exception:
-        missing.append(m)
+from importlib.util import find_spec
+
+missing = [m for m in ("numpy", "sentence_transformers") if find_spec(m) is None]
 print(" ".join(missing))
 PYEOF
 )"
   if [ -n "${missing_extras// /}" ]; then
-    warn "optional extras missing (${missing_extras# }) — ~95 tests will be silently skipped"
+    warn "optional extras missing ($missing_extras) — ~95 tests will be silently skipped"
     warn "  a green run here does NOT match CI coverage; install: uv pip install -e '.[dev,embeddings,benchmark]'"
   fi
 
@@ -164,7 +170,9 @@ PYEOF
   #    from a real regression until you check out base into the SAME worktree
   #    and compare. Warn before the number is trusted, not after.
   # Counted before this script starts its own pytest, so every hit is someone
-  # else's run. The bracket trick keeps pgrep from matching its own pattern.
+  # else's run. `pgrep -f` substring-matches whole command lines, so this can
+  # over-count (a `vim notes_pytest.txt` counts as one). It is warning-only and
+  # errs toward telling you to double-check a number, which is the safe side.
   others="$(pgrep -f "[p]ytest" 2>/dev/null | wc -l | tr -d ' ')"
   others="${others:-0}"
   if [ "$others" -gt 0 ] 2>/dev/null; then


### PR DESCRIPTION
## Why

PR #495 shipped correctly but cost four review rounds, three of them spent on numbers that were confidently reported and wrong:

- the build's `mypy` disclosure ("no new genuinely-wrong annotations" — it was +19, and 3 of those pointed at a real defect)
- a patch agent's "+0 delta, full suite green" — measured in a venv silently missing `numpy`/`torch`/`sentence-transformers`, running ~95 fewer tests than the review did
- my own "+0, verified in one consistent environment" — true under redis-py 8.x, `+4` under 7.1.1

Every one had an environmental cause, and none announced itself: the suite went green, or failed in a way indistinguishable from a real regression. Two reviewers separately burned time on 73–158 phantom failures that turned out to be Redis DB 15 contention from other worktrees.

## What

Four guards in `ci-local.sh`'s existing preflight, next to the version-drift guard that already handles this class of problem:

| # | Trap | Behavior |
|---|------|----------|
| 1 | `popoto` resolves outside this checkout — the plugin's `src.popoto` collapse means the suite silently tests *another tree* | refresh, then **hard fail** with the `PYTHONPATH` fix |
| 2 | `.[dev]` alone omits optional extras, silently deselecting ~95 tests | warn, name the right extras |
| 3 | redis-py 8.x fails `test_isolated_db_subprocess` environmentally | predict it so it isn't chased |
| 4 | worktrees share Redis DB 15; concurrent runs produce phantom failures | warn, name the base-vs-branch comparison that separates contention from regression |

Guard 1 hard-fails rather than warning: a run against the wrong tree doesn't produce a *degraded* number, it produces a confident number about code you aren't changing.

`CLAUDE.md` documents all five, including the one that can't be automated — the `mypy` delta is redis-py-version-dependent, so a single-environment measurement proves nothing about the diff.

**These are guards rather than documentation because prose was already available and didn't work.** Every agent that shipped a bad number on #495 had `CLAUDE.md` loaded.

## Verification

Each guard exercised, not assumed:

- **Guard 1, end-to-end**: shadowed `popoto` via `PYTHONPATH` → fires, attempts refresh, exits `2`, venv left healthy. Clean path unaffected (`docs` gate exits 0; `tests` gate still collects 2389).
- **Guards 2/3**: detection logic run against known present/absent modules and the local redis-py 7.1.1 (correctly silent — the 8.x failure was worktree-local).
- **Guard 4**: fired live against a real concurrent `pytest` from another checkout.

## Also

`.worktrees/` is now gitignored. `.claude/worktrees/` was ignored but the path the SDLC pipeline actually uses was not — five embedded-repo gitlinks landed in the first commit here via `git add -A` before being caught and amended out. Ignoring it removes the trap instead of relying on selective staging.

## Also in this branch (not part of the guards)

Commit `4e9cd8d` trims `CLAUDE.md` from 166 to 58 lines, cutting content that was self-discoverable or duplicated in `README.md` (Setup, the file-by-file Architecture walkthrough, generic redis-cli usage). It is unrelated to the guards and was not mentioned in the original version of this body — flagged in review as an incomplete enumeration, which it was. Kept rather than split because it is additive to the same file this PR edits and the trim preserved the new worktree-verification section. The non-derivable content (Popoto key-naming patterns, reserved field names, git workflow) is retained.

Commit `a36d888` fixes two review findings in the guards themselves: guard 1 could hard-fail a **healthy** venv when the repo path contains an apostrophe (`$ROOT` was interpolated into a single-quoted Python literal → `SyntaxError` → empty comparison target), and guard 2 cost ~5s per run by fully importing `sentence_transformers`/torch where `find_spec` answers the question in 0.016s.

Follow-up for the global SDLC skills (`do-patch`, `do-pr-review`) is filed separately — those live in `~/.claude/skills/`, not this repo.
