### PR TITLE
Release v1.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "popoto"
-version = "1.8.0"
+version = "1.8.1"
 description = "A Python Redis ORM"
 readme = "README.md"
 authors = [{ name = "Tom Counsell", email = "other@tomcounsell.com" }]


### PR DESCRIPTION
Bump version to 1.8.1.

Headline: **#477** — forward-incompat index-pointer fix (moved `\x00idxset` pointer out of the model hash; fixed delete-order and unique-conflict orphan-hash bugs). Resolves the 1.8.0 mixed-deploy hazard.

Also included since 1.8.0:
- #490 (PR #500) — test-infra: redis-py-8 plugin compat (`sibling_client_kwargs`) + benchmark DB-0/14 key isolation
- #496 (PR #499) — deterministic retrieval-relevance test via query-aware BM25 model