### PR TITLE
fix(#490): redis-py-8 plugin compat + benchmark DB-0/14 key isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ A `.worktrees/` checkout can report a confident, wrong number in five ways — e
 
 1. **Wrong package under test**: if the venv's editable install doesn't resolve to this checkout, the suite silently tests another tree — new-API failures look like regressions.
 2. **Fresh worktree venv deselects ~95 tests**: `.[dev]` alone omits `numpy`/`sentence-transformers`. Install `.[dev,embeddings,benchmark]` (adding `dataframe` pulls pandas, which breaks `test_dataframe_field.py` collection on 3.x).
-3. **redis-py 8.x fails `test_pytest_plugin.py::test_isolated_db_subprocess`** (`maint_notifications_pool_handler`) — environmental, not a regression.
+3. ~~**redis-py 8.x fails `test_pytest_plugin.py::test_isolated_db_subprocess`**~~ — fixed in #490 (PR #500). Root cause was not environmental: redis-py 8 injects pool-internal bookkeeping keys (`himport_registry`, `maint_notifications_*`, `orig_*`) into `connection_kwargs`, which `Redis.__init__` rejects when splatted. `redis_db.sibling_client_kwargs()` now whitelists only standard connection params for DB-0-probe sites.
 4. **Every worktree shares Redis DB 15**: concurrent suites from other checkouts have produced 73-158 phantom failures. To isolate contention from regression, check out base into the same worktree and compare.
 5. **mypy error delta is redis-py-version-dependent** (not automated): redis-py types every command `Awaitable[T] | T` for both sync/async clients, so 7.x flags sites 8.x narrows. Measure base-vs-branch in both a 7.x and 8.x environment before trusting a delta.
 

--- a/src/popoto/pytest_plugin.py
+++ b/src/popoto/pytest_plugin.py
@@ -238,8 +238,13 @@ def _popoto_db0_tripwire(request):
     db0_client = None
     before = None
     try:
-        pool_kwargs = redis_db.POPOTO_REDIS_DB.connection_pool.connection_kwargs.copy()
-        pool_kwargs["db"] = 0
+        # Whitelist the connection params: a pool's connection_kwargs carries
+        # redis-py 8 pool-internal keys (himport_registry, maint_notifications_*)
+        # that redis.Redis(**kwargs) rejects, which would silently disable the
+        # tripwire (this branch is except-guarded) on redis-py 8.
+        pool_kwargs = redis_db.sibling_client_kwargs(
+            redis_db.POPOTO_REDIS_DB.connection_pool.connection_kwargs, db=0
+        )
         db0_client = _redis.Redis(**pool_kwargs)
         before = db0_client.dbsize()
     except Exception:

--- a/src/popoto/redis_db.py
+++ b/src/popoto/redis_db.py
@@ -105,9 +105,7 @@ _async_redis_lock = asyncio.Lock()
 # Using a BlockingConnectionPool with this cap makes excess coroutines wait for
 # a free connection instead of erroring. Override via POPOTO_ASYNC_MAX_CONNECTIONS.
 try:
-    _ASYNC_MAX_CONNECTIONS = int(
-        os.environ.get("POPOTO_ASYNC_MAX_CONNECTIONS", "128")
-    )
+    _ASYNC_MAX_CONNECTIONS = int(os.environ.get("POPOTO_ASYNC_MAX_CONNECTIONS", "128"))
 except ValueError:
     _ASYNC_MAX_CONNECTIONS = 128
 
@@ -120,9 +118,7 @@ except ValueError:
 # connections"). A BlockingConnectionPool makes excess threads wait for a free
 # connection instead. Override via POPOTO_SYNC_MAX_CONNECTIONS.
 try:
-    _SYNC_MAX_CONNECTIONS = int(
-        os.environ.get("POPOTO_SYNC_MAX_CONNECTIONS", "128")
-    )
+    _SYNC_MAX_CONNECTIONS = int(os.environ.get("POPOTO_SYNC_MAX_CONNECTIONS", "128"))
 except ValueError:
     _SYNC_MAX_CONNECTIONS = 128
 
@@ -197,6 +193,75 @@ def set_REDIS_DB_settings(env_partition_name: str = "", *args, **kwargs) -> None
     # global REDIS_GRAPH
     # REDIS_GRAPH = Graph('social', POPOTO_REDIS_DB)
     logger.debug("Redis connection reset.")
+
+
+# Connection parameters that are safe to copy from a connection pool's
+# ``connection_kwargs`` when constructing a *sibling* ``redis.Redis`` client
+# (e.g. a DB-0 probe that reuses the live host/port/auth but targets a
+# different DB). redis-py 8 injects pool-internal bookkeeping keys —
+# ``himport_registry``, ``maint_notifications_config``,
+# ``maint_notifications_pool_handler``, ``orig_host_address``,
+# ``orig_socket_timeout``, ``orig_socket_connect_timeout`` — into a pool's
+# ``connection_kwargs``. Splatting that full dict into ``redis.Redis(**kwargs)``
+# raises ``TypeError: Redis.__init__() got an unexpected keyword argument
+# 'himport_registry'`` (the exact key surfaced depends on kwarg-check order).
+# Whitelisting the standard connection params sidesteps this on every redis-py
+# version, and stays Valkey-safe (no Redis-module-specific options).
+_SIBLING_CONNECTION_KEYS = (
+    "host",
+    "port",
+    "db",
+    "username",
+    "password",
+    "socket_timeout",
+    "socket_connect_timeout",
+    "ssl",
+    "ssl_keyfile",
+    "ssl_certfile",
+    "ssl_ca_certs",
+    "unix_socket_path",
+)
+
+
+def sibling_client_kwargs(
+    source_kwargs: dict[str, object], **overrides: object
+) -> dict[str, object]:
+    """Whitelist connection kwargs safe to splat into ``redis.Redis(**kw)``.
+
+    A connection pool's ``connection_kwargs`` cannot be passed wholesale to the
+    ``redis.Redis`` constructor on redis-py 8: the pool injects internal keys
+    (``himport_registry``, ``maint_notifications_pool_handler``, ``orig_*`` …)
+    that ``Redis.__init__`` rejects. This returns only the standard connection
+    parameters present in ``source_kwargs`` (dropping ``None`` values), then
+    applies any explicit ``overrides`` (e.g. ``db=0`` to build a DB-0 probe on
+    the same host/port/auth).
+
+    Args:
+        source_kwargs: A pool's ``connection_kwargs`` (or any mapping of
+            connection parameters) to copy the safe subset from.
+        **overrides: Parameters to set/replace on the returned dict, applied
+            after the whitelist (so ``db=0`` wins over any inherited ``db``).
+
+    Returns:
+        A dict containing only whitelisted params plus the overrides, ready to
+        splat into ``redis.Redis(**kwargs)`` on any redis-py version.
+
+    Example::
+
+        from popoto.redis_db import POPOTO_REDIS_DB, sibling_client_kwargs
+
+        kwargs = sibling_client_kwargs(
+            POPOTO_REDIS_DB.connection_pool.connection_kwargs, db=0
+        )
+        db0 = redis.Redis(**kwargs)
+    """
+    out = {
+        key: source_kwargs[key]
+        for key in _SIBLING_CONNECTION_KEYS
+        if source_kwargs.get(key) is not None
+    }
+    out.update(overrides)
+    return out
 
 
 def get_REDIS_DB():

--- a/tests/benchmarks/csr/run_csr.py
+++ b/tests/benchmarks/csr/run_csr.py
@@ -45,6 +45,18 @@ RESULTS_DIR = Path(__file__).parent.parent / "results" / "csr"
 
 RUN_LABELS = ("standard", "adversarial")
 
+# Key shapes this harness writes, for the bench-DB residue sweep (issue #490).
+# Per-case models are named ``CsrMem<8hex>`` (see corpus._build_csr_model_class),
+# so record keys are ``CsrMem<hex>:...``, sorted indexes ``CsrMem<hex>:_importance``
+# and BM25 keys ``$BM25:CsrMem<hex>:content_index...``. ``$`` is not a SCAN
+# metacharacter, so both patterns are literal outside the trailing glob. Before
+# #490 run_csr ran against the default DB 0 with only per-case cleanup, so any
+# case that errored/was killed before cleanup leaked these keys into DB 0.
+_CSR_STALE_KEY_PATTERNS = (
+    "CsrMem*",
+    "$BM25:CsrMem*",
+)
+
 
 def _run_one_query(assembler, model_class, agent_id, query):
     """Execute one assemble() run and score it.
@@ -363,10 +375,43 @@ def main(argv=None) -> int:
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
+    # DB hygiene (issue #490): before #490 this harness ran against the live
+    # default connection (DB 0), so any case killed/errored before its per-case
+    # cleanup leaked CsrMem*/$BM25:CsrMem* keys into production-shaped DB 0
+    # (~6741 stray keys observed) and polluted concurrent runs — which also made
+    # the CSR determinism tests fail non-deterministically. Point the connection
+    # at the shared bench DB (default 14, db0 rejected) and sweep residue before
+    # and after. Reuses run_external's helpers so the isolation posture is
+    # identical to the SIQ/external harnesses. Scoped to this entrypoint — never
+    # runs at import time, so the pytest DB-15 plugin is unaffected.
+    from src.popoto.redis_db import POPOTO_REDIS_DB
+    from tests.benchmarks.run_external import (
+        _point_connection_at_db,
+        _resolve_bench_db,
+        _sweep_stale_benchmark_keys,
+    )
+
+    bench_db = _resolve_bench_db()
+    _point_connection_at_db(bench_db)
+    swept = _sweep_stale_benchmark_keys(POPOTO_REDIS_DB, _CSR_STALE_KEY_PATTERNS)
+    print(
+        f"CSR: bench DB = {bench_db} (db0 rejected; db15 is pytest-only); "
+        f"swept {swept} stale key(s) at startup."
+    )
+
     # Import here so `--help` never touches Redis or the suite lint.
     from .suites.default import SUITE
 
-    aggregate = run_suite(SUITE)
+    try:
+        aggregate = run_suite(SUITE)
+    finally:
+        # Sweep this run's own residue so a completed run leaves the bench DB
+        # clean (issue #490); never a blanket flushdb (DB 14 is shared with
+        # concurrent benchmarks). Best-effort — must not mask the run result.
+        try:
+            _sweep_stale_benchmark_keys(POPOTO_REDIS_DB, _CSR_STALE_KEY_PATTERNS)
+        except Exception as exc:  # noqa: BLE001 - teardown never crashes the run
+            logger.warning("CSR teardown sweep failed (non-fatal): %s", exc)
     s = aggregate["summary"]
     print(f"Cases: {s['n_cases']} (errors: {s['n_errors']})")
     print(f"RSR (standard):    {s['rsr_std']:.6f}")

--- a/tests/benchmarks/run_external.py
+++ b/tests/benchmarks/run_external.py
@@ -162,22 +162,24 @@ def _point_connection_at_db(target_db: int) -> None:
     old_pool.disconnect()
 
 
-def _sweep_stale_benchmark_keys(redis_conn) -> int:
+def _sweep_stale_benchmark_keys(redis_conn, patterns=_STALE_KEY_PATTERNS) -> int:
     """SCAN + DEL any benchmark residue left by prior/interrupted runs.
 
     Uses cursor-based SCAN (non-blocking, Valkey-safe — no Redis modules) to
-    enumerate keys matching :data:`_STALE_KEY_PATTERNS` and DELs them. Operates
-    on whatever connection it is handed, so it targets exactly the DB the
-    harness is pointed at.
+    enumerate keys matching ``patterns`` and DELs them. Operates on whatever
+    connection it is handed, so it targets exactly the DB the harness is
+    pointed at. Reused by other harnesses (e.g. CSR) with their own patterns.
 
     Args:
         redis_conn: A ``redis.Redis`` client (the live Popoto connection).
+        patterns: Iterable of glob patterns to sweep (default:
+            :data:`_STALE_KEY_PATTERNS`, the external harness's own key shapes).
 
     Returns:
         The number of stale keys deleted.
     """
     deleted = 0
-    for pattern in _STALE_KEY_PATTERNS:
+    for pattern in patterns:
         cursor = 0
         while True:
             cursor, keys = redis_conn.scan(cursor, match=pattern, count=500)
@@ -211,6 +213,30 @@ def _select_bench_db() -> int:
         bench_db,
     )
     return bench_db
+
+
+def _teardown_bench_db(bench_db: int) -> None:
+    """Sweep this harness's residue from the bench DB after a run.
+
+    The startup sweep (:func:`_select_bench_db`) protects the *next* run, but a
+    completed run that never sweeps at exit leaves its own keys behind (issue
+    #490 observed ~1251 stray keys accumulating in DB 14). This sweeps only the
+    external harness's own key shapes (:data:`_STALE_KEY_PATTERNS`), never a
+    blanket ``flushdb`` — DB 14 is shared with concurrently-running benchmarks,
+    so a flush would nuke a neighbour's in-flight keyspace. Best-effort: swallows
+    connection errors so a teardown hiccup never masks the run's real exit code.
+    """
+    try:
+        from src.popoto.redis_db import POPOTO_REDIS_DB
+
+        swept = _sweep_stale_benchmark_keys(POPOTO_REDIS_DB)
+        logger.info(
+            "Swept %d benchmark key(s) from DB %d at teardown.",
+            swept,
+            bench_db,
+        )
+    except Exception as exc:  # noqa: BLE001 - teardown must never crash the run
+        logger.warning("Benchmark teardown sweep failed (non-fatal): %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -976,7 +1002,22 @@ def main():
     # by prior/interrupted runs BEFORE any ingestion. Scoped to this entrypoint
     # so it never affects import-time behavior or the pytest db15 plugin.
     bench_db = _select_bench_db()
+    try:
+        return _run_benchmark(args, bench_db)
+    finally:
+        # Sweep this run's own residue so a completed run leaves the bench DB
+        # clean (issue #490). Runs on every exit path — success, error, or
+        # non-zero return — because ingestion has already written keys by then.
+        _teardown_bench_db(bench_db)
 
+
+def _run_benchmark(args, bench_db):
+    """Execute the benchmark run itself (post DB-isolation setup).
+
+    Extracted from :func:`main` so the caller can guarantee a teardown sweep of
+    the bench DB in a ``finally`` regardless of which return path exits (issue
+    #490). Returns the process exit code.
+    """
     # When --limit is combined with the legacy contiguous-prefix mode, warn:
     # 'head' benchmarks only the easiest on-disk category and is not
     # representative of the whole dataset.

--- a/tests/benchmarks/test_external.py
+++ b/tests/benchmarks/test_external.py
@@ -813,6 +813,41 @@ class TestStaleKeySweep:
         assert POPOTO_REDIS_DB.exists(keeper) == 1
         POPOTO_REDIS_DB.delete(keeper)
 
+    def test_custom_patterns_sweep_only_matching_keys(self):
+        """The generalized sweep (issue #490) accepts caller-supplied patterns.
+
+        CSR reuses ``_sweep_stale_benchmark_keys`` with its own key shapes
+        (``CsrMem*`` / ``$BM25:CsrMem*``). Passing those patterns must sweep the
+        CSR residue while leaving the external harness's ExtMem* keys — and any
+        unrelated key — untouched.
+        """
+        from src.popoto.redis_db import POPOTO_REDIS_DB
+        from tests.benchmarks.run_external import _sweep_stale_benchmark_keys
+
+        csr_keys = {
+            "CsrMemdeadbeef:abc": "1",
+            "CsrMemdeadbeef:_importance": "1",
+            "$BM25:CsrMemdeadbeef:content_index": "1",
+        }
+        ext_key = "ExtMem12345678:xyz"  # external residue — must survive
+        keeper = "SomeOtherModel:keepme"
+        for k, v in csr_keys.items():
+            POPOTO_REDIS_DB.set(k, v)
+        POPOTO_REDIS_DB.set(ext_key, "1")
+        POPOTO_REDIS_DB.set(keeper, "1")
+
+        csr_patterns = ("CsrMem*", "$BM25:CsrMem*")
+        swept = _sweep_stale_benchmark_keys(POPOTO_REDIS_DB, csr_patterns)
+
+        assert swept >= len(csr_keys)
+        for k in csr_keys:
+            assert POPOTO_REDIS_DB.exists(k) == 0
+        # The external-harness residue and unrelated keys are untouched — the
+        # custom patterns only matched CsrMem*.
+        assert POPOTO_REDIS_DB.exists(ext_key) == 1
+        assert POPOTO_REDIS_DB.exists(keeper) == 1
+        POPOTO_REDIS_DB.delete(ext_key, keeper)
+
     def test_sweep_on_clean_db_returns_zero(self):
         """A DB with no residue sweeps zero keys."""
         from src.popoto.redis_db import POPOTO_REDIS_DB

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -524,9 +524,13 @@ class TestIsolatedDbSubprocess:
                 """))
 
         # DB-0 client for the (non-destructive) leak check.  Connect on the same
-        # host/port the suite uses, but always DB 0.
-        kwargs = redis_db.POPOTO_REDIS_DB.connection_pool.connection_kwargs.copy()
-        kwargs["db"] = 0
+        # host/port the suite uses, but always DB 0.  Whitelist the params:
+        # redis-py 8 injects pool-internal keys (himport_registry,
+        # maint_notifications_*) into connection_kwargs that redis.Redis(**kw)
+        # rejects with TypeError.
+        kwargs = redis_db.sibling_client_kwargs(
+            redis_db.POPOTO_REDIS_DB.connection_pool.connection_kwargs, db=0
+        )
         db0 = _redis.Redis(**kwargs)
 
         def _marker_keys():
@@ -578,3 +582,70 @@ class TestIsolatedDbSubprocess:
             f"src.popoto write leaked to DB 0 — isolation bypassed. "
             f"Found {len(leaked)} key(s): {leaked[:10]}"
         )
+
+
+class TestSiblingClientKwargs:
+    """Regression tests for ``redis_db.sibling_client_kwargs`` (issue #490).
+
+    redis-py 8 injects pool-internal bookkeeping keys (``himport_registry``,
+    ``maint_notifications_config``, ``maint_notifications_pool_handler``,
+    ``orig_*``) into a connection pool's ``connection_kwargs``. Splatting that
+    dict wholesale into ``redis.Redis(**kwargs)`` — as the DB-0 tripwire and the
+    subprocess-isolation test used to — raises ``TypeError: Redis.__init__() got
+    an unexpected keyword argument 'himport_registry'`` on redis-py 8. The
+    helper whitelists only the standard connection params, so it is robust on
+    every redis-py version. These tests inject a synthetic pool-only key so they
+    are meaningful even on redis-py 7 (where the real keys do not exist).
+    """
+
+    def test_strips_unknown_pool_only_keys(self):
+        """Pool-internal keys are dropped; standard params survive."""
+        source = {
+            "host": "localhost",
+            "port": 6379,
+            "password": "secret",
+            "socket_timeout": 5,
+            # redis-py 8 pool-injected keys that Redis.__init__ rejects:
+            "himport_registry": object(),
+            "maint_notifications_pool_handler": object(),
+            "orig_host_address": "10.0.0.1",
+        }
+        out = redis_db.sibling_client_kwargs(source)
+        assert out["host"] == "localhost"
+        assert out["port"] == 6379
+        assert out["password"] == "secret"
+        assert out["socket_timeout"] == 5
+        assert "himport_registry" not in out
+        assert "maint_notifications_pool_handler" not in out
+        assert "orig_host_address" not in out
+
+    def test_overrides_win(self):
+        """Explicit overrides replace inherited values (e.g. db=0 probe)."""
+        source = {"host": "localhost", "port": 6379, "db": 15}
+        out = redis_db.sibling_client_kwargs(source, db=0)
+        assert out["db"] == 0
+
+    def test_drops_none_values(self):
+        """``None`` params are dropped so they never mask real defaults."""
+        source = {"host": "localhost", "port": 6379, "password": None}
+        out = redis_db.sibling_client_kwargs(source)
+        assert "password" not in out
+
+    def test_result_builds_a_real_client_from_a_live_pool(self):
+        """The whitelisted kwargs from the LIVE pool build a usable client.
+
+        This is the end-to-end guard: take the running connection's actual
+        ``connection_kwargs`` (which on redis-py 8 carry the poisonous
+        pool-internal keys), whitelist them for DB 0, and confirm the resulting
+        ``redis.Redis(**kwargs)`` constructs and pings without a TypeError.
+        Non-destructive: only pings, never writes.
+        """
+        import redis as _redis
+
+        live_kwargs = redis_db.POPOTO_REDIS_DB.connection_pool.connection_kwargs
+        kwargs = redis_db.sibling_client_kwargs(live_kwargs, db=0)
+        client = _redis.Redis(**kwargs)
+        try:
+            assert client.ping() is True
+        finally:
+            client.close()


### PR DESCRIPTION
Fixes #490.

## Part (a) — `test_isolated_db_subprocess` fails on redis-py 8

**Root cause (reproduced under redis-py 8.1.0):** the failure is *not* in the plugin's pool swap (`_swap_db` reconstructs a `ConnectionPool`, which tolerates the injected keys). It is in code that splats a pool's `connection_kwargs` straight into `redis.Redis(**kwargs)`. redis-py 8 injects pool-internal bookkeeping keys — `himport_registry`, `maint_notifications_config`, `maint_notifications_pool_handler`, `orig_*` — into `connection_kwargs`, and `Redis.__init__` has a strict signature that rejects them:

```
TypeError: Redis.__init__() got an unexpected keyword argument 'himport_registry'
```

(The issue cited `maint_notifications_pool_handler`; the exact key surfaced depends on kwarg-check order — same class of bug.)

**Fix:** added `redis_db.sibling_client_kwargs()` — whitelists only the standard connection params (host/port/db/auth/timeouts/ssl), safe to splat into `redis.Redis(**kw)` on **any** redis-py version, Valkey-safe. Applied at the two DB-0-probe sites:
- the plugin's DB-0 tripwire fixture (previously **silently disabled** on redis-py 8 by its `except` guard), and
- the `test_isolated_db_subprocess` DB-0 leak check.

This is a genuine in-repo fix, not a skip.

## Part (b) — benchmark harness leaks keys to DB 0 / DB 14

- **`run_csr` ran against DB 0 with no isolation** (only per-case cleanup) — the primary source of the ~6741 stray `CsrMem*`/`$BM25:CsrMem*` keys in DB 0 and the non-deterministic CSR determinism failures. Now points at the shared bench DB (default 14, `db0` rejected) and sweeps residue before/after, reusing `run_external`'s helpers so its posture matches the SIQ/external harnesses.
- **`run_external` swept only at startup**, so a completed run left its own residue behind (~1251 keys in DB 14). Added a teardown sweep via a `finally` (body extracted to `_run_benchmark`) that fires on every exit path. Never a blanket `flushdb` — DB 14 is shared with concurrent benchmarks.
- Generalized `_sweep_stale_benchmark_keys` to accept caller-supplied patterns.

## Regression coverage
- `TestSiblingClientKwargs` (4 tests): strips pool-only keys, overrides win, drops `None`, and builds+pings a real client from the **live** pool's kwargs.
- `TestStaleKeySweep::test_custom_patterns_sweep_only_matching_keys`: the generalized sweep hits only the supplied patterns.

## Verification
Both problems reproduce on clean `origin/main`. Fixes verified in **clean editable installs** on both **redis-py 7.4.1** and **redis-py 8.1.0** (the project's local system Python has a stale non-editable `popoto`, worktree trap #1 — not used for measurement):

| Suite | redis-py 7.4.1 | redis-py 8.1.0 |
|---|---|---|
| `tests/test_pytest_plugin.py` | 33 passed | 33 passed (was 1 failed) |
| `tests/benchmarks/test_csr.py` + `csr/test_corpus.py` | 24 passed | 24 passed |
| `test_external.py::TestStaleKeySweep`/`TestBenchDbSelection` | — | 8 passed |

End-to-end: `run_csr --dry-run` and `run_external --dry-run` both leave DB 0 and DB 14 at **0** residual keys; `POPOTO_BENCH_DB=0` is rejected loudly.

`black --check` clean; mypy delta vs `main` is **0** (measured on redis-py 7.4.1).

Note: `black` (repo-pinned 26.3.1) also collapsed two pre-existing multi-line statements in `redis_db.py` that `main` was already non-compliant on — incidental compliance, not new formatting.